### PR TITLE
[EC-250] eth_getWork returns error if called while syncing

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -67,7 +67,6 @@ class RegularSync(
       waitingForActor = None
       handleBlockBodies(peer, blockBodies)
 
-    //todo improve mined block handling - add info that block was not included because of syncing [EC-250]
     //we allow inclusion of mined block only if we are not syncing / reorganising chain
     case MinedBlock(block) =>
       if (headersQueue.isEmpty && waitingForActor.isEmpty) {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcError.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcError.scala
@@ -14,4 +14,5 @@ object JsonRpcErrors {
   val InternalError = JsonRpcError(-32603, "Internal JSON-RPC error", None)
   def LogicError(msg: String) = JsonRpcError(-32000, msg, None)
   val AccountLocked = LogicError("account is locked or unknown")
+  val NoWork = JsonRpcError(-32001, "Syncing. Cannot give any work.", None)
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -135,8 +135,8 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
 
   it should "eth_syncing" in new TestSetup {
     (appStateStorage.getSyncStartingBlock _).expects().returning(100)
-    (appStateStorage.getBestBlockNumber _).expects().returning(200)
-    (appStateStorage.getEstimatedHighestBlock _).expects().returning(300)
+    (appStateStorage.getBestBlockNumber _).expects().returning(200).twice()
+    (appStateStorage.getEstimatedHighestBlock _).expects().returning(300).twice()
 
     val rpcRequest = JsonRpcRequest("2.0", "eth_syncing", None, Some(1))
 
@@ -454,7 +454,8 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
     val headerPowHash = s"0x${Hex.toHexString(kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)))}"
 
-    (appStateStorage.getBestBlockNumber _).expects().returns(1)
+    (appStateStorage.getBestBlockNumber _).expects().returns(1).twice()
+    (appStateStorage.getEstimatedHighestBlock _).expects().returns(1)
     (blockGenerator.generateBlockForMining _).expects(*, *, *, *)
       .returns(Right(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil)))
 
@@ -489,7 +490,8 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
     val headerPowHash = s"0x${Hex.toHexString(kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)))}"
 
-    (appStateStorage.getBestBlockNumber _).expects().returns(1)
+    (appStateStorage.getBestBlockNumber _).expects().returns(1).twice()
+    (appStateStorage.getEstimatedHighestBlock _).expects().returns(1)
     (blockGenerator.generateBlockForMining _).expects(*, *, *, *)
       .returns(Right(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil)))
 


### PR DESCRIPTION
## Description

Changes `eth_getWork` implementation so that no block is generated and returned if the client is syncing (as the mined block won't be accepted in RegularSync), as is done in [Parity](https://github.com/paritytech/parity/blob/master/rpc/src/v1/impls/eth.rs#L534).
The `EthService.lastActive` time is not updated in that case, so the `eth_mining` response is not affected by this `eth_work` call.

*Note*: The returned error code is `-32001` as it also is it in Parity.