### PR TITLE
[EC-87] BlockBroadcast propagation algorithm

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcast.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcast.scala
@@ -4,6 +4,10 @@ import akka.actor.ActorRef
 import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
+import io.iohk.ethereum.network.p2p.messages.PV62
+import io.iohk.ethereum.network.p2p.messages.PV62.BlockHash
+
+import scala.util.Random
 
 trait BlockBroadcast {
 
@@ -11,23 +15,47 @@ trait BlockBroadcast {
 
   /**
     * Broadcasts various NewBlock's messages to handshaked peers, considering that a block should not be sent to a peer
-    * that is thought to know it. In the current implementation we send every block to every peer (that doesn't know
-    * this block)
+    * that is thought to know it.
+    * The hash of the block is sent to all of those peers while the block itself is only sent to
+    * the square root of the total number of those peers, with the subset being obtained randomly.
     *
     * @param newBlocks, blocks to broadcast
-    * @param handshakedPeers
+    * @param handshakedPeers, to which the blocks will be broadcasted to
     */
-  //FIXME: Decide block propagation algorithm (for now we send block to every peer) [EC-87]
-  def broadcastNewBlocks(newBlocks: Seq[NewBlock], handshakedPeers: Map[Peer, PeerInfo]): Unit = {
-    val blocksForEachPeer: Seq[(Peer, NewBlock)] = for {
-      (peer, peerInfo) <- handshakedPeers.toSeq
-      newBlock <- newBlocks
-      if shouldSendNewBlock(newBlock, peerInfo)
-    } yield (peer, newBlock)
-    blocksForEachPeer.foreach{ case (peer, newBlock) => etcPeerManager ! EtcPeerManagerActor.SendMessage(newBlock, peer.id) }
+  def broadcastBlocks(newBlocks: Seq[NewBlock], handshakedPeers: Map[Peer, PeerInfo]): Unit = {
+    newBlocks.foreach { newBlock =>
+      val peersWithoutBlock = handshakedPeers.collect {
+        case (peer, peerInfo) if shouldSendNewBlock(newBlock, peerInfo) => peer }.toSet
+
+      broadcastNewBlock(newBlock, peersWithoutBlock)
+      broadcastNewBlockHash(newBlock, peersWithoutBlock)
+    }
   }
 
   private def shouldSendNewBlock(newBlock: NewBlock, peerInfo: PeerInfo): Boolean =
     newBlock.block.header.number > peerInfo.maxBlockNumber || newBlock.totalDifficulty > peerInfo.totalDifficulty
 
+  private def broadcastNewBlock(newBlock: NewBlock, peers: Set[Peer]): Unit =
+    obtainRandomPeerSubset(peers).foreach { peer =>
+      etcPeerManager ! EtcPeerManagerActor.SendMessage(newBlock, peer.id)
+    }
+
+  private def broadcastNewBlockHash(newBlock: NewBlock, peers: Set[Peer]): Unit = peers.foreach { peer =>
+    val newBlockHeader = newBlock.block.header
+    val newBlockHashMsg = PV62.NewBlockHashes(Seq(BlockHash(newBlockHeader.hash, newBlockHeader.number)))
+    etcPeerManager ! EtcPeerManagerActor.SendMessage(newBlockHashMsg, peer.id)
+  }
+
+
+  /**
+    * Obtains a random subset of peers. The returned set will verify:
+    *   subsetPeers.size == sqrt(peers.size)
+    *
+    * @param peers
+    * @return a random subset of peers
+    */
+  private[sync] def obtainRandomPeerSubset(peers: Set[Peer]): Set[Peer] = {
+    val numberOfPeersToSend = Math.sqrt(peers.size).toInt
+    Random.shuffle(peers).take(numberOfPeersToSend)
+  }
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -221,7 +221,7 @@ class RegularSync(
           val (newBlocks, errorOpt) = processBlocks(blocks, blockParentTd)
 
           if(newBlocks.nonEmpty){
-            broadcastNewBlocks(newBlocks, handshakedPeers)
+            broadcastBlocks(newBlocks, handshakedPeers)
             log.debug(s"got new blocks up till block: ${newBlocks.last.block.header.number} " +
               s"with hash ${Hex.toHexString(newBlocks.last.block.header.hash.toArray[Byte])}")
           }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
@@ -6,11 +6,11 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.TestProbe
 import io.iohk.ethereum.Fixtures
 import io.iohk.ethereum.domain.{Block, BlockHeader}
-import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer, PeerActor}
+import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.{NewBlock, Status}
-import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
-import io.iohk.ethereum.network.p2p.messages.Versions
+import io.iohk.ethereum.network.p2p.messages.PV62.{BlockBody, NewBlockHashes}
+import io.iohk.ethereum.network.p2p.messages.{PV62, Versions}
 import org.scalatest.{FlatSpec, Matchers}
 
 class BlockBroadcastSpec extends FlatSpec with Matchers  {
@@ -23,19 +23,22 @@ class BlockBroadcastSpec extends FlatSpec with Matchers  {
 
     //Block that should be sent as it's total difficulty is higher than known by peer
     val secondHeader: BlockHeader = baseBlockHeader.copy(number = initialPeerInfo.maxBlockNumber - 3)
+    val secondBlockNewHashes = NewBlockHashes(Seq(PV62.BlockHash(secondHeader.hash, secondHeader.number)))
     val secondBlock = NewBlock(Block(secondHeader, BlockBody(Nil, Nil)), initialPeerInfo.totalDifficulty + 2)
 
     //when
-    blockBroadcast.broadcastNewBlocks(Seq(firstBlock, secondBlock), Map(peer -> initialPeerInfo))
+    blockBroadcast.broadcastBlocks(Seq(firstBlock, secondBlock), Map(peer -> initialPeerInfo))
 
     //then
     etcPeerManagerProbe.expectMsg(EtcPeerManagerActor.SendMessage(secondBlock, peer.id))
+    etcPeerManagerProbe.expectMsg(EtcPeerManagerActor.SendMessage(secondBlockNewHashes, peer.id))
     etcPeerManagerProbe.expectNoMsg()
   }
 
   it should "send a new block only when it is not known by the peer (known by comparing max block number)" in new TestSetup {
     //given
     val firstHeader: BlockHeader = baseBlockHeader.copy(number = initialPeerInfo.maxBlockNumber + 4)
+    val firstBlockNewHashes = NewBlockHashes(Seq(PV62.BlockHash(firstHeader.hash, firstHeader.number)))
     val firstBlock = NewBlock(Block(firstHeader, BlockBody(Nil, Nil)), initialPeerInfo.totalDifficulty - 2)
 
     //Block should already be known by the peer due to max block known
@@ -43,10 +46,51 @@ class BlockBroadcastSpec extends FlatSpec with Matchers  {
     val secondBlock = NewBlock(Block(secondHeader, BlockBody(Nil, Nil)), initialPeerInfo.totalDifficulty - 2)
 
     //when
-    blockBroadcast.broadcastNewBlocks(Seq(firstBlock, secondBlock), Map(peer -> initialPeerInfo))
+    blockBroadcast.broadcastBlocks(Seq(firstBlock, secondBlock), Map(peer -> initialPeerInfo))
 
     //then
     etcPeerManagerProbe.expectMsg(EtcPeerManagerActor.SendMessage(firstBlock, peer.id))
+    etcPeerManagerProbe.expectMsg(EtcPeerManagerActor.SendMessage(firstBlockNewHashes, peer.id))
+    etcPeerManagerProbe.expectNoMsg()
+  }
+
+  it should "send block hashes to all peers while the blocks only to sqrt of them" in new TestSetup {
+    //given
+    val firstHeader: BlockHeader = baseBlockHeader.copy(number = initialPeerInfo.maxBlockNumber + 4)
+    val firstBlockNewHashes = NewBlockHashes(Seq(PV62.BlockHash(firstHeader.hash, firstHeader.number)))
+    val firstBlock = NewBlock(Block(firstHeader, BlockBody(Nil, Nil)), initialPeerInfo.totalDifficulty - 2)
+
+    val peer2Probe = TestProbe()
+    val peer2 = Peer(new InetSocketAddress("127.0.0.1", 0), peer2Probe.ref, false)
+    val peer3Probe = TestProbe()
+    val peer3 = Peer(new InetSocketAddress("127.0.0.1", 0), peer3Probe.ref, false)
+    val peer4Probe = TestProbe()
+    val peer4 = Peer(new InetSocketAddress("127.0.0.1", 0), peer4Probe.ref, false)
+
+    //when
+    val peersWithInfo = Map(
+      peer -> initialPeerInfo,
+      peer2 -> initialPeerInfo,
+      peer3 -> initialPeerInfo,
+      peer4 -> initialPeerInfo)
+    val blockBroadcastFirstTwoPeers = new BlockBroadcast {
+      override val etcPeerManager: ActorRef = etcPeerManagerProbe.ref
+
+      override def obtainRandomPeerSubset(peers: Set[Peer]): Set[Peer] = Set(peer, peer2)
+    }
+    blockBroadcastFirstTwoPeers.broadcastBlocks(Seq(firstBlock), peersWithInfo)
+
+    //then
+    etcPeerManagerProbe.expectMsgAllOf(
+      //Only first two peers receive the complete block
+      EtcPeerManagerActor.SendMessage(firstBlock, peer.id),
+      EtcPeerManagerActor.SendMessage(firstBlock, peer2.id),
+
+      //All the peers should receive the block hashes
+      EtcPeerManagerActor.SendMessage(firstBlockNewHashes, peer.id),
+      EtcPeerManagerActor.SendMessage(firstBlockNewHashes, peer2.id),
+      EtcPeerManagerActor.SendMessage(firstBlockNewHashes, peer3.id),
+      EtcPeerManagerActor.SendMessage(firstBlockNewHashes, peer4.id))
     etcPeerManagerProbe.expectNoMsg()
   }
 


### PR DESCRIPTION
## Description

Modifies the block propagation algorithm from sending `NewBlock` messages to all peers, to sending `NewBlockHashes` messages to all peers but sending `NewBlock` messages to only a randomly selected `sqrt(|peers|)` as both Parity and Geth propagate blocks that way.