### PR TITLE
[EC-303] RegularSync refactor

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -247,7 +247,7 @@ mantis {
 
   sync {
     # Whether to enable fast-sync
-    do-fast-sync = true
+    do-fast-sync = false
 
     # Interval for updating peers during sync
     peers-scan-interval = 3.seconds

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -121,6 +121,7 @@ class GenesisDataLoader(
         blockchain.save(Block(header, BlockBody(Nil, Nil)))
         blockchain.save(header.hash, Nil)
         blockchain.save(header.hash, header.difficulty)
+        blockchain.saveBlockNumber(0, header.hash)
         Success(())
     }
   }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -74,9 +74,9 @@ class SyncController(
   }
 
   def startRegularSync(): Unit = {
-    val regularSync = context.actorOf(RegularSync.props(appStateStorage, blockchain, validators, etcPeerManager,
+    val regularSync = context.actorOf(NewRegularSync.props(appStateStorage, blockchain, validators, etcPeerManager,
       peerEventBus, ommersPool, pendingTransactionsManager, ledger, syncConfig, scheduler), "regular-sync")
-    regularSync ! RegularSync.Start
+    regularSync ! NewRegularSync.Start
     context become runningRegularSync(regularSync)
   }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -11,7 +11,7 @@ import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction, UInt256, _}
 import akka.actor.ActorRef
 import io.iohk.ethereum.db.storage.AppStateStorage
 import akka.util.ByteString
-import io.iohk.ethereum.blockchain.sync.RegularSync
+import io.iohk.ethereum.blockchain.sync.{NewRegularSync, RegularSync}
 import io.iohk.ethereum.crypto._
 import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import io.iohk.ethereum.jsonrpc.FilterManager.{FilterChanges, FilterLogs, LogFilterLogs, TxLog}
@@ -484,7 +484,7 @@ class EthService(
       blockGenerator.getPrepared(req.powHeaderHash) match {
         case Some(pendingBlock) if appStateStorage.getBestBlockNumber() <= pendingBlock.block.header.number =>
           import pendingBlock._
-          syncingController ! RegularSync.MinedBlock(block.copy(header = block.header.copy(nonce = req.nonce, mixHash = req.mixHash)))
+          syncingController ! NewRegularSync.MinedBlock(block.copy(header = block.header.copy(nonce = req.nonce, mixHash = req.mixHash)))
           Right(SubmitWorkResponse(true))
         case _ =>
           Right(SubmitWorkResponse(false))

--- a/src/main/scala/io/iohk/ethereum/mining/BlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/mining/BlockGenerator.scala
@@ -39,7 +39,7 @@ class BlockGenerator(blockchain: Blockchain, blockchainConfig: BlockchainConfig,
         val body = BlockBody(transactionsForBlock, ommers)
         val block = Block(header, body)
 
-        val prepared = ledger.prepareBlock(block, validators) match {
+        val prepared = ledger.prepareBlock(block) match {
           case BlockPreparationResult(prepareBlock, BlockResult(_, gasUsed, receipts), stateRoot) =>
             val receiptsLogs: Seq[Array[Byte]] = BloomFilter.EmptyBloomFilter.toArray +: receipts.map(_.logsBloomFilter.toArray)
             val bloomFilter = ByteString(or(receiptsLogs: _*))

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV62.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV62.scala
@@ -95,6 +95,21 @@ object PV62 {
     }
   }
 
+
+  case class GetBlockHeaders(block: Either[BigInt, ByteString], maxHeaders: BigInt, skip: BigInt, reverse: Boolean) extends Message {
+    override def code: Int = GetBlockHeaders.code
+
+    override def toString: String = {
+      s"""GetBlockHeaders{
+          |block: ${block.fold(a => a, b => Hex.toHexString(b.toArray[Byte]))}
+          |maxHeaders: $maxHeaders
+          |skip: $skip
+          |reverse: $reverse
+          |}
+     """.stripMargin
+    }
+  }
+
   object BlockHeaderImplicits {
     implicit class BlockHeaderEnc(blockHeader: BlockHeader) extends RLPSerializable {
       override def toRLPEncodable: RLPEncodeable = {
@@ -211,20 +226,6 @@ object PV62 {
 
   case class BlockBodies(bodies: Seq[BlockBody]) extends Message {
     val code: Int = BlockBodies.code
-  }
-
-  case class GetBlockHeaders(block: Either[BigInt, ByteString], maxHeaders: BigInt, skip: BigInt, reverse: Boolean) extends Message {
-    override def code: Int = GetBlockHeaders.code
-
-    override def toString: String = {
-      s"""GetBlockHeaders{
-         |block: ${block.fold(a => a, b => Hex.toHexString(b.toArray[Byte]))}
-         |maxHeaders: $maxHeaders
-         |skip: $skip
-         |reverse: $reverse
-         |}
-     """.stripMargin
-    }
   }
 
   object BlockHeaders {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -354,9 +354,10 @@ trait ValidatorsBuilder {
 
 trait LedgerBuilder {
   self: BlockchainConfigBuilder
-    with BlockChainBuilder =>
+    with BlockChainBuilder
+    with ValidatorsBuilder =>
 
-  lazy val ledger: Ledger = new LedgerImpl(VM, blockchain, blockchainConfig)
+  lazy val ledger: Ledger = new LedgerImpl(VM, blockchain, blockchainConfig, validators)
 }
 
 trait SyncControllerBuilder {


### PR DESCRIPTION
The aim of this PR is to provide is to remove the logic of importing blocks from `RegularSync` and have single entry point in the `Ledger`, thus providing better decoupling between components. This single entry point - `importBlock` should handle chain re-org and be suitable for use with ETS blockchain tests: #296 

TODOs:

- [ ] correctly handle branch switches wrt pending transactions and ommers
- [ ] ignore blocks that are too far behind
- [ ] delete/prune old stale blocks
- [ ] integrate with blockchain tests
- [ ] reorganize packages (`blockchain.sync`,  `domain.Blockchain`)
- [ ] try to reduce dependencies (`Blockchain`)

So far I have used this code to successfully sync the first 150k blocks.