### PR TITLE
[EC-252] Move UInt256 to utils or domain

### DIFF
--- a/src/ets/scala/io/iohk/ethereum/ets/vm/ScenarioParser.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/vm/ScenarioParser.scala
@@ -4,9 +4,8 @@ import akka.util.ByteString
 import io.circe._
 import io.circe.parser._
 import io.circe.generic.auto._
-import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.{Address, UInt256}
 import io.iohk.ethereum.utils.NumericUtils._
-import io.iohk.ethereum.vm.UInt256
 import org.spongycastle.util.encoders.Hex
 
 import scala.util.Try

--- a/src/ets/scala/io/iohk/ethereum/ets/vm/scenario.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/vm/scenario.scala
@@ -1,8 +1,7 @@
 package io.iohk.ethereum.ets.vm
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.Address
-import io.iohk.ethereum.vm.UInt256
+import io.iohk.ethereum.domain.{Address, UInt256}
 
 case class ScenarioGroup(
   name: String,

--- a/src/ets/scala/io/iohk/ethereum/ets/vm/testopcodes.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/vm/testopcodes.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.ets.vm
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.{Address, UInt256}
 import io.iohk.ethereum.vm._
 
 case object TestCREATE extends CreateOp {

--- a/src/evmTest/scala/io/iohk/ethereum/vm/CallerSpec.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/CallerSpec.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.vm
 
 import io.iohk.ethereum.vm.utils.EvmTestEnv
 import org.scalatest.{FreeSpec, Matchers}
+import io.iohk.ethereum.domain.UInt256
 
 // scalastyle:off magic.number
 class CallerSpec extends FreeSpec with Matchers {

--- a/src/evmTest/scala/io/iohk/ethereum/vm/ContractCallingItselfSpec.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/ContractCallingItselfSpec.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.vm
 
 import io.iohk.ethereum.vm.utils.EvmTestEnv
 import org.scalatest.{FreeSpec, Matchers}
+import io.iohk.ethereum.domain.UInt256
 
 // scalastyle:off magic.number
 class ContractCallingItselfSpec extends FreeSpec with Matchers {

--- a/src/evmTest/scala/io/iohk/ethereum/vm/FibonacciSpec.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/FibonacciSpec.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.vm
 
 import io.iohk.ethereum.vm.utils.EvmTestEnv
 import org.scalatest.{FreeSpec, Matchers}
+import io.iohk.ethereum.domain.UInt256
 
 // scalastyle:off magic.number
 class FibonacciSpec extends FreeSpec with Matchers {

--- a/src/evmTest/scala/io/iohk/ethereum/vm/MinimumViableTokenSpec.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/MinimumViableTokenSpec.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.vm
 
 import io.iohk.ethereum.vm.utils.EvmTestEnv
 import org.scalatest.{FreeSpec, Matchers}
+import io.iohk.ethereum.domain.UInt256
 
 // scalastyle:off magic.number
 class MinimumViableTokenSpec extends FreeSpec with Matchers {

--- a/src/evmTest/scala/io/iohk/ethereum/vm/MutualRecursionSpec.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/MutualRecursionSpec.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.vm
 
 import io.iohk.ethereum.vm.utils.EvmTestEnv
 import org.scalatest.{FreeSpec, Matchers}
+import io.iohk.ethereum.domain.UInt256
 
 // scalastyle:off magic.number
 class MutualRecursionSpec extends FreeSpec with Matchers {

--- a/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
+++ b/src/evmTest/scala/io/iohk/ethereum/vm/utils/EvmTestEnv.scala
@@ -2,17 +2,14 @@ package io.iohk.ethereum.vm.utils
 
 import java.io.File
 
+import akka.util.ByteString
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.crypto._
+import io.iohk.ethereum.domain.{Account, Address, UInt256}
+import io.iohk.ethereum.vm._
+
 import scala.language.dynamics
 import scala.util.Random
-
-import akka.util.ByteString
-import io.iohk.ethereum.crypto._
-import io.iohk.ethereum.rlp.RLPList
-import io.iohk.ethereum.rlp.RLPImplicits._
-import io.iohk.ethereum.rlp.RLPImplicitConversions._
-import io.iohk.ethereum.{rlp, crypto}
-import io.iohk.ethereum.domain.{Account, Address}
-import io.iohk.ethereum.vm._
 
 object EvmTestEnv {
   val ContractsDir = new File("target/contracts")

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -1,12 +1,12 @@
 package io.iohk.ethereum.txExecTest
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.{BlockchainImpl, Receipt}
+import io.iohk.ethereum.domain.{BlockchainImpl, Receipt, UInt256}
 import io.iohk.ethereum.ledger.LedgerImpl
 import io.iohk.ethereum.txExecTest.util.FixtureProvider
 import io.iohk.ethereum.utils.{BlockchainConfig, MonetaryPolicyConfig}
 import io.iohk.ethereum.validators._
-import io.iohk.ethereum.vm.{UInt256, VM}
+import io.iohk.ethereum.vm.VM
 import org.scalatest.{FlatSpec, Matchers}
 
 class ForksTest extends FlatSpec with Matchers {

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -10,7 +10,7 @@ import io.iohk.ethereum.db.storage.AppStateStorage
 import io.iohk.ethereum.db.storage.NodeStorage.{NodeEncoded, NodeHash}
 import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
-import io.iohk.ethereum.domain.{Blockchain, _}
+import io.iohk.ethereum.domain.{Blockchain, UInt256, _}
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, InMemoryWorldStateProxyStorage}
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
@@ -21,7 +21,6 @@ import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
 import io.iohk.ethereum.network.{ForkResolver, PeerEventBusActor, PeerManagerActor}
 import io.iohk.ethereum.nodebuilder.{AuthHandshakerBuilder, NodeKeyBuilder, SecureRandomBuilder}
 import io.iohk.ethereum.utils.{BlockchainConfig, Config, NodeStatus, ServerStatus}
-import io.iohk.ethereum.vm.UInt256
 import org.spongycastle.util.encoders.Hex
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -11,12 +11,11 @@ import io.iohk.ethereum.{crypto, rlp}
 import io.iohk.ethereum.db.dataSource.{DataSource, EphemDataSource}
 import io.iohk.ethereum.db.storage._
 import io.iohk.ethereum.db.storage.pruning.PruningMode
-import io.iohk.ethereum.domain.{Account, Block, BlockHeader, Blockchain}
+import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.utils.Config.DbConfig
-import io.iohk.ethereum.vm.UInt256
 import org.json4s.{CustomSerializer, DefaultFormats, JString, JValue}
 import org.spongycastle.util.encoders.Hex
 

--- a/src/main/scala/io/iohk/ethereum/domain/Account.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Account.scala
@@ -6,7 +6,6 @@ import io.iohk.ethereum.mpt.ByteArraySerializable
 import io.iohk.ethereum.network.p2p.messages.PV63.AccountImplicits
 import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPImplicits._
-import io.iohk.ethereum.vm.UInt256
 import org.spongycastle.util.encoders.Hex
 
 object Account {

--- a/src/main/scala/io/iohk/ethereum/domain/Address.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Address.scala
@@ -4,7 +4,6 @@ import akka.util.ByteString
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.mpt.ByteArrayEncoder
 import io.iohk.ethereum.utils.ByteUtils.padLeft
-import io.iohk.ethereum.vm.UInt256
 import org.spongycastle.util.encoders.Hex
 
 object Address {

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -9,7 +9,7 @@ import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, InMemoryWorldStateProxy
 import io.iohk.ethereum.mpt.{MerklePatriciaTrie, NodesKeyValueStorage}
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.network.p2p.messages.PV63.MptNode
-import io.iohk.ethereum.vm.{Storage, UInt256, WorldStateProxy}
+import io.iohk.ethereum.vm.{Storage, WorldStateProxy}
 import io.iohk.ethereum.network.p2p.messages.PV63.MptNode._
 
 /**

--- a/src/main/scala/io/iohk/ethereum/domain/UInt256.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/UInt256.scala
@@ -1,8 +1,8 @@
-package io.iohk.ethereum.vm
+package io.iohk.ethereum.domain
 
 import akka.util.ByteString
 
-import language.implicitConversions
+import scala.language.implicitConversions
 
 // scalastyle:off number.of.methods
 object UInt256 {

--- a/src/main/scala/io/iohk/ethereum/domain/UInt256.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/UInt256.scala
@@ -62,7 +62,6 @@ object UInt256 {
   private val MaxSignedValue: BigInt = BigInt(2).pow(Size * 8 - 1) - 1
 }
 
-// TODO: consider moving to util as Uint256, which follows Scala numeric conventions, and is used across the system for P_256 numbers (see YP 4.3) [EC-252]
 /** Represents 256 bit unsigned integers with standard arithmetic, byte-wise operation and EVM-specific extensions */
 class UInt256 private (private val n: BigInt) extends Ordered[UInt256] {
 

--- a/src/main/scala/io/iohk/ethereum/domain/package.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/package.scala
@@ -1,8 +1,8 @@
 package io.iohk.ethereum
 
 import akka.util.ByteString
+import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.mpt.{ByteArrayEncoder, ByteArraySerializable, HashByteArraySerializable, MerklePatriciaTrie, NodesKeyValueStorage}
-import io.iohk.ethereum.vm.UInt256
 import io.iohk.ethereum.rlp.UInt256RLPImplicits._
 
 package object domain {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -7,9 +7,8 @@ import java.util.concurrent.atomic.AtomicReference
 
 import akka.pattern.ask
 import akka.util.Timeout
-import io.iohk.ethereum.domain._
+import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction, UInt256, _}
 import akka.actor.ActorRef
-import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction}
 import io.iohk.ethereum.db.storage.AppStateStorage
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.SyncController.MinedBlock
@@ -27,7 +26,6 @@ import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.UInt256RLPImplicits._
-import io.iohk.ethereum.vm.UInt256
 import org.spongycastle.util.encoders.Hex
 
 import scala.concurrent.Future

--- a/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.db.storage._
 import io.iohk.ethereum.domain
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.{MerklePatriciaTrie, _}
-import io.iohk.ethereum.vm.{Storage, UInt256, WorldStateProxy}
+import io.iohk.ethereum.vm.{Storage, WorldStateProxy}
 
 object InMemoryWorldStateProxy {
 

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.ledger.BlockExecutionError.{StateBeforeFailure, TxsExecu
 import io.iohk.ethereum.ledger.Ledger.{BlockPreparationResult, BlockResult, PC, PR, TxResult}
 import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
 import io.iohk.ethereum.validators.{BlockValidator, SignedTransactionValidator}
-import io.iohk.ethereum.vm.UInt256._
+import io.iohk.ethereum.domain.UInt256._
 import io.iohk.ethereum.vm._
 import org.spongycastle.util.encoders.Hex
 

--- a/src/main/scala/io/iohk/ethereum/rlp/UInt256RLPImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/rlp/UInt256RLPImplicits.scala
@@ -1,8 +1,8 @@
 package io.iohk.ethereum.rlp
 
 import akka.util.ByteString
+import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.rlp.RLP._
-import io.iohk.ethereum.vm.UInt256
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 
 import scala.language.implicitConversions

--- a/src/main/scala/io/iohk/ethereum/utils/BigIntExtensionMethods.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/BigIntExtensionMethods.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.utils
 
-import io.iohk.ethereum.vm.UInt256
+import io.iohk.ethereum.domain.UInt256
 
 object BigIntExtensionMethods {
   implicit class BigIntAsUnsigned(val srcBigInteger: BigInt) extends AnyVal {

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -6,12 +6,11 @@ import akka.util.ByteString
 import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig}
 import io.iohk.ethereum.db.dataSource.LevelDbConfig
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, BasicPruning, PruningMode}
-import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.{Address, UInt256}
 import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonRpcConfig
 import io.iohk.ethereum.jsonrpc.http.JsonRpcHttpServer.JsonRpcHttpServerConfig
 import io.iohk.ethereum.network.PeerManagerActor.{FastSyncHostConfiguration, PeerConfiguration}
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
-import io.iohk.ethereum.vm.UInt256
 import org.spongycastle.util.encoders.Hex
 
 import scala.concurrent.duration._

--- a/src/main/scala/io/iohk/ethereum/validators/SignedTransactionValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/SignedTransactionValidator.scala
@@ -4,7 +4,7 @@ import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.validators.SignedTransactionError._
 import io.iohk.ethereum.utils.BlockchainConfig
-import io.iohk.ethereum.vm.{EvmConfig, UInt256}
+import io.iohk.ethereum.vm.EvmConfig
 
 trait SignedTransactionValidator {
 

--- a/src/main/scala/io/iohk/ethereum/vm/EvmConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/EvmConfig.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.vm
 
 import akka.util.ByteString
+import io.iohk.ethereum.domain.UInt256
 import io.iohk.ethereum.utils.BlockchainConfig
 
 // scalastyle:off number.of.methods

--- a/src/main/scala/io/iohk/ethereum/vm/ExecEnv.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ExecEnv.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.vm
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.{ Address, BlockHeader }
+import io.iohk.ethereum.domain.{Address, BlockHeader, UInt256}
 
 /** Execution environment constants of an EVM program.
   *  See section 9.3 in Yellow Paper for more detail.

--- a/src/main/scala/io/iohk/ethereum/vm/Memory.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Memory.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.vm
 
 import akka.util.ByteString
+import io.iohk.ethereum.domain.UInt256
 import org.spongycastle.util.encoders.Hex
 
 object Memory {

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -2,8 +2,8 @@ package io.iohk.ethereum.vm
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.kec256
-import io.iohk.ethereum.domain.{Address, TxLogEntry}
-import io.iohk.ethereum.vm.UInt256._
+import io.iohk.ethereum.domain.{Address, TxLogEntry, UInt256}
+import io.iohk.ethereum.domain.UInt256._
 
 // scalastyle:off magic.number
 // scalastyle:off number.of.types

--- a/src/main/scala/io/iohk/ethereum/vm/PrecompiledContracts.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/PrecompiledContracts.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.vm
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto._
-import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.{Address, UInt256}
 import io.iohk.ethereum.utils.ByteUtils
 
 import scala.util.Try

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramError.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramError.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum.vm
 
+import io.iohk.ethereum.domain.UInt256
+
 /**
   * Marker trait for errors that may occur during program execution
   */

--- a/src/main/scala/io/iohk/ethereum/vm/ProgramState.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/ProgramState.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.vm
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.{Address, TxLogEntry}
+import io.iohk.ethereum.domain.{Address, TxLogEntry, UInt256}
 
 object ProgramState {
   def apply[W <: WorldStateProxy[W, S], S <: Storage[S]](context: ProgramContext[W, S]): ProgramState[W, S] =

--- a/src/main/scala/io/iohk/ethereum/vm/Stack.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Stack.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum.vm
 
+import io.iohk.ethereum.domain.UInt256
+
 object Stack {
   /**
     * Stack max size as defined in the YP (9.1)

--- a/src/main/scala/io/iohk/ethereum/vm/Storage.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Storage.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum.vm
 
+import io.iohk.ethereum.domain.UInt256
+
 
 /**
   * Account's storage representation. Implementation should be immutable and only keep track of changes to the storage

--- a/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.vm
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.kec256
-import io.iohk.ethereum.domain.{Account, Address}
+import io.iohk.ethereum.domain.{Account, Address, UInt256}
 import io.iohk.ethereum.rlp
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPList

--- a/src/main/scala/io/iohk/ethereum/vm/package.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/package.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum
 
+import io.iohk.ethereum.domain.UInt256
+
 package object vm {
 
   /**

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -6,9 +6,8 @@ import java.security.SecureRandom
 import akka.util.ByteString
 import io.iohk.ethereum.mpt.HexPrefix.bytesToNibbles
 import io.iohk.ethereum.network.p2p.messages.PV63._
-import io.iohk.ethereum.vm.UInt256
 import org.scalacheck.{Arbitrary, Gen}
-import io.iohk.ethereum.domain._
+import io.iohk.ethereum.domain.{UInt256, _}
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -6,7 +6,6 @@ import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.db.storage.ArchiveNodeStorage
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
-import io.iohk.ethereum.vm.UInt256
 import org.scalatest.{FlatSpec, Matchers}
 
 class BlockchainSpec extends FlatSpec with Matchers {

--- a/src/test/scala/io/iohk/ethereum/domain/UInt256Spec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/UInt256Spec.scala
@@ -1,10 +1,10 @@
-package io.iohk.ethereum.vm
+package io.iohk.ethereum.domain
 
 import akka.util.ByteString
 import io.iohk.ethereum.vm.Generators._
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
-import io.iohk.ethereum.vm.UInt256._
+import io.iohk.ethereum.domain.UInt256._
 
 class UInt256Spec extends FunSuite with PropertyChecks {
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -9,14 +9,13 @@ import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.{Fixtures, NormalPatience, Timeouts, crypto}
 import io.iohk.ethereum.db.components.{SharedEphemDataSources, Storages}
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
-import io.iohk.ethereum.domain.{Address, Block, BlockHeader, BlockchainImpl}
+import io.iohk.ethereum.domain.{Address, Block, BlockHeader, BlockchainImpl, UInt256, _}
 import io.iohk.ethereum.db.storage.{AppStateStorage, ArchiveNodeStorage}
-import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.EthService._
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.transactions.PendingTransactionsManager
-import io.iohk.ethereum.utils.{BlockchainConfig, FilterConfig, MiningConfig, PruningConfig, TxPoolConfig}
+import io.iohk.ethereum.utils._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -31,7 +30,6 @@ import io.iohk.ethereum.mining.{BlockGenerator, PendingBlock}
 import io.iohk.ethereum.mpt.{ByteArrayEncoder, ByteArraySerializable, HashByteArraySerializable, MerklePatriciaTrie}
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{PendingTransaction, PendingTransactionsResponse}
 import io.iohk.ethereum.validators.Validators
-import io.iohk.ethereum.vm.UInt256
 import org.scalamock.scalatest.MockFactory
 import org.spongycastle.util.encoders.Hex
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/PersonalServiceSpec.scala
@@ -5,14 +5,13 @@ import akka.testkit.TestProbe
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.db.storage.AppStateStorage
-import io.iohk.ethereum.domain._
+import io.iohk.ethereum.domain.{UInt256, _}
 import io.iohk.ethereum.jsonrpc.JsonRpcErrors._
 import io.iohk.ethereum.jsonrpc.PersonalService._
 import io.iohk.ethereum.keystore.KeyStore.{DecryptionFailed, IOError}
 import io.iohk.ethereum.keystore.{KeyStore, Wallet}
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{AddOrOverrideTransaction, GetPendingTransactions, PendingTransaction, PendingTransactionsResponse}
 import io.iohk.ethereum.utils.{BlockchainConfig, MonetaryPolicyConfig, TxPoolConfig}
-import io.iohk.ethereum.vm.UInt256
 import io.iohk.ethereum.{Fixtures, NormalPatience, Timeouts}
 import org.scalamock.matchers.Matcher
 import org.scalamock.scalatest.MockFactory

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockRewardSpec.scala
@@ -5,9 +5,8 @@ import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.{Fixtures, Mocks}
 import io.iohk.ethereum.db.components.{SharedEphemDataSources, Storages}
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
-import io.iohk.ethereum.domain.{Account, Address, Block, BlockchainImpl}
+import io.iohk.ethereum.domain._
 import io.iohk.ethereum.utils.{BlockchainConfig, Config}
-import io.iohk.ethereum.vm.UInt256
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteAccountsSpec.scala
@@ -3,8 +3,7 @@ package io.iohk.ethereum.ledger
 import io.iohk.ethereum.utils.{BlockchainConfig, Config}
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl}
-import io.iohk.ethereum.vm.UInt256
+import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, UInt256}
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -2,11 +2,8 @@ package io.iohk.ethereum.ledger
 
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.db.components.Storages.PruningModeComponent
-import io.iohk.ethereum.db.components.{SharedEphemDataSources, Storages}
-import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
-import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl}
-import io.iohk.ethereum.vm.{Generators, UInt256}
+import io.iohk.ethereum.domain.{Account, Address, BlockchainImpl, UInt256}
+import io.iohk.ethereum.vm.Generators
 import org.scalatest.{FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
@@ -17,7 +17,7 @@ import io.iohk.ethereum.utils.{BlockchainConfig, Config}
 import io.iohk.ethereum.ledger.Ledger.{BlockResult, PC, PR}
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.nodebuilder.SecureRandomBuilder
-import io.iohk.ethereum.vm.{UInt256, _}
+import io.iohk.ethereum.vm.{_}
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import org.spongycastle.crypto.params.ECPublicKeyParameters

--- a/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
@@ -11,7 +11,7 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.{BlockPreparationError, LedgerImpl}
 import io.iohk.ethereum.utils.{BlockchainConfig, Logger, MiningConfig, MonetaryPolicyConfig}
 import io.iohk.ethereum.validators._
-import io.iohk.ethereum.vm.{UInt256, VM}
+import io.iohk.ethereum.vm.VM
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex

--- a/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -9,7 +9,7 @@ import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components.{SharedEphemDataSources, Storages}
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
 import io.iohk.ethereum.db.storage.AppStateStorage
-import io.iohk.ethereum.domain.{Block, Blockchain, BlockchainImpl}
+import io.iohk.ethereum.domain.{Block, Blockchain, BlockchainImpl, UInt256}
 import io.iohk.ethereum.network.ForkResolver
 import io.iohk.ethereum.network.PeerManagerActor.PeerConfiguration
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
@@ -23,7 +23,6 @@ import io.iohk.ethereum.network.p2p.messages.WireProtocol.Hello.HelloEnc
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Capability, Disconnect, Hello}
 import io.iohk.ethereum.nodebuilder.SecureRandomBuilder
 import io.iohk.ethereum.utils._
-import io.iohk.ethereum.vm.UInt256
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/io/iohk/ethereum/validators/BlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/validators/BlockHeaderValidatorSpec.scala
@@ -3,10 +3,9 @@ package io.iohk.ethereum.validators
 import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain._
+import io.iohk.ethereum.domain.{UInt256, _}
 import io.iohk.ethereum.utils.{BlockchainConfig, Config, MonetaryPolicyConfig}
 import io.iohk.ethereum.validators.BlockHeaderError._
-import io.iohk.ethereum.vm.UInt256
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex

--- a/src/test/scala/io/iohk/ethereum/validators/SignedTransactionValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/validators/SignedTransactionValidatorSpec.scala
@@ -5,11 +5,11 @@ import java.security.SecureRandom
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.ECDSASignature
-import io.iohk.ethereum.domain.{Account, Address, SignedTransaction, Transaction}
+import io.iohk.ethereum.domain._
 import io.iohk.ethereum.{Fixtures, crypto}
 import io.iohk.ethereum.utils.{BlockchainConfig, Config}
 import io.iohk.ethereum.validators.SignedTransactionError.{TransactionSignatureError, _}
-import io.iohk.ethereum.vm.{EvmConfig, UInt256}
+import io.iohk.ethereum.vm.EvmConfig
 import org.scalatest.{FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex
 

--- a/src/test/scala/io/iohk/ethereum/vm/CallOpcodesSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/CallOpcodesSpec.scala
@@ -4,7 +4,7 @@ import akka.util.ByteString
 import org.scalatest.{Matchers, WordSpec}
 import Assembly._
 import io.iohk.ethereum.crypto._
-import io.iohk.ethereum.domain.{Account, Address}
+import io.iohk.ethereum.domain.{Account, Address, UInt256}
 import io.iohk.ethereum.utils.ByteUtils
 import io.iohk.ethereum.vm.MockWorldState._
 import org.scalatest.prop.PropertyChecks

--- a/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/CreateOpcodeSpec.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.vm
 
-import io.iohk.ethereum.domain.{Account, Address}
+import io.iohk.ethereum.domain.{Account, Address, UInt256}
 import org.scalatest.{Matchers, WordSpec}
 import MockWorldState.{PC, PS}
 import akka.util.ByteString

--- a/src/test/scala/io/iohk/ethereum/vm/Generators.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/Generators.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.vm
 
 import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
-import io.iohk.ethereum.domain.{Account, Address, BlockHeader}
+import io.iohk.ethereum.domain.{Account, Address, BlockHeader, UInt256}
 import io.iohk.ethereum.vm.MockWorldState._
 import org.scalacheck.{Arbitrary, Gen}
 import org.spongycastle.util.encoders.Hex

--- a/src/test/scala/io/iohk/ethereum/vm/MemorySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/MemorySpec.scala
@@ -5,7 +5,7 @@ import io.iohk.ethereum.vm.Generators._
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.{Arbitrary, Gen}
-
+import io.iohk.ethereum.domain.UInt256
 
 class MemorySpec extends FunSuite with PropertyChecks with Matchers {
 

--- a/src/test/scala/io/iohk/ethereum/vm/MockStorage.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/MockStorage.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum.vm
 
+import io.iohk.ethereum.domain.UInt256
+
 object MockStorage {
   val Empty = MockStorage()
 

--- a/src/test/scala/io/iohk/ethereum/vm/MockWorldState.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/MockWorldState.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.vm
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.kec256
-import io.iohk.ethereum.domain.{Account, Address}
+import io.iohk.ethereum.domain.{Account, Address, UInt256}
 
 object MockWorldState {
   type PS = ProgramState[MockWorldState, MockStorage]

--- a/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/OpCodeFunSpec.scala
@@ -2,9 +2,9 @@ package io.iohk.ethereum.vm
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.kec256
-import io.iohk.ethereum.domain.{Account, Address, TxLogEntry}
+import io.iohk.ethereum.domain.{Account, Address, TxLogEntry, UInt256}
 import io.iohk.ethereum.vm.Generators._
-import io.iohk.ethereum.vm.UInt256._
+import io.iohk.ethereum.domain.UInt256._
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, Matchers}

--- a/src/test/scala/io/iohk/ethereum/vm/OpCodeGasSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/OpCodeGasSpec.scala
@@ -3,8 +3,9 @@ package io.iohk.ethereum.vm
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.prop.PropertyChecks
 import Generators._
-import UInt256.{One, Two, Zero}
 import io.iohk.ethereum.domain.{Account, Address}
+import io.iohk.ethereum.domain.UInt256
+import io.iohk.ethereum.domain.UInt256._
 import io.iohk.ethereum.vm.MockWorldState.PS
 
 class OpCodeGasSpec extends FunSuite with OpCodeTesting with Matchers with PropertyChecks {

--- a/src/test/scala/io/iohk/ethereum/vm/PrecompiledContractsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/PrecompiledContractsSpec.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.vm
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto._
-import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.domain.{Address, UInt256}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, Matchers}
 import MockWorldState._

--- a/src/test/scala/io/iohk/ethereum/vm/StackSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/StackSpec.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.vm
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FunSuite, Matchers}
+import io.iohk.ethereum.domain.UInt256
 
 class StackSpec extends FunSuite with Matchers with PropertyChecks {
 


### PR DESCRIPTION
This PR moves UInt256 to domain because it is part of YP and is used in objects representing various entities like Account or Address 