### PR TITLE
Add EIP161 block number config to ropsten.conf

### DIFF
--- a/src/universal/conf/ropsten.conf
+++ b/src/universal/conf/ropsten.conf
@@ -14,6 +14,7 @@ mantis {
     eip150-block-number = "0"
     eip155-block-number = "10"
     eip160-block-number = "10"
+    eip161-block-number = "10"
     difficulty-bomb-pause-block-number = "0"
     difficulty-bomb-continue-block-number = "0"
     max-code-size = 24576


### PR DESCRIPTION
## Descripion

This PR adds `eip161-block-number` config taken from https://raw.githubusercontent.com/paritytech/parity/master/ethcore/res/ethereum/ropsten.json