### PR TITLE
[EC-314] FIX: Pruning may fail if a node is updated after marked as prune candidate

### DIFF
--- a/src/main/scala/io/iohk/ethereum/db/storage/encoding/package.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/encoding/package.scala
@@ -18,11 +18,11 @@ package object encoding {
 
   private val storedNodeEncDec = new RLPDecoder[StoredNode] with RLPEncoder[StoredNode] {
     override def decode(rlp: RLPEncodeable): StoredNode = rlp match {
-      case RLPList(nodeEncoded, references) => StoredNode(nodeEncoded, references)
+      case RLPList(nodeEncoded, references, lastUpdateAt) => StoredNode(nodeEncoded, references, lastUpdateAt)
       case _ => throw new RuntimeException("Error when decoding stored node")
     }
 
-    override def encode(obj: StoredNode): RLPEncodeable = rlpEncode(RLPList(obj.nodeEncoded, obj.references))
+    override def encode(obj: StoredNode): RLPEncodeable = rlpEncode(RLPList(obj.nodeEncoded, obj.references, obj.lastUpdateAt))
   }
 
   private val pruneCandidatesEncDec = new RLPEncoder[PruneCandidates] with RLPDecoder[PruneCandidates] {

--- a/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
@@ -56,6 +56,33 @@ class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
     dataSource.storage.size shouldEqual 0
   }
 
+  it should "not prune a key that was updated after marked as prune candidate" in new TestSetup {
+    val storage = new ReferenceCountNodeStorage(nodeStorage, pruningOffset = 0, blockNumber = Some(9))
+
+    val inserted = insertRangeKeys(4, storage)
+    val (key1, val1) :: xs = inserted.toList
+
+    storage.get(key1).get sameElements val1.toArray[Byte] // Data exists
+
+    val storage2 = new ReferenceCountNodeStorage(nodeStorage, pruningOffset = 0, blockNumber = Some(10))
+    storage2.remove(key1)
+    storage2.get(key1).get sameElements val1.toArray[Byte] // Data exists until pruning
+
+    val storage3 = new ReferenceCountNodeStorage(nodeStorage, pruningOffset = 0, blockNumber = Some(11))
+    storage3.put(key1, val1) // Add and remove the key, prune should be reset
+    storage3.get(key1).get sameElements val1.toArray[Byte] // Data exists until pruning
+
+    val storage4 = new ReferenceCountNodeStorage(nodeStorage, pruningOffset = 0, blockNumber = Some(12))
+    storage4.remove(key1) // Add and remove the key, prune should be reset
+    storage4.get(key1).get sameElements val1.toArray[Byte] // Data exists until pruning
+
+    storage4.prune(0, 12) shouldEqual PruneResult(11, pruned = 0)
+    storage4.get(key1).get sameElements val1 // Data should still exist after pruning because it was touched at block#3
+
+    storage.prune(11, 13) shouldEqual PruneResult(12, pruned = 1)
+    storage.get(key1) shouldBe None // Data should have now been removed
+  }
+
   trait TestSetup {
     val dataSource = EphemDataSource()
     val nodeStorage = new NodeStorage(dataSource)


### PR DESCRIPTION
# Description

In some rare cases, we might delete an MPT node while doing pruning that might be used after a reorg.

**Important: This is nor related with randomly missing mpt nodes as this should be deterministic on a regular sync run**

# How to reproduce

1. If a mpt node is marked as prune candidate (which means it can be deleted after X blocks because it has no more references) at block 10
2. Mpt node is added again at block 11
3. Mpt node is deleted at block 12 

When pruning candidates for block 10, it will delete mpt node

# Fix

When looking for prune candidates, check by current references **and** last mpt node usage