### PR TITLE
Static Analysis tools fixes

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -64,7 +64,7 @@ class GenesisDataLoader(
             throw ex
         }
       case None =>
-        log.info(s"Using default genesis data")
+        log.info("Using default genesis data")
         val src = Source.fromResource("blockchain/default-genesis.json")
         try {
           src.getLines().mkString
@@ -159,7 +159,7 @@ object GenesisDataLoader {
           else "0" ++ noPrefix
         Try(ByteString(Hex.decode(inp))) match {
           case Success(bs) => bs
-          case Failure(ex) => throw new RuntimeException("Cannot parse hex string: " + s)
+          case Failure(_) => throw new RuntimeException("Cannot parse hex string: " + s)
         }
       case other => throw new RuntimeException("Expected hex string, but got: " + other)
     }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -125,7 +125,7 @@ trait FastSync {
   def waitingForTargetBlock(peer: Peer,
                             targetBlockNumber: BigInt,
                             timeout: Cancellable): Receive = handlePeerUpdates orElse {
-    case MessageFromPeer(blockHeaders: BlockHeaders, peerId) =>
+    case MessageFromPeer(blockHeaders: BlockHeaders, _) =>
       timeout.cancel()
       peerEventBus ! Unsubscribe(MessageClassifier(Set(BlockHeaders.code), PeerSelector.WithId(peer.id)))
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncReceiptsRequestHandler.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSyncReceiptsRequestHandler.scala
@@ -97,10 +97,7 @@ class FastSyncReceiptsRequestHandler(
         ReceiptsInvalid(blockValidator.validateBlockAndReceipts(header, receipt).left.get)
       case (None, _) => ReceiptsDbError
     }
-    receiptsValidationError match {
-      case Some(error) => error
-      case None => ReceiptsValid(blockHashesWithReceipts)
-    }
+    receiptsValidationError.getOrElse(ReceiptsValid(blockHashesWithReceipts))
   }
 
   override def handleTimeout(): Unit = {

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
@@ -116,8 +116,8 @@ object ReferenceCountNodeStorage {
         // Get Node from storage and filter ones which have references = 0 now (maybe they were added again after blockNumber)
         val pruneCandidateNodes = pruneCandidates.nodeKeys.map(nodeStorage.get)
         val pruneCandidateNodesWithKeys = pruneCandidateNodes.zip(pruneCandidates.nodeKeys)
-        val nodesToDelete = pruneCandidateNodesWithKeys.filter(n => n._1.isDefined && storedNodeFromBytes(n._1.get).references == 0)
-        nodesToDelete.map(_._2)
+        pruneCandidateNodesWithKeys.collect {
+          case (Some(candidate), candidateKey) if storedNodeFromBytes(candidate).references == 0 => candidateKey }
       }.map(nodeKeysToDelete => {
         // Update nodestorage removing all nodes that are no longer being used
         nodeStorage.update(key +: nodeKeysToDelete, Nil)

--- a/src/main/scala/io/iohk/ethereum/domain/Address.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Address.scala
@@ -42,7 +42,7 @@ class Address private(val bytes: ByteString) {
 
   override def equals(that: Any): Boolean = that match {
     case addr: Address => addr.bytes == bytes
-    case other => false
+    case _ => false
   }
 
   override def hashCode: Int =

--- a/src/main/scala/io/iohk/ethereum/keystore/KeyStore.scala
+++ b/src/main/scala/io/iohk/ethereum/keystore/KeyStore.scala
@@ -112,7 +112,7 @@ class KeyStoreImpl(keyStoreDir: String, secureRandom: SecureRandom) extends KeyS
   private def listFiles(): Either[KeyStoreError, List[String]] = {
     val dir = new File(keyStoreDir)
     Try {
-      if (!dir.exists() || !dir.isDirectory())
+      if (!dir.exists || !dir.isDirectory)
         Left(IOError(s"Could not read $keyStoreDir"))
       else
         Right(dir.listFiles().toList.map(_.getName))

--- a/src/main/scala/io/iohk/ethereum/network/rlpx/FrameCodec.scala
+++ b/src/main/scala/io/iohk/ethereum/network/rlpx/FrameCodec.scala
@@ -141,7 +141,7 @@ class FrameCodec(private val secrets: Secrets) {
 
       if (firstFrame) {
         // packet-type only in first frame
-        enc.processBytes(ptype.toArray, 0, ptype.length, buff, 0)
+        enc.processBytes(ptype, 0, ptype.length, buff, 0)
         out ++= ByteString(buff.take(ptype.length))
         secrets.egressMac.update(buff, 0, ptype.length)
       }


### PR DESCRIPTION
Includes fixes to several issues detected while running various static analysis tools.
The problems fixed were:
* Removed empty interpolated string (`s"..."`).
* Removed unused variables.
* Removed parenthesis from accessor only method.
* Removed unnecessary `toArray` conversion.