### PR TITLE
[EC-128][EC-244] Handle NewBlock messages

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -293,7 +293,7 @@ mantis {
     target-block-offset = 500
 
     # How often to query peers for new blocks after the top of the chain has been reached
-    check-for-new-block-interval = 1.seconds
+    check-for-new-block-interval = 10.seconds
 
     # size of the list that keeps track of peers that are failing to provide us with mpt node
     # we switch them to download only blockchain elements

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcast.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcast.scala
@@ -19,17 +19,15 @@ trait BlockBroadcast {
     * The hash of the block is sent to all of those peers while the block itself is only sent to
     * the square root of the total number of those peers, with the subset being obtained randomly.
     *
-    * @param newBlocks, blocks to broadcast
+    * @param newBlock, block to broadcast
     * @param handshakedPeers, to which the blocks will be broadcasted to
     */
-  def broadcastBlocks(newBlocks: Seq[NewBlock], handshakedPeers: Map[Peer, PeerInfo]): Unit = {
-    newBlocks.foreach { newBlock =>
-      val peersWithoutBlock = handshakedPeers.collect {
-        case (peer, peerInfo) if shouldSendNewBlock(newBlock, peerInfo) => peer }.toSet
+  def broadcastBlock(newBlock: NewBlock, handshakedPeers: Map[Peer, PeerInfo]): Unit = {
+    val peersWithoutBlock = handshakedPeers.collect {
+      case (peer, peerInfo) if shouldSendNewBlock(newBlock, peerInfo) => peer }.toSet
 
-      broadcastNewBlock(newBlock, peersWithoutBlock)
-      broadcastNewBlockHash(newBlock, peersWithoutBlock)
-    }
+    broadcastNewBlock(newBlock, peersWithoutBlock)
+    broadcastNewBlockHash(newBlock, peersWithoutBlock)
   }
 
   private def shouldSendNewBlock(newBlock: NewBlock, peerInfo: PeerInfo): Boolean =

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -7,6 +7,9 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.{BlockExecutionError, Ledger}
 import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
+import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
+import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
+import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.transactions.PendingTransactionsManager
@@ -37,8 +40,11 @@ class RegularSync(
   private var headersQueue: Seq[BlockHeader] = Nil
   private var waitingForActor: Option[ActorRef] = None
   private var resolvingBranches: Boolean = false
+  private var resumeRegularSyncTimeout: Option[Cancellable] = None
 
   scheduler.schedule(printStatusInterval, printStatusInterval, self, PrintStatus)
+
+  peerEventBus ! Subscribe(MessageClassifier(Set(NewBlock.code), PeerSelector.AllPeers))
 
   def handleCommonMessages: Receive = handlePeerListMessages orElse handleBlacklistMessages
 
@@ -52,10 +58,56 @@ class RegularSync(
       askForHeaders()
   }
 
-  def running: Receive = handleCommonMessages orElse {
-    case ResumeRegularSync =>
-      askForHeaders()
+  private def resumeRegularSync(): Unit = {
+    resumeRegularSyncTimeout.foreach(_.cancel)
+    resumeRegularSyncTimeout = None
+    askForHeaders()
+  }
 
+  /**
+    * Handles broadcasted blocks, processing them and inserting them to the blockchain if necessary
+    * FIXME: Current implementation is naive in that NewBlock msgs that can't be immediately processed are discarded
+    *        and requested again to the peers
+    */
+  def handleBroadcastedBlockMessages: Receive = {
+    case MessageFromPeer(NewBlock(newBlock, _), peerId) =>
+      //we allow inclusion of new block only if we are not syncing / reorganising chain
+      if (headersQueue.isEmpty && waitingForActor.isEmpty) {
+        val currentBestBlock = appStateStorage.getBestBlockNumber()
+        val maybeBlockParentTd = blockchain.getBlockHeaderByHash(newBlock.header.parentHash)
+          .flatMap(b => blockchain.getTotalDifficultyByHash(b.hash))
+        val maybeCurrentBlockTd = blockchain.getTotalDifficultyByNumber(currentBestBlock)
+
+        (maybeBlockParentTd, maybeCurrentBlockTd) match {
+          case (_, None) =>
+            //Something went wrong, we don't have the total difficulty of the latest block
+            //TODO: Investigate if we can recover from this error [EC-165]
+            throw new IllegalStateException(s"No total difficulty for the latest block with number $currentBestBlock")
+          case (None, Some(_)) =>
+            //The received block should be imported, however we don't have it's parent.
+            //This could be caused by our client not being up-to-date or a fork in the blockchain
+            //RegularSync is resumed which will lead to the needed reorganization
+            log.debug("Resumed regular sync due to receiving NewBlock and not having it's parent")
+            resumeRegularSync()
+          case (Some(parentTd), Some(currentTd)) if currentTd >= parentTd + newBlock.header.difficulty =>
+            //The received block is not imported as it's total difficulty is too low, do nothing
+            log.debug("Not inserting NewBlock due to having too low total difficulty")
+          case (Some(parentTd), Some(_)) =>
+            val blockProcessResult = processBlock(newBlock, parentTd)
+            blockProcessResult match {
+              case Right(_) =>
+                //Delete old blocks no longer needed
+                if(newBlock.header.number < currentBestBlock)
+                  ((newBlock.header.number + 1) to currentBestBlock).foreach(blockchain.removeBlock)
+                log.debug(s"Added new block ${newBlock.header.number} received from $peerId")
+              case Left(err) =>
+                blacklist(peerId, blacklistDuration, err.toString)
+            }
+        }
+      }
+  }
+
+  def handleResponseToRequest: Receive = {
     case ResponseReceived(peer: Peer, BlockHeaders(headers), timeTaken) =>
       log.info("Received {} block headers in {} ms", headers.size, timeTaken)
       waitingForActor = None
@@ -67,6 +119,18 @@ class RegularSync(
       waitingForActor = None
       handleBlockBodies(peer, blockBodies)
 
+    case PeerRequestHandler.RequestFailed(peer, reason) if waitingForActor.contains(sender()) =>
+      waitingForActor = None
+      if (handshakedPeers.contains(peer)) {
+        blacklist(peer.id, blacklistDuration, reason)
+      }
+      scheduleResume()
+  }
+
+  def running: Receive = handleCommonMessages orElse handleBroadcastedBlockMessages orElse handleResponseToRequest orElse {
+    case ResumeRegularSync =>
+      resumeRegularSync()
+
     //todo improve mined block handling - add info that block was not included because of syncing [EC-250]
     //we allow inclusion of mined block only if we are not syncing / reorganising chain
     case MinedBlock(block) =>
@@ -76,7 +140,13 @@ class RegularSync(
           .flatMap(b => blockchain.getTotalDifficultyByHash(b.hash)) match {
           case Some(parentTd) if appStateStorage.getBestBlockNumber() < block.header.number =>
             //just insert block and let resolve it with regular download
-            insertMinedBlock(block, parentTd)
+            val blockProcessResult = processBlock(block, parentTd)
+            blockProcessResult match {
+              case Right(_) =>
+                log.debug(s"Added new mined block $block")
+              case Left(err) =>
+                log.warning(s"Failed to execute mined block because of $err")
+            }
           case _ =>
             log.error("Failed to add mined block")
         }
@@ -86,33 +156,24 @@ class RegularSync(
 
     case PrintStatus =>
       log.info(s"Block: ${appStateStorage.getBestBlockNumber()}. Peers: ${handshakedPeers.size} (${blacklistedPeers.size} blacklisted)")
-
-    case PeerRequestHandler.RequestFailed(peer, reason) if waitingForActor.contains(sender()) =>
-      waitingForActor = None
-      if (handshakedPeers.contains(peer)) {
-        blacklist(peer.id, blacklistDuration, reason)
-      }
-      scheduleResume()
   }
 
-  private def insertMinedBlock(block: Block, parentTd: BigInt) = {
-    val result: Either[BlockExecutionError, Seq[Receipt]] = ledger.executeBlock(block, validators)
+  private def processBlock(block: Block, parentTd: BigInt): Either[BlockExecutionError, BigInt] = {
+    val blockHashToDelete = blockchain.getBlockHeaderByNumber(block.header.number).map(_.hash).filter(_ != block.header.hash)
+    val blockExecResult = ledger.executeBlock(block, validators)
 
-    result match {
-      case Right(receipts) =>
-        blockchain.save(block)
-        blockchain.save(block.header.hash, receipts)
-        appStateStorage.putBestBlockNumber(block.header.number)
-        val newTd = parentTd + block.header.difficulty
-        blockchain.save(block.header.hash, newTd)
+    blockExecResult.map { receipts =>
+      blockchain.save(block)
+      blockchain.save(block.header.hash, receipts)
+      appStateStorage.putBestBlockNumber(block.header.number)
+      val newTd = parentTd + block.header.difficulty
+      blockchain.save(block.header.hash, newTd)
+      blockHashToDelete.foreach(blockchain.removeBlock)
 
-        handshakedPeers.keys.foreach(peer => etcPeerManager ! EtcPeerManagerActor.SendMessage(NewBlock(block, newTd), peer.id))
-        ommersPool ! new RemoveOmmers((block.header +: block.body.uncleNodesList).toList)
-        pendingTransactionsManager ! PendingTransactionsManager.RemoveTransactions(block.body.transactionList)
-
-        log.debug(s"Added new block $block")
-      case Left(err) =>
-        log.warning(s"Failed to execute mined block because of $err")
+      broadcastBlock(NewBlock(block, newTd), handshakedPeers)
+      ommersPool ! RemoveOmmers((block.header +: block.body.uncleNodesList).toList)
+      pendingTransactionsManager ! PendingTransactionsManager.RemoveTransactions(block.body.transactionList)
+      newTd
     }
   }
 
@@ -220,11 +281,9 @@ class RegularSync(
         case Some(blockParentTd) =>
           val (newBlocks, errorOpt) = processBlocks(blocks, blockParentTd)
 
-          if(newBlocks.nonEmpty){
-            broadcastBlocks(newBlocks, handshakedPeers)
+          if(newBlocks.nonEmpty)
             log.debug(s"got new blocks up till block: ${newBlocks.last.block.header.number} " +
               s"with hash ${Hex.toHexString(newBlocks.last.block.header.hash.toArray[Byte])}")
-          }
 
           errorOpt match {
             case Some(error) =>
@@ -268,20 +327,9 @@ class RegularSync(
       newBlocks -> None
 
     case Seq(block, otherBlocks@_*) =>
-      val blockHashToDelete = blockchain.getBlockHeaderByNumber(block.header.number).map(_.hash).filter(_ != block.header.hash)
-      val blockExecResult = ledger.executeBlock(block, validators)
-      blockExecResult match {
-        case Right(receipts) =>
-          blockchain.save(block)
-          blockchain.save(block.header.hash, receipts)
-          appStateStorage.putBestBlockNumber(block.header.number)
-          val newTd = blockParentTd + block.header.difficulty
-          blockchain.save(block.header.hash, newTd)
-          blockHashToDelete.foreach(blockchain.removeBlock)
-
-          pendingTransactionsManager ! PendingTransactionsManager.RemoveTransactions(block.body.transactionList)
-          ommersPool ! new RemoveOmmers((block.header +: block.body.uncleNodesList).toList)
-
+      val blockProcessResult = processBlock(block, blockParentTd)
+      blockProcessResult match {
+        case Right(newTd) =>
           processBlocks(otherBlocks, newTd, newBlocks :+ NewBlock(block, newTd))
         case Left(error) =>
           newBlocks -> Some(error)
@@ -290,7 +338,7 @@ class RegularSync(
 
   private def scheduleResume() = {
     headersQueue = Nil
-    scheduler.scheduleOnce(checkForNewBlockInterval, self, ResumeRegularSync)
+    resumeRegularSyncTimeout = Some(scheduler.scheduleOnce(checkForNewBlockInterval, self, ResumeRegularSync))
   }
 
   private def resumeWithDifferentPeer(currentPeer: Peer, reason: String = "error in response") = {
@@ -319,7 +367,7 @@ object RegularSync {
     Props(new RegularSync(appStateStorage, blockchain, validators, etcPeerManager, peerEventBus, ommersPool, pendingTransactionsManager,
       ledger, syncConfig, scheduler))
 
-  private case object ResumeRegularSync
+  private[sync] case object ResumeRegularSync
   private case class ResolveBranch(peer: ActorRef)
   private case object PrintStatus
 

--- a/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Blockchain.scala
@@ -109,6 +109,9 @@ trait Blockchain {
     */
   def getTotalDifficultyByHash(blockhash: ByteString): Option[BigInt]
 
+  def getTotalDifficultyByNumber(blockNumber: BigInt): Option[BigInt] =
+    getHashByBlockNumber(blockNumber).flatMap(getTotalDifficultyByHash)
+
   def getTransactionLocation(txHash: ByteString): Option[TransactionLocation]
 
   /**
@@ -122,6 +125,8 @@ trait Blockchain {
   }
 
   def removeBlock(hash: ByteString): Unit
+
+  def removeBlock(blockNumber: BigInt): Unit = getHashByBlockNumber(blockNumber).foreach(removeBlock)
 
   /**
     * Persists a block header in the underlying Blockchain Database

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -27,7 +27,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import org.spongycastle.util.encoders.Hex
 
-import scala.collection.immutable.Queue
+import scala.collection.immutable.{Queue, Set}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -177,7 +177,7 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
   }
 
   it should "request for block bodies again if block bodies validation fails" in new TestSetup() {
-    override val syncController = TestActorRef(Props(new SyncController(
+    override lazy val syncController = TestActorRef(Props(new SyncController(
       storagesInstance.storages.appStateStorage,
       blockchain,
       storagesInstance.storages.fastSyncStateStorage,
@@ -968,6 +968,8 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     syncController ! SyncController.Start
 
+    peerMessageBus.expectMsg(Subscribe(MessageClassifier(Set(NewBlock.code), PeerSelector.AllPeers)))
+
     syncController.getSingleChild("regular-sync") ! HandshakedPeers(Map(
       peer -> PeerInfo(peer1Status, forkAccepted = true, totalDifficulty = peer1Status.totalDifficulty, maxBlockNumber = 0)))
     peerMessageBus.expectMsg(Subscribe(PeerDisconnectedClassifier(PeerSelector.WithId(peer.id))))
@@ -1096,6 +1098,156 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
       EtcPeerManagerActor.SendMessage(GetNodeData(Seq(ByteString("node_hash"))), peer.id))
   }
 
+  it should "include a NewBlock if it should be imported" in new TestSetup() {
+    val peer1TestProbe: TestProbe = TestProbe()(system)
+
+    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
+
+    Thread.sleep(1.seconds.toMillis)
+
+    val peer1Status= Status(1, 1, 1, ByteString("peer1_bestHash"), ByteString("unused"))
+
+    val expectedMaxBlock = 399500
+    val maxBlocTotalDifficulty = 12340
+    val maxBlockHeader: BlockHeader = baseBlockHeader.copy(number = expectedMaxBlock)
+
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(maxBlockHeader.number)
+    storagesInstance.storages.blockHeadersStorage.put(maxBlockHeader.hash, maxBlockHeader)
+    storagesInstance.storages.blockNumberMappingStorage.put(maxBlockHeader.number, maxBlockHeader.hash)
+    storagesInstance.storages.totalDifficultyStorage.put(maxBlockHeader.hash, maxBlocTotalDifficulty)
+
+    storagesInstance.storages.appStateStorage.fastSyncDone()
+
+    syncControllerWithoutSyncing ! SyncController.Start
+
+    syncControllerWithoutSyncing.getSingleChild("regular-sync") ! HandshakedPeers(Map(
+      peer1 -> PeerInfo(peer1Status, forkAccepted = true, totalDifficulty = peer1Status.totalDifficulty, maxBlockNumber = 0)
+    ))
+    syncControllerWithoutSyncing ! RegularSync.ResumeRegularSync
+
+    //Node stops syncing
+    etcPeerManager.expectMsg(EtcPeerManagerActor.SendMessage(
+      GetBlockHeaders(Left(expectedMaxBlock + 1), syncConfig.blockHeadersPerRequest, 0, reverse = false), peer1.id))
+    etcPeerManager.reply(MessageFromPeer(BlockHeaders(Nil), peer1.id))
+
+    //Wait for headers response processing
+    Thread.sleep(1.seconds.toMillis)
+
+    //Node receives new block
+    val block = Block(baseBlockHeader.copy(number = maxBlockHeader.number + 1, parentHash = maxBlockHeader.hash, difficulty = 1), BlockBody(Nil, Nil))
+    syncControllerWithoutSyncing ! MessageFromPeer(NewBlock(block, maxBlocTotalDifficulty + 1), peer1.id)
+
+    //Wait for NewBlock msg processing
+    Thread.sleep(2.seconds.toMillis)
+
+    //The NewBlock was processed and inserted into the blockchain
+    storagesInstance.storages.appStateStorage.getBestBlockNumber() shouldBe maxBlockHeader.number + 1
+  }
+
+  it should "not include a NewBlock if it's total difficulty is too low" in new TestSetup() {
+    val peer1TestProbe: TestProbe = TestProbe()(system)
+
+    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
+
+    Thread.sleep(1.seconds.toMillis)
+
+    val peer1Status= Status(1, 1, 1, ByteString("peer1_bestHash"), ByteString("unused"))
+
+    val firstBlockNumber = 399500
+    val firstBlockTotalDifficulty = 12340
+    val firstBlock: BlockHeader = baseBlockHeader.copy(number = firstBlockNumber)
+    val secondBlockNumber = firstBlockNumber + 1
+    val secondBlockTotalDifficulty = firstBlockTotalDifficulty + 2
+    val secondBlock: BlockHeader = baseBlockHeader.copy(number = secondBlockNumber)
+
+    addBlockToStorages(firstBlock, firstBlockTotalDifficulty)
+    addBlockToStorages(secondBlock, secondBlockTotalDifficulty)
+
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(secondBlock.number)
+    storagesInstance.storages.appStateStorage.fastSyncDone()
+
+    syncControllerWithoutSyncing ! SyncController.Start
+
+    syncControllerWithoutSyncing.getSingleChild("regular-sync") ! HandshakedPeers(Map(
+      peer1 -> PeerInfo(peer1Status, forkAccepted = true, totalDifficulty = peer1Status.totalDifficulty, maxBlockNumber = 0)
+    ))
+    syncControllerWithoutSyncing ! RegularSync.ResumeRegularSync
+
+    //Node stops syncing
+    etcPeerManager.expectMsg(EtcPeerManagerActor.SendMessage(
+      GetBlockHeaders(Left(secondBlockNumber + 1), syncConfig.blockHeadersPerRequest, 0, reverse = false), peer1.id))
+    etcPeerManager.reply(MessageFromPeer(BlockHeaders(Nil), peer1.id))
+
+    //Wait for headers response processing
+    Thread.sleep(1.seconds.toMillis)
+
+    //Node receives new block
+    val block = Block(baseBlockHeader.copy(number = firstBlock.number + 1, parentHash = firstBlock.hash, difficulty = 1), BlockBody(Nil, Nil))
+    syncControllerWithoutSyncing ! MessageFromPeer(NewBlock(block, firstBlockTotalDifficulty + 1), peer1.id)
+
+    //Wait for NewBlock msg processing
+    Thread.sleep(2.seconds.toMillis)
+
+    //The NewBlock was processed but not inserted into the blockchain
+    storagesInstance.storages.appStateStorage.getBestBlockNumber() shouldBe secondBlock.number
+  }
+
+  it should "include a NewBlock if it's a better but old block" in new TestSetup() {
+    val peer1TestProbe: TestProbe = TestProbe()(system)
+
+    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
+
+    Thread.sleep(1.seconds.toMillis)
+
+    val peer1Status= Status(1, 1, 1, ByteString("peer1_bestHash"), ByteString("unused"))
+
+    val firstBlockNumber = 399500
+    val firstBlockTotalDifficulty = 12340
+    val firstBlock: BlockHeader = baseBlockHeader.copy(number = firstBlockNumber)
+    val secondBlockNumber = firstBlockNumber + 1
+    val secondBlockTotalDifficulty = firstBlockTotalDifficulty + 2
+    val secondBlock: BlockHeader = baseBlockHeader.copy(number = secondBlockNumber)
+    val thirdBlockNumber = secondBlockNumber + 1
+    val thirdBlockTotalDifficulty = secondBlockTotalDifficulty + 2
+    val thirdBlock: BlockHeader = baseBlockHeader.copy(number = thirdBlockNumber)
+
+    addBlockToStorages(firstBlock, firstBlockTotalDifficulty)
+    addBlockToStorages(secondBlock, secondBlockTotalDifficulty)
+    addBlockToStorages(thirdBlock, thirdBlockTotalDifficulty)
+
+    storagesInstance.storages.appStateStorage.putBestBlockNumber(thirdBlock.number)
+    storagesInstance.storages.appStateStorage.fastSyncDone()
+
+    syncControllerWithoutSyncing ! SyncController.Start
+
+    syncControllerWithoutSyncing.getSingleChild("regular-sync") ! HandshakedPeers(Map(
+      peer1 -> PeerInfo(peer1Status, forkAccepted = true, totalDifficulty = peer1Status.totalDifficulty, maxBlockNumber = 0)
+    ))
+    syncControllerWithoutSyncing ! RegularSync.ResumeRegularSync
+
+    //Node stops syncing
+    etcPeerManager.expectMsg(EtcPeerManagerActor.SendMessage(
+      GetBlockHeaders(Left(thirdBlockNumber + 1), syncConfig.blockHeadersPerRequest, 0, reverse = false), peer1.id))
+    etcPeerManager.reply(MessageFromPeer(BlockHeaders(Nil), peer1.id))
+
+    //Wait for headers response processing
+    Thread.sleep(1.seconds.toMillis)
+
+    //Node receives new block
+    val block = Block(baseBlockHeader.copy(number = firstBlock.number + 1, parentHash = firstBlock.hash, difficulty = 10), BlockBody(Nil, Nil))
+    syncControllerWithoutSyncing ! MessageFromPeer(NewBlock(block, firstBlockTotalDifficulty + 10), peer1.id)
+
+    //Wait for NewBlock msg processing
+    Thread.sleep(2.seconds.toMillis)
+
+    //The NewBlock was processed and inserted into the blockchain
+    storagesInstance.storages.appStateStorage.getBestBlockNumber() shouldBe block.header.number
+
+    //Old blocks were deleted
+    blockchain.getBlockByHash(secondBlock.hash) shouldBe None
+    blockchain.getBlockByHash(thirdBlock.hash) shouldBe None
+  }
+
   class TestSetup(blocksForWhichLedgerFails: Seq[BigInt] = Nil) extends EphemBlockchainTestSetup {
 
     private def isNewBlock(msg: Message): Boolean = msg match {
@@ -1113,20 +1265,21 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val peerMessageBus = TestProbe()
     peerMessageBus.ignoreMsg{
+      case Subscribe(MessageClassifier(codes, PeerSelector.AllPeers)) if codes == Set(NewBlock.code) => true
       case Subscribe(PeerDisconnectedClassifier(_)) => true
       case Unsubscribe(Some(PeerDisconnectedClassifier(_))) => true
     }
     val pendingTransactionsManager = TestProbe()
     val ommersPool = TestProbe()
 
-    lazy val syncConfig = new SyncConfig {
+    def obtainSyncConfig(checkingForNewBlockInterval: FiniteDuration): SyncConfig = new SyncConfig {
       override val printStatusInterval: FiniteDuration = 1.hour
       override val persistStateSnapshotInterval: FiniteDuration = 20.seconds
       override val targetBlockOffset: Int = 500
       override val branchResolutionBatchSize: Int = 20
       override val blacklistDuration: FiniteDuration = 5.seconds
       override val syncRetryInterval: FiniteDuration = 1.second
-      override val checkForNewBlockInterval: FiniteDuration = 1.second
+      override val checkForNewBlockInterval: FiniteDuration = checkingForNewBlockInterval
       override val startRetryInterval: FiniteDuration = 500.milliseconds
       override val branchResolutionMaxRequests: Int = 100
       override val blockChainOnlyPeersPoolSize: Int = 100
@@ -1142,7 +1295,8 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
       override val fastSyncThrottle: FiniteDuration = 100.milliseconds
     }
 
-    val syncController = TestActorRef(Props(new SyncController(
+    lazy val syncConfig = obtainSyncConfig(1.seconds)
+    lazy val syncController = TestActorRef(Props(new SyncController(
       storagesInstance.storages.appStateStorage,
       blockchain,
       storagesInstance.storages.fastSyncStateStorage,
@@ -1150,6 +1304,17 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
       new Mocks.MockValidatorsAlwaysSucceed,
       peerMessageBus.ref, pendingTransactionsManager.ref, ommersPool.ref, etcPeerManager.ref,
       syncConfig,
+      externalSchedulerOpt = None)))
+
+    lazy val syncConfigWithoutSyncing = obtainSyncConfig(10.minutes)
+    lazy val syncControllerWithoutSyncing = TestActorRef(Props(new SyncController(
+      storagesInstance.storages.appStateStorage,
+      blockchain,
+      storagesInstance.storages.fastSyncStateStorage,
+      ledger,
+      new Mocks.MockValidatorsAlwaysSucceed,
+      peerMessageBus.ref, pendingTransactionsManager.ref, ommersPool.ref, etcPeerManager.ref,
+      syncConfigWithoutSyncing,
       externalSchedulerOpt = None)))
 
     val EmptyTrieRootHash: ByteString = Account.EmptyStorageRootHash
@@ -1173,6 +1338,12 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter {
     blockchain.save(baseBlockHeader.parentHash, BigInt(0))
 
     val startDelayMillis = 200
+
+    def addBlockToStorages(blockHeader: BlockHeader, blockTD: BigInt): Unit = {
+      storagesInstance.storages.blockHeadersStorage.put(blockHeader.hash, blockHeader)
+      storagesInstance.storages.blockNumberMappingStorage.put(blockHeader.number, blockHeader.hash)
+      storagesInstance.storages.totalDifficultyStorage.put(blockHeader.hash, blockTD)
+    }
   }
 
 }


### PR DESCRIPTION
## Description

Includes handling of `NewBlock` messages so that they are inserted into the blockchain or the client restarts syncing if necessary. This fixes the [issue](https://iohk.myjetbrains.com/youtrack/issue/EC-244) that the Mantis client had on [etcstats](http://etcstats.net/) where the Mantis node was usually out-dated in comparison with the other nodes.

**Note:** Due to the refactoring to be done in [EC-303](https://iohk.myjetbrains.com/youtrack/issue/EC-303) the handling of the `NewBlockHashes` message was not included in this PR.