### PR TITLE
Refactor DataSource.update API

### DIFF
--- a/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/db/IodbDataSourceIntegrationSuite.scala
@@ -1,6 +1,7 @@
-package io.iohk.ethereum.db
+/*package io.iohk.ethereum.db
 
 import akka.util.ByteString
+import io.iohk.ethereum.common.Upsert
 import io.iohk.ethereum.db.dataSource.IodbDataSource
 import org.scalacheck.Gen
 import org.scalatest.FlatSpec
@@ -18,14 +19,16 @@ class IodbDataSourceIntegrationSuite extends FlatSpec with DataSourceIntegration
       withDir { path =>
         val keyList = unFilteredKeyList.take(KeyNumberLimit)
         val keysToInsert = keyList.take(keyList.size/2)
-        val db = createDataSource(path).update(OtherNamespace, Seq(), keysToInsert.zip(keysToInsert))
+        val db = createDataSource(path).update(OtherNamespace, keysToInsert.zip(keysToInsert).map(t => Upsert[IndexedSeq[Byte], IndexedSeq[Byte]](t)))
 
         val invalidKeyList = keyList.map{ key =>
           val suffixOfRandomLength = (0 until Gen.choose(1, MaxIncreaseInLength).sample.get).map(_ => 1.toByte )
           suffixOfRandomLength ++ key
         }
 
-        invalidKeyList.foreach { key => assert( Try{db.update(OtherNamespace, Seq(), Seq(key->key))}.isFailure) }
+        invalidKeyList.foreach { key => assert(Try{
+          db.update(OtherNamespace, Seq(key->key).map(t => Upsert[IndexedSeq[Byte], IndexedSeq[Byte]](t)))}.isFailure)
+        }
 
         db.destroy()
       }
@@ -36,7 +39,7 @@ class IodbDataSourceIntegrationSuite extends FlatSpec with DataSourceIntegration
     forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
       withDir { path =>
         val keyList = unFilteredKeyList.take(KeyNumberLimit)
-        val db = createDataSource(path).update(OtherNamespace, Seq(), keyList.zip(keyList))
+        val db = createDataSource(path).update(OtherNamespace, keyList.zip(keyList).map(t => Upsert[IndexedSeq[Byte], IndexedSeq[Byte]](t)))
 
         val invalidKeyList = keyList.map { key =>
           val suffixOfRandomLength = (0 until Gen.choose(1, MaxIncreaseInLength).sample.get).map(_ => 1.toByte)
@@ -49,4 +52,4 @@ class IodbDataSourceIntegrationSuite extends FlatSpec with DataSourceIntegration
       }
     }
   }
-}
+}*/

--- a/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
+++ b/src/it/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeIntegrationSuite.scala
@@ -116,23 +116,22 @@ class MerklePatriciaTreeIntegrationSuite extends FunSuite
     }
   }
 
