### PR TITLE
[EC-280] Find and fix performance bottleneck in peer download

### DIFF
--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
@@ -4,7 +4,6 @@ import akka.util.ByteString
 import io.iohk.ethereum.db.dataSource.DataSource
 import io.iohk.ethereum.db.storage.BlockBodiesStorage.BlockBodyHash
 import io.iohk.ethereum.domain.{Address, SignedTransaction, Transaction}
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.rlp._
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
@@ -55,7 +54,6 @@ object BlockBodiesStorage {
 
 
   private[BlockBodiesStorage] def toBytes(blockBody: BlockBody): IndexedSeq[Byte] = {
-    import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
     encode(BlockBody.blockBodyToRlpEncodable(
       blockBody,
       signedTransactionToBytes,
@@ -64,7 +62,6 @@ object BlockBodiesStorage {
   }
 
   private[BlockBodiesStorage] def fromBytes(bytes: Array[Byte]): BlockBody = {
-    import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
     BlockBody.rlpEncodableToBlockBody(
       rawDecode(bytes),
       signedTransactionFromEncodable,

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
@@ -3,9 +3,11 @@ package io.iohk.ethereum.db.storage
 import akka.util.ByteString
 import io.iohk.ethereum.db.dataSource.DataSource
 import io.iohk.ethereum.db.storage.BlockBodiesStorage.BlockBodyHash
+import io.iohk.ethereum.domain.{Address, SignedTransaction, Transaction}
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
-import io.iohk.ethereum.rlp.{decode => rlpDecode, encode => rlpEncode}
-import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.rlp._
+import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
 
 /**
   * This class is used to store the BlockBody, by using:
@@ -14,19 +16,59 @@ import io.iohk.ethereum.utils.Config
   */
 class BlockBodiesStorage(val dataSource: DataSource) extends KeyValueStorage[BlockBodyHash, BlockBody, BlockBodiesStorage] {
 
-  import BlockBody._
-
   override val namespace: IndexedSeq[Byte] = Namespaces.BodyNamespace
 
   override def keySerializer: (BlockBodyHash) => IndexedSeq[Byte] = identity
 
-  override def valueSerializer: (BlockBody) => IndexedSeq[Byte] = _.toBytes
+  override def valueSerializer: (BlockBody) => IndexedSeq[Byte] = BlockBodiesStorage.toBytes
 
-  override def valueDeserializer: (IndexedSeq[Byte]) => BlockBody = b => b.toArray[Byte].toBlockBody
+  override def valueDeserializer: (IndexedSeq[Byte]) => BlockBody = b => BlockBodiesStorage.fromBytes(b.toArray[Byte])
 
   override protected def apply(dataSource: DataSource): BlockBodiesStorage = new BlockBodiesStorage(dataSource)
 }
 
 object BlockBodiesStorage {
   type BlockBodyHash = ByteString
+
+  import io.iohk.ethereum.rlp.RLPImplicitConversions._
+  import io.iohk.ethereum.rlp.RLPImplicits._
+
+  private def signedTransactionToBytes(signedTx: SignedTransaction): RLPEncodeable = {
+    import signedTx._
+    import signedTx.tx._
+    RLPList(nonce, gasPrice, gasLimit, receivingAddress.map(_.toArray).getOrElse(Array.emptyByteArray): Array[Byte], value,
+      payload, signature.v, signature.r, signature.s, senderAddress.toArray)
+  }
+
+  private def signedTransactionFromEncodable(rlpEncodeable: RLPEncodeable): SignedTransaction = rlpEncodeable match {
+    case RLPList(nonce, gasPrice, gasLimit, (receivingAddress: RLPValue), value,
+    payload, pointSign, signatureRandom, signature, senderAddress) =>
+      val receivingAddressOpt = if(receivingAddress.bytes.isEmpty) None else Some(Address(receivingAddress.bytes))
+      SignedTransaction(
+        Transaction(nonce, gasPrice, gasLimit, receivingAddressOpt, value, payload),
+        (pointSign: Int).toByte,
+        signatureRandom,
+        signature,
+        Address(senderAddress: Array[Byte])
+      )
+  }
+
+
+  private[BlockBodiesStorage] def toBytes(blockBody: BlockBody): IndexedSeq[Byte] = {
+    import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
+    encode(BlockBody.blockBodyToRlpEncodable(
+      blockBody,
+      signedTransactionToBytes,
+      header => BlockHeaderEnc(header).toRLPEncodable
+    ))
+  }
+
+  private[BlockBodiesStorage] def fromBytes(bytes: Array[Byte]): BlockBody = {
+    import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
+    BlockBody.rlpEncodableToBlockBody(
+      rawDecode(bytes),
+      signedTransactionFromEncodable,
+      rlp => BlockheaderEncodableDec(rlp).toBlockHeader
+    )
+  }
 }

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -32,6 +32,11 @@ object SignedTransaction {
     } yield SignedTransaction(tx, txSignature, sender)
   }
 
+  def apply(tx: Transaction, pointSign: Byte, signatureRandom: ByteString, signature: ByteString, address: Address): SignedTransaction = {
+    val txSignature = ECDSASignature(r = new BigInteger(1, signatureRandom.toArray), s = new BigInteger(1, signature.toArray), v = pointSign)
+    SignedTransaction(tx, txSignature, address)
+  }
+
   def sign(tx: Transaction, keyPair: AsymmetricCipherKeyPair, chainId: Option[Byte]): SignedTransaction = {
     val bytes = bytesToSign(tx, chainId)
     val sig = ECDSASignature.sign(bytes, keyPair, chainId)


### PR DESCRIPTION
## Description

Based on the reported issue "client seems to get slower (in terms of block processing) around block 50k" we started to run some tests and benchmarks and reached to the conclusion there is an issue when validating blocks before inserting them while fast sync and when executing them during regular sync. To be more precise:

1. When receiving a block during regular & fast sync we need to, amongst other checks, to validate ommers (if present). Thats done in `io.iohk.ethereum.validators.OmmersValidatorImpl#validate`
2. One of those checks is to validate that an ommer hasn't been used on previous blocks as ommer [YP section 11.1 eq 143, 144 and 145](http://gavwood.com/paper.pdf)
3. To do perform (2) we were retrieving up to 6 parent block bodies from db. When doing so we were deserializing both ommers and transactions
4. When deserializing the transactions we were calling `io.iohk.ethereum.domain.SignedTransaction#apply` which was trying to recover sender address. That operation is too expensive and seems to be taking a lot of processing time (see Benchmarks section) even if we dont need to use transactions when validating ommers (it's a consecuence of BlockBody deserialization)

## Solutions

The following fix alternatives where considered:
1. Lazy evaluate signed transactions sender address in order to avoid calculation if not needed
	- Pros: The fix was applied where it was generated
	- Cons: 
		- It would require some changes not only on other parts of the code but how we handle senderTransacion as it might fail in new places now. In other words, we might introduce several bugs and would need to be more careful when invoking `io.iohk.ethereum.domain.SignedTransaction#senderAddress`.
		- We would need to change how SignedTransaction is created (case class would no longer be an option)
2. Lazy evaluate BlockBody singedTransactions and uncles. This alternative has quite the same pros and cons as (1)
3. Use a different RLP encoding when storing block bodies into db in order to be able persist precalculated address:
	- Pros:
		- Less error prone approach, it would just require changes in `io.iohk.ethereum.db.storage.BlockBodiesStorage` but not in other parts of the code (not even in validations and executions)
		- Easy to develop
		- Will also improve performance on several places where transactions (or block bodies) are retrieved from db. For example: several rpc methods (`io.iohk.ethereum.jsonrpc.EthService#getBlockTransactionCountByHash`, `io.iohk.ethereum.jsonrpc.FilterManager#getLogs`) or when doing regular sync `io.iohk.ethereum.blockchain.sync.RegularSync#processBlockHeaders`
	- Cons:
		- We will be storing sender addresses into databse and that will increase disk space used
		- Previous dbs snapshots won't be compatible

After some discussions we decided to go for the cleanest and easier solution (3)

## Benchmarks

The test was basically reading, executing and storing in a new db from block 1 to 200k of main net blockchain source db. Both scenarios were ran twice.

The execution lead to an interesting result. We are no longer spending time to calculate sender address as it's taken from the source db so the improvement appears to be huge **but it's important to note that when syncing from network, when receiving a block SignedTransaction senderAddress will be calculated and time will be spent there. That cannot be avoided as it's main goal is to validate transaction signature**

### How to run benchmarks

To run _Current Codebse_ scenario:
1. Checkout feature/snapshotBasedRegressionTest
2. Follow the steps stated in https://github.com/input-output-hk/mantis/pull/276

To run _With Fix_ one:
1. Checkout feature/snapshotBasedRegressionTest
2. Download the [following databse](https://s3.amazonaws.com/atixpublicbucket/new_db_format_up_to_200k.zip) (a new source with precalculated addresses as from)
3. Follow the steps stated in https://github.com/input-output-hk/mantis/pull/276 suing the db from (2) as source

#### Setup
- CPU: Intel(R) Core(TM) i7-3632QM CPU @ 2.20GHz
- Disk: SanDisk SDSSDA24
- Memory: 12 GB

#### Current codebase

commit efa26c6e11430b94ba5c8eaa474fbf62ca2c519c
Author: Radek Tkaczyk <radek.tkaczyk@iohk.io>
Date:   Fri Aug 11 16:03:34 2017 +0200

    Merge remote-tracking branch 'origin/phase/daedalus' into feature/snapshotBasedRegressionTest

- Run 1:
	- start: 15:26:17,272
	- end:   15:40:35.828
	- time to 50%: ~14mins
- Run 2:
	- start: 	16:09:31,575
	- 50%:	16:24:05.997 
	- 93%:	17:03:51.327
	- time to 50%: ~15mins
	- time to 93%: ~55mins

#### With fix

commit 56c84d6f56a4eb3b6e84c78a98f95c8649f4dabe
Author: Alan Verbner <alan.verbner@iohk.io>
Date:   Mon Aug 14 16:19:00 2017 -0300

    Block Bodies are stored with a different rlp encoding in database to avoid Address recalculation

- Run 1:
  - start: 17:17:23.546
  - 50%: 17:20:55.052
  - end:  17:27:10.679
  - time to 50%: ~3mins
  - time to 100%: ~10mins
- Run 2:
	- start: 17:32:37,340
	- 50%: 17:36:18.364		
	- 100%: 17:42:26.964
	- time to 50%: ~4mins
	- time to 100%: ~10mins