-}
+  trait PersistentStorage {
+    def withNodeStorage(testCode: NodesKeyValueStorage => Unit): Unit = {
+      val dbPath = Files.createTempDirectory("testdb").toAbsolutePath.toString
+      val dataSource = LevelDBDataSource(new LevelDbConfig {
+        override val verifyChecksums: Boolean = true
+        override val paranoidChecks: Boolean = true
+        override val createIfMissing: Boolean = true
+        override val path: String = dbPath
+      })
 
-trait PersistentStorage {
-  def withNodeStorage(testCode: NodesKeyValueStorage => Unit): Unit = {
-    val dbPath = Files.createTempDirectory("testdb").toAbsolutePath.toString
-    val dataSource = LevelDBDataSource(new LevelDbConfig {
-      override val verifyChecksums: Boolean = true
-      override val paranoidChecks: Boolean = true
-      override val createIfMissing: Boolean = true
-      override val path: String = dbPath
-    })
-
-    try {
-      testCode(new ArchiveNodeStorage(new NodeStorage(dataSource)))
-    } finally {
-      val dir = new File(dbPath)
-      !dir.exists() || dir.delete()
+      try {
+        testCode(new ArchiveNodeStorage(new NodeStorage(dataSource)))
+      } finally {
+        val dir = new File(dbPath)
+        !dir.exists() || dir.delete()
+      }
     }
   }
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -57,11 +57,11 @@ object FixtureProvider {
 
       def traverse(nodeHash: ByteString): Unit = fixtures.stateMpt.get(nodeHash).orElse(fixtures.contractMpts.get(nodeHash)) match {
         case Some(m: BranchNode) =>
-          storages.nodesKeyValueStorageFor(Some(block.header.number)).update(Nil, Seq(ByteString(m.hash) -> m.toBytes))
+          storages.nodesKeyValueStorageFor(Some(block.header.number)).put(ByteString(m.hash), m.toBytes)
           m.children.collect { case Some(Left(hash)) => hash}.foreach(e => traverse(e))
 
         case Some(m: ExtensionNode) =>
-          storages.nodesKeyValueStorageFor(Some(block.header.number)).update(Nil, Seq(ByteString(m.hash) -> m.toBytes))
+          storages.nodesKeyValueStorageFor(Some(block.header.number)).put(ByteString(m.hash), m.toBytes)
           m.next match {
             case Left(hash) if hash.nonEmpty => traverse(hash)
             case _ =>
@@ -69,7 +69,7 @@ object FixtureProvider {
 
         case Some(m: LeafNode) =>
           import AccountImplicits._
-          storages.nodesKeyValueStorageFor(Some(block.header.number)).update(Nil, Seq(ByteString(m.hash) -> m.toBytes))
+          storages.nodesKeyValueStorageFor(Some(block.header.number)).put(ByteString(m.hash), m.toBytes)
           Try(m.value.toArray[Byte].toAccount).toOption.foreach { account =>
             if (account.codeHash != DumpChainActor.emptyEvm) {
               storages.evmCodeStorage.put(account.codeHash, fixtures.evmCode(account.codeHash))

--- a/src/main/scala/io/iohk/ethereum/common/BatchOperation.scala
+++ b/src/main/scala/io/iohk/ethereum/common/BatchOperation.scala
@@ -1,0 +1,9 @@
+package io.iohk.ethereum.common
+
+sealed trait BatchOperation[K, V]
+case class Upsert[K, V](key: K, value: V) extends BatchOperation[K, V]
+case class Removal[K, V](key: K) extends BatchOperation[K, V]
+
+object Upsert {
+  def apply[K, V](t: (K, V)): Upsert[K,V] = Upsert[K, V](t._1, t._2)
+}

--- a/src/main/scala/io/iohk/ethereum/common/SimpleMap.scala
+++ b/src/main/scala/io/iohk/ethereum/common/SimpleMap.scala
@@ -20,7 +20,7 @@ trait SimpleMap[K, V, T <: SimpleMap[K, V, T]] {
     * @param value
     * @return New trie with the (key-value) pair inserted.
     */
-  def put(key: K, value: V): T = update(Nil, Seq(key -> value))
+  def put(key: K, value: V): T = update(Seq(Upsert(key, value)))
 
   /**
     * This function inserts a (key-value) pair into the trie. If the key is already asociated with another value it is updated.
@@ -37,7 +37,7 @@ trait SimpleMap[K, V, T <: SimpleMap[K, V, T]] {
     * @param key
     * @return New trie with the (key-value) pair associated with the key passed deleted from the trie.
     */
-  def remove(key: K): T = update(Seq(key), Nil)
+  def remove(key: K): T = update(Seq(Removal(key)))
 
   /**
     * This function deletes a (key-value) pair from the trie. If no (key-value) pair exists with the passed trie then there's no effect on it.
@@ -51,11 +51,9 @@ trait SimpleMap[K, V, T <: SimpleMap[K, V, T]] {
   /**
     * This function updates the KeyValueStore by deleting, updating and inserting new (key-value) pairs.
     *
-    * @param toRemove which includes all the keys to be removed from the KeyValueStore.
-    * @param toUpsert which includes all the (key-value) pairs to be inserted into the KeyValueStore.
-    *                 If a key is already in the DataSource its value will be updated.
+    * @param batchOperations sequence of operations to be applied
     * @return the new DataSource after the removals and insertions were done.
     */
-  def update(toRemove: Seq[K], toUpsert: Seq[(K, V)]): T
+  def update(batchOperations: Seq[BatchOperation[K, V]]): T
 
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -1,10 +1,9 @@
 package io.iohk.ethereum.db.dataSource
 
-trait DataSource {
+import io.iohk.ethereum.common.BatchOperation
+import io.iohk.ethereum.db.dataSource.DataSource.{Key, Namespace, Value}
 
-  type Key = IndexedSeq[Byte]
-  type Value = IndexedSeq[Byte]
-  type Namespace = IndexedSeq[Byte]
+trait DataSource {
 
   /**
     * This function obtains the associated value to a key. It requires the (key-value) pair to be in the DataSource
@@ -28,12 +27,10 @@ trait DataSource {
     * This function updates the DataSource by deleting, updating and inserting new (key-value) pairs.
     *
     * @param namespace from which the (key-value) pairs will be removed and inserted.
-    * @param toRemove which includes all the keys to be removed from the DataSource.
-    * @param toUpsert which includes all the (key-value) pairs to be inserted into the DataSource.
-    *                 If a key is already in the DataSource its value will be updated.
+    * @param batchOperations sequence of operations to be applied
     * @return the new DataSource after the removals and insertions were done.
     */
-  def update(namespace: Namespace, toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource
+  def update(namespace: Namespace, batchOperations: Seq[BatchOperation[DataSource.Key, DataSource.Value]]): DataSource
 
   /**
     * This function updates the DataSource by deleting all the (key-value) pairs in it.
@@ -52,3 +49,11 @@ trait DataSource {
     */
   def destroy(): Unit
 }
+
+object DataSource {
+
+  type Key = IndexedSeq[Byte]
+  type Value = IndexedSeq[Byte]
+  type Namespace = IndexedSeq[Byte]
+}
+

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
@@ -1,5 +1,8 @@
 package io.iohk.ethereum.db.dataSource
 
+import io.iohk.ethereum.common.{BatchOperation, Removal, Upsert}
+import io.iohk.ethereum.db.dataSource.DataSource.{Key, Namespace, Value}
+
 class EphemDataSource(var storage: Map[IndexedSeq[Byte], IndexedSeq[Byte]]) extends DataSource {
 
   /**
@@ -11,10 +14,21 @@ class EphemDataSource(var storage: Map[IndexedSeq[Byte], IndexedSeq[Byte]]) exte
 
   override def get(namespace: Namespace, key: Key): Option[Value] = storage.get(namespace ++: key)
 
-  override def update(namespace: Namespace, toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource = {
-    val afterRemoval = toRemove.foldLeft(storage)((storage, key) => storage - (namespace ++ key))
-    val afterUpdate = toUpsert.foldLeft(afterRemoval)((storage, toUpdate) =>
-      storage + ((namespace ++ toUpdate._1) -> toUpdate._2))
+  /**
+    * This function updates the DataSource by deleting, updating and inserting new (key-value) pairs.
+    *
+    * @param namespace from which the (key-value) pairs will be removed and inserted.
+    * @param batchOperations sequence of operations to be applied
+    * @return the new DataSource after the removals and insertions were done.
+    */
+  override def update(namespace: Namespace, batchOperations: Seq[BatchOperation[Key, Value]]): DataSource = {
+    val afterUpdate = batchOperations.foldLeft(storage) { (storage, bOp) =>
+      bOp match {
+        case Removal(key) => storage - (namespace ++ key)
+        case Upsert(key, value) => storage + ((namespace ++ key) -> value)
+      }
+    }
+
     storage = afterUpdate
     this
   }
@@ -27,6 +41,7 @@ class EphemDataSource(var storage: Map[IndexedSeq[Byte], IndexedSeq[Byte]]) exte
   override def close(): Unit = ()
 
   override def destroy(): Unit = ()
+
 }
 
 object EphemDataSource {

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReadOnlyNodeStorage.scala
@@ -1,5 +1,6 @@
 package io.iohk.ethereum.db.storage
 
+import io.iohk.ethereum.common.BatchOperation
 import io.iohk.ethereum.db.storage.NodeStorage.{NodeEncoded, NodeHash}
 import io.iohk.ethereum.ledger.InMemorySimpleMapProxy
 import io.iohk.ethereum.mpt.NodesKeyValueStorage
@@ -21,16 +22,13 @@ class ReadOnlyNodeStorage private(wrapped: InMemorySimpleMapProxy[NodeHash, Node
   /**
     * This function updates the KeyValueStore by deleting, updating and inserting new (key-value) pairs.
     *
-    * @param toRemove which includes all the keys to be removed from the KeyValueStore.
-    * @param toUpsert which includes all the (key-value) pairs to be inserted into the KeyValueStore.
-    *                 If a key is already in the DataSource its value will be updated.
+    * @param batchOperations sequence of operations to be applied
     * @return the new DataSource after the removals and insertions were done.
     */
-  override def update(toRemove: Seq[NodeHash], toUpsert: Seq[(NodeHash, NodeEncoded)]): NodesKeyValueStorage = {
-    val updatedCache = wrapped.update(toRemove, toUpsert)
+  override def update(batchOperations: Seq[BatchOperation[NodeHash, NodeEncoded]]): NodesKeyValueStorage = {
+    val updatedCache = wrapped.update(batchOperations)
     new ReadOnlyNodeStorage(updatedCache)
   }
-
 }
 
 object ReadOnlyNodeStorage {

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -213,7 +213,7 @@ class BlockchainHostActorSpec extends FlatSpec with Matchers {
     val exampleHash = ByteString(Hex.decode("ab"*32))
     val extensionNode: MptNode = ExtensionNode(exampleNibbles, Left(exampleHash))
 
-    storagesInstance.storages.nodesKeyValueStorageFor(Some(0)).update(Nil, Seq(ByteString(extensionNode.hash) -> (extensionNode.toBytes: Array[Byte])))
+    storagesInstance.storages.nodesKeyValueStorageFor(Some(0)).put(ByteString(extensionNode.hash), extensionNode.toBytes: Array[Byte])
 
     //when
     blockchainHost ! MessageFromPeer(GetNodeData(Seq(ByteString(extensionNode.hash))), peerId)

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.nio.file.Files
 
 import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.common.{Removal, Upsert}
 import org.scalatest.FlatSpec
 import org.scalatest.prop.PropertyChecks
 
@@ -32,7 +33,7 @@ trait DataSourceTestBehavior
       val someByteString = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
       withDir { path =>
         val dataSource = createDataSource(path)
-        dataSource.update(OtherNamespace, Seq(), Seq(someByteString -> someByteString))
+        dataSource.update(OtherNamespace, Seq(Upsert(someByteString -> someByteString)))
 
         dataSource.get(OtherNamespace, someByteString) match {
           case Some(b) if b == someByteString => succeed
@@ -49,12 +50,12 @@ trait DataSourceTestBehavior
       withDir { path =>
         val dataSource = createDataSource(path)
 
-        dataSource.update(OtherNamespace, Seq(), Seq(key1 -> key1, key2 -> key2))
+        dataSource.update(OtherNamespace, Seq(Upsert(key1, key1), Upsert(key2, key2)))
 
         assert(dataSource.get(OtherNamespace, key1).isDefined)
         assert(dataSource.get(OtherNamespace, key2).isDefined)
 
-        dataSource.update(OtherNamespace, Seq(key1), Seq())
+        dataSource.update(OtherNamespace, Seq(Removal(key1)))
 
         assert(dataSource.get(OtherNamespace, key1).isEmpty)
         assert(dataSource.get(OtherNamespace, key2).isDefined)
@@ -68,7 +69,7 @@ trait DataSourceTestBehavior
       withDir { path =>
         val dataSource = createDataSource(path)
 
-        dataSource.update(OtherNamespace, Seq(), Seq(someByteString -> someByteString))
+        dataSource.update(OtherNamespace, Seq(Upsert(someByteString, someByteString)))
 
         assert(dataSource.get(OtherNamespace, someByteString).isDefined)
 
@@ -89,14 +90,14 @@ trait DataSourceTestBehavior
         val dataSource = createDataSource(path)
 
         //Insertion
-        dataSource.update(OtherNamespace, Seq(), Seq(someByteString -> someValue1))
-        dataSource.update(OtherNamespace2, Seq(), Seq(someByteString -> someValue2))
+        dataSource.update(OtherNamespace, Seq(Upsert(someByteString, someValue1)))
+        dataSource.update(OtherNamespace2, Seq(Upsert(someByteString, someValue2)))
 
         assert(dataSource.get(OtherNamespace, someByteString).contains(someValue1))
         assert(dataSource.get(OtherNamespace2, someByteString).contains(someValue2))
 
         //Removal
-        dataSource.update(OtherNamespace2, Seq(someByteString), Nil)
+        dataSource.update(OtherNamespace2, Seq(Removal(someByteString)))
 
         assert(dataSource.get(OtherNamespace, someByteString).contains(someValue1))
         assert(dataSource.get(OtherNamespace2, someByteString).isEmpty)

--- a/src/test/scala/io/iohk/ethereum/db/storage/NodeStorageSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/NodeStorageSuite.scala
@@ -2,6 +2,7 @@ package io.iohk.ethereum.db.storage
 
 import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.common.{Removal, Upsert}
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.network.p2p.messages.PV63.MptNodeEncoders._
 import org.scalacheck.Gen
@@ -15,7 +16,7 @@ class NodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenerator
       val initialNodeStorage: NodeStorage = new NodeStorage(EphemDataSource())
       val nodeStorage = mptNodes.foldLeft(initialNodeStorage){
         case (recNodeStorage, node) =>
-          recNodeStorage.update(Nil, Seq(ByteString(node.hash) -> node.toBytes))
+          recNodeStorage.update(Seq(Upsert(ByteString(node.hash) -> node.toBytes)))
       }
 
       mptNodes.foreach{ node =>
@@ -33,14 +34,14 @@ class NodeStorageSuite extends FunSuite with PropertyChecks with ObjectGenerator
       val initialNodeStorage: NodeStorage = new NodeStorage(EphemDataSource())
       val nodeStorage = mptNodes.foldLeft(initialNodeStorage){
         case (recNodeStorage, node) =>
-          recNodeStorage.update(Nil, Seq(ByteString(node.hash) -> node.toBytes))
+          recNodeStorage.update(Seq(Upsert(ByteString(node.hash) -> node.toBytes)))
       }
 
       //Nodes are deleted
       val (toDelete, toLeave) = mptNodes.splitAt(Gen.choose(0, mptNodes.size).sample.get)
       val nodeStorageAfterDelete = toDelete.foldLeft(nodeStorage){
         case (recNodeStorage, node) =>
-          recNodeStorage.update(Seq(ByteString(node.hash)), Nil)
+          recNodeStorage.update(Seq(Removal(ByteString(node.hash))))
       }
 
       toLeave.foreach{ node =>

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemorySimpleMapProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemorySimpleMapProxySpec.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.ledger
 
 import java.nio.ByteBuffer
 
-import io.iohk.ethereum.common.SimpleMap
+import io.iohk.ethereum.common.{Removal, SimpleMap, Upsert}
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.db.storage.{ArchiveNodeStorage, NodeStorage}
 import io.iohk.ethereum.mpt.{ByteArraySerializable, MerklePatriciaTrie}
@@ -66,7 +66,7 @@ class InMemorySimpleMapProxySpec extends FlatSpec with Matchers {
   }
 
   "InMemoryTrieProxy" should "handle batch operations" in new TestSetup {
-    val updatedProxy = InMemorySimpleMapProxy.wrap[Int, Int, MerklePatriciaTrie[Int, Int]](mpt).update(Seq(1), Seq((2, 2), (2, 3)))
+    val updatedProxy = InMemorySimpleMapProxy.wrap[Int, Int, MerklePatriciaTrie[Int, Int]](mpt).update(Seq(Removal(1), Upsert(2, 2), Upsert(2, 3)))
     assertNotContainsKey(updatedProxy, 1)
     assertContains(updatedProxy, 2, 3)
   }

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -5,6 +5,7 @@ import java.security.MessageDigest
 
 import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
+import io.iohk.ethereum.common.Upsert
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.db.storage.{ArchiveNodeStorage, NodeStorage}
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.defaultByteArraySerializable
@@ -301,8 +302,7 @@ class MerklePatriciaTrieSuite extends FunSuite
     val trie = EmptyTrie.put(key1, key1).put(key2, key2).put(key3, key3).put(key4, key4)
     val wrongSource = EphemDataSource().update(
       IndexedSeq[Byte]('e'.toByte),
-      toRemove = Seq(),
-      toUpsert = Seq(ByteString(trie.getRootHash) -> ByteString(trie.nodeStorage.get(ByteString(trie.getRootHash)).get))
+      Seq(Upsert(ByteString(trie.getRootHash) -> ByteString(trie.nodeStorage.get(ByteString(trie.getRootHash)).get)))
     )
     val trieWithWrongSource = MerklePatriciaTrie[Array[Byte], Array[Byte]](trie.getRootHash, new ArchiveNodeStorage(new NodeStorage(wrongSource)))
     val trieAfterDelete = Try {


### PR DESCRIPTION
# Description

The following PR proposes a refactor on `io.iohk.ethereum.db.dataSource.DataSource#update` API in order to make it more clear. 

Currently it receives two collections: keys to remove and data to upsert. That way it will execute all the removals first and then the upserts. That doesn't feel natural for the user that might want to create an operations batch to do everything at once. 
For example, if we want to: `(Insert, k1, v1)` and then `(Remove, k1)` two calls to `DataSource#update` are neededed in order to prevent update to execute `Remove` and `Insert` leaving something in the DB.

**_Note: This refactor is not urgent as it's not fixing any bugs in our code_**

## Proposal
Update API in order to use `batchOperations: Seq[BatchOperation[Key, Value]]`. This is not a complex change and we have a bunch of tests to be sure we don't introduce any bugs.

## Todo
- [x] Update IODB DataSource
- [ ] Take a second look at the code before removing WIP
- [ ] Maybe defining an operand to avoid adding `Upsert` and `Removal`
