### PR TITLE
[EC-319] pre-import validation / disallow orphaned blocks

### DIFF
--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainSuite.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainSuite.scala
@@ -54,7 +54,10 @@ class BlockchainSuite extends FreeSpec with Matchers with Logger {
 
     val invalidBlocks = getBlocks(getInvalid)
 
-    blocksToProcess.foreach(ledger.importBlock)
+    blocksToProcess.foreach { b =>
+      val r = ledger.importBlock(b)
+      log.debug(s"Block (${b.idTag}) import result: $r")
+    }
 
     val lastBlock = getBestBlock()
 
@@ -65,8 +68,8 @@ class BlockchainSuite extends FreeSpec with Matchers with Logger {
     val expectedState = getExpectedState()
     val resultState = getResultState()
 
-    resultState should contain theSameElementsAs expectedState
     lastBlock.get.header.hash shouldEqual scenario.lastblockhash
+    resultState should contain theSameElementsAs expectedState
     lastBlock.get.header.stateRoot shouldEqual expectedWorldStateHash
   }
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -99,6 +99,10 @@ class RegularSync(
           case DuplicateBlock =>
             log.debug(s"Ignoring duplicate block ${newBlock.header.number} (${Hex.toHexString(newBlock.header.hash.toArray)}) from $peerId")
 
+          case UnknownParent =>
+            // This is normal when receiving broadcasted blocks
+            log.debug(s"Ignoring orphaned block ${newBlock.header.number} (${Hex.toHexString(newBlock.header.hash.toArray)}) from $peerId")
+
           case ChainReorganised(oldBranch, newBranch, totalDifficulties) =>
             updateTxAndOmmerPools(newBranch, oldBranch)
             broadcastBlocks(newBranch, totalDifficulties)
@@ -157,6 +161,9 @@ class RegularSync(
           case BlockEnqueued =>
             log.debug(s"Mined block ${block.header.number} was added to the queue")
             ommersPool ! AddOmmers(block.header)
+
+          case UnknownParent =>
+            log.warning(s"Mined block has no parent on the main chain")
 
           case BlockImportFailed(err) =>
             log.warning(s"Failed to execute mined block because of $err")
@@ -249,7 +256,7 @@ class RegularSync(
       val blocks = headersQueue.zip(m).map{ case (header, body) => Block(header, body) }
 
       @tailrec
-      def importBlocks(blocks: List[Block], importedBlocks: List[Block] = Nil): (List[Block], Option[BlockImportFailed]) =
+      def importBlocks(blocks: List[Block], importedBlocks: List[Block] = Nil): (List[Block], Option[Any]) =
         blocks match {
           case Nil =>
             (importedBlocks, None)
@@ -265,7 +272,7 @@ class RegularSync(
               case r @ (DuplicateBlock | BlockEnqueued) =>
                 importBlocks(tail, importedBlocks)
 
-              case err @ BlockImportFailed(_) =>
+              case err @ (UnknownParent | BlockImportFailed(_)) =>
                 (importedBlocks, Some(err))
             }
         }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -256,7 +256,7 @@ class RegularSync(
       val blocks = headersQueue.zip(m).map{ case (header, body) => Block(header, body) }
 
       @tailrec
-      def importBlocks(blocks: List[Block], importedBlocks: List[Block] = Nil): (List[Block], Option[Any]) =
+      def importBlocks(blocks: List[Block], importedBlocks: List[Block] = Nil): (List[Block], Option[BlockImportResult]) =
         blocks match {
           case Nil =>
             (importedBlocks, None)

--- a/src/main/scala/io/iohk/ethereum/domain/Block.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Block.scala
@@ -16,6 +16,9 @@ case class Block(header: BlockHeader, body: BlockBody) {
        | body: $body
      """.stripMargin
   }
+
+  def idTag: String =
+    header.idTag
 }
 
 object Block {

--- a/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
@@ -23,34 +23,37 @@ case class BlockHeader(
     mixHash: ByteString,
     nonce: ByteString) {
 
-    override def toString: String = {
-      s"""BlockHeader {
-         |parentHash: ${Hex.toHexString(parentHash.toArray[Byte])}
-         |ommersHash: ${Hex.toHexString(ommersHash.toArray[Byte])}
-         |beneficiary: ${Hex.toHexString(beneficiary.toArray[Byte])}
-         |stateRoot: ${Hex.toHexString(stateRoot.toArray[Byte])}
-         |transactionsRoot: ${Hex.toHexString(transactionsRoot.toArray[Byte])}
-         |receiptsRoot: ${Hex.toHexString(receiptsRoot.toArray[Byte])}
-         |logsBloom: ${Hex.toHexString(logsBloom.toArray[Byte])}
-         |difficulty: $difficulty,
-         |number: $number,
-         |gasLimit: $gasLimit,
-         |gasUsed: $gasUsed,
-         |unixTimestamp: $unixTimestamp,
-         |extraData: ${Hex.toHexString(extraData.toArray[Byte])}
-         |mixHash: ${Hex.toHexString(mixHash.toArray[Byte])}
-         |nonce: ${Hex.toHexString(nonce.toArray[Byte])}
-         |}""".stripMargin
-    }
-
-    /**
-      * calculates blockHash for given block header
-      * @return - hash that can be used to get block bodies / receipts
-      */
-    lazy val hash: ByteString = ByteString(kec256(this.toBytes: Array[Byte]))
-
-    lazy val hashAsHexString: String = Hex.toHexString(hash.toArray)
+  override def toString: String = {
+    s"""BlockHeader {
+       |parentHash: ${Hex.toHexString(parentHash.toArray[Byte])}
+       |ommersHash: ${Hex.toHexString(ommersHash.toArray[Byte])}
+       |beneficiary: ${Hex.toHexString(beneficiary.toArray[Byte])}
+       |stateRoot: ${Hex.toHexString(stateRoot.toArray[Byte])}
+       |transactionsRoot: ${Hex.toHexString(transactionsRoot.toArray[Byte])}
+       |receiptsRoot: ${Hex.toHexString(receiptsRoot.toArray[Byte])}
+       |logsBloom: ${Hex.toHexString(logsBloom.toArray[Byte])}
+       |difficulty: $difficulty,
+       |number: $number,
+       |gasLimit: $gasLimit,
+       |gasUsed: $gasUsed,
+       |unixTimestamp: $unixTimestamp,
+       |extraData: ${Hex.toHexString(extraData.toArray[Byte])}
+       |mixHash: ${Hex.toHexString(mixHash.toArray[Byte])}
+       |nonce: ${Hex.toHexString(nonce.toArray[Byte])}
+       |}""".stripMargin
   }
+
+  /**
+    * calculates blockHash for given block header
+    * @return - hash that can be used to get block bodies / receipts
+    */
+  lazy val hash: ByteString = ByteString(kec256(this.toBytes: Array[Byte]))
+
+  lazy val hashAsHexString: String = Hex.toHexString(hash.toArray)
+
+  def idTag: String =
+    s"$number: $hashAsHexString"
+}
 
 object BlockHeader {
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -437,11 +437,11 @@ class EthService(
     reportActive()
     import io.iohk.ethereum.consensus.Ethash.{seed, epoch}
 
-    val blockNumber = appStateStorage.getBestBlockNumber() + 1
+    val bestBlock = blockchain.getBestBlock()
 
-    getOmmersFromPool(blockNumber).zip(getTransactionsFromPool).map {
+    getOmmersFromPool(bestBlock.header.number + 1).zip(getTransactionsFromPool).map {
       case (ommers, pendingTxs) =>
-        blockGenerator.generateBlockForMining(blockNumber, pendingTxs.pendingTransactions.map(_.stx), ommers.headers, miningConfig.coinbase) match {
+        blockGenerator.generateBlockForMining(bestBlock, pendingTxs.pendingTransactions.map(_.stx), ommers.headers, miningConfig.coinbase) match {
           case Right(pb) =>
             Right(GetWorkResponse(
               powHeaderHash = ByteString(kec256(BlockHeader.getEncodedWithoutNonce(pb.block.header))),

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -16,7 +16,7 @@ import scala.annotation.tailrec
 
 trait Ledger {
 
-  def executeBlock(block: Block): Either[BlockExecutionError, Seq[Receipt]]
+  def executeBlock(block: Block, alreadyValidated: Boolean = false): Either[BlockExecutionError, Seq[Receipt]]
 
   def prepareBlock(block: Block): BlockPreparationResult
 
@@ -60,18 +60,24 @@ class LedgerImpl(
     *         - [[BlockImportFailed]] - block failed to execute (when importing to top or reorganising the chain)
     */
   def importBlock(block: Block): BlockImportResult = {
-    //val validationResult: Either[Nothing, BlockHeader] = Right(block.header)
-    val validationResult = validators.blockHeaderValidator.validatePreImport(block.header, blockchain)
+    val validationResult = validateBlockBeforeExecution(block)
     validationResult match {
       case Left(error) =>
-        log.debug(s"Block(${block.header.number}: ${Hex.toHexString(block.header.hash.toArray)}) failed pre-import validation")
-        BlockImportFailed(error.toString)
+        val knownParent = blockchain.getBlockHeaderByHash(block.header.parentHash).isDefined || blockQueue.isQueued(block.header.parentHash)
+
+        if (knownParent) {
+          log.debug(s"Block(${block.idTag}) failed pre-import validation")
+          BlockImportFailed(error.reason)
+        } else {
+          log.debug(s"Block(${block.idTag}) has no known parent")
+          UnknownParent
+        }
 
       case Right(_) =>
         val isDuplicate = blockchain.getBlockByHash(block.header.hash).isDefined || blockQueue.isQueued(block.header.hash)
 
         if (isDuplicate) {
-          log.debug(s"Ignoring duplicate block: (${block.header.number}: ${Hex.toHexString(block.header.hash.toArray)})")
+          log.debug(s"Ignoring duplicate block: (${block.idTag})")
           DuplicateBlock
         }
 
@@ -91,7 +97,7 @@ class LedgerImpl(
 
   private def importBlockToTop(block: Block, bestBlockNumber: BigInt, currentTd: BigInt): BlockImportResult = {
     val topBlockHash = blockQueue.enqueueBlock(block, bestBlockNumber).get.hash
-    val topBlocks = blockQueue.removeBranch(topBlockHash)
+    val topBlocks = blockQueue.getBranch(topBlockHash, dequeue = true)
     val (importedBlocks, maybeError) = executeBlocks(topBlocks, currentTd)
     val totalDifficulties = importedBlocks.foldLeft(List(currentTd)) {(tds, b) =>
       (tds.head + b.header.difficulty) :: tds
@@ -153,7 +159,7 @@ class LedgerImpl(
     *        (oldBranch, newBranch) as lists of blocks
     */
   private def reorganiseChainFromQueue(queuedLeaf: ByteString): Either[BlockExecutionError, (List[Block], List[Block])] = {
-    val newBranch = blockQueue.removeBranch(queuedLeaf)
+    val newBranch = blockQueue.getBranch(queuedLeaf, dequeue = true)
     val parent = newBranch.head.header.parentHash
     val bestNumber = blockchain.getBestBlockNumber()
     val parentTd = blockchain.getTotalDifficultyByHash(parent).get
@@ -210,7 +216,7 @@ class LedgerImpl(
   private def executeBlocks(blocks: List[Block], parentTd: BigInt): (List[Block], Option[BlockExecutionError]) = {
     blocks match {
       case block :: remainingBlocks =>
-        executeBlock (block) match {
+        executeBlock(block, alreadyValidated = true) match {
           case Right (receipts) =>
             val td = parentTd + block.header.difficulty
             blockchain.save(block, receipts, td, saveAsBestBlock = true)
@@ -304,10 +310,18 @@ class LedgerImpl(
       Nil
   }
 
-  def executeBlock(block: Block): Either[BlockExecutionError, Seq[Receipt]] = {
+  /**
+    * Executes a block
+    *
+    * @param alreadyValidated should we skip pre-execution validation (if the block has already been validated,
+    *                         eg. in the importBlock method)
+    */
+  def executeBlock(block: Block, alreadyValidated: Boolean = false): Either[BlockExecutionError, Seq[Receipt]] = {
+
+    val preExecValidationResult = if (alreadyValidated) Right(block) else validateBlockBeforeExecution(block)
 
     val blockExecResult = for {
-      _ <- validateBlockBeforeExecution(block)
+      _ <- preExecValidationResult
 
       execResult <- executeBlockTransactions(block)
       BlockResult(resultingWorldStateProxy, gasUsed, receipts) = execResult
@@ -492,9 +506,10 @@ class LedgerImpl(
 
   private def validateBlockBeforeExecution(block: Block): Either[BlockExecutionError, Unit] = {
     val result = for {
-      _ <- validators.blockHeaderValidator.validate(block.header, blockchain)
+      _ <- validators.blockHeaderValidator.validate(block.header, getHeaderFromChainOrQueue _)
       _ <- validators.blockValidator.validateHeaderAndBody(block.header, block.body)
-      _ <- validators.ommersValidator.validate(block.header.number, block.body.uncleNodesList, blockchain)
+      _ <- validators.ommersValidator.validate(block.header.parentHash, block.header.number, block.body.uncleNodesList,
+        getHeaderFromChainOrQueue, getNBlocksBackFromChainOrQueue)
     } yield ()
     result.left.map(error => ValidationBeforeExecError(error.toString))
   }
@@ -718,6 +733,27 @@ class LedgerImpl(
       .foldLeft(world)(deleteEmptyAccount)
       .clearTouchedAccounts
   }
+
+  private def getHeaderFromChainOrQueue(hash: ByteString): Option[BlockHeader] =
+    blockchain.getBlockHeaderByHash(hash).orElse(blockQueue.getBlockByHash(hash).map(_.header))
+
+  private def getNBlocksBackFromChainOrQueue(hash: ByteString, n: Int): List[Block] = {
+    val queuedBlocks = blockQueue.getBranch(hash, dequeue = false).take(n)
+    if (queuedBlocks.length == n)
+      queuedBlocks
+    else {
+      val chainedBlockHash = queuedBlocks.headOption.map(_.header.parentHash).getOrElse(hash)
+      blockchain.getBlockByHash(chainedBlockHash) match {
+        case None =>
+          Nil
+
+        case Some(block) =>
+          val remaining = n - queuedBlocks.length - 1
+          val numbers = (block.header.number - remaining) until block.header.number
+          numbers.toList.flatMap(blockchain.getBlockByNumber) :+ block
+      }
+    }
+  }
 }
 
 object Ledger {
@@ -747,6 +783,7 @@ case object BlockEnqueued extends BlockImportResult
 case object DuplicateBlock extends BlockImportResult
 case class ChainReorganised(oldBranch: List[Block], newBranch: List[Block], totalDifficulties: List[BigInt]) extends BlockImportResult
 case class BlockImportFailed(error: String) extends BlockImportResult
+case object UnknownParent extends BlockImportResult
 
 sealed trait BranchResolutionResult
 case class  NewBetterBranch(oldBranch: Seq[Block]) extends BranchResolutionResult

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -33,6 +33,7 @@ trait Ledger {
 //FIXME: Make Ledger independent of BlockchainImpl, for which it should become independent of WorldStateProxy type
 //TODO: EC-313: this has grown a bit large, consider splitting the aspects block import, block exec and TX exec
 // scalastyle:off number.of.methods
+// scalastyle:off file.size.limit
 /**
   * Ledger handles importing and executing blocks.
   * Note: this class thread-unsafe because of its dependencies on Blockchain and BlockQueue

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -421,7 +421,7 @@ trait SecureRandomBuilder {
 
 trait MinerBuilder {
   self: ActorSystemBuilder
-    with StorageBuilder
+    with BlockchainBuilder
     with OmmersPoolBuilder
     with PendingTransactionsManagerBuilder
     with BlockGeneratorBuilder
@@ -429,7 +429,7 @@ trait MinerBuilder {
     with MiningConfigBuilder =>
 
   lazy val miner: ActorRef = actorSystem.actorOf(Miner.props(
-    storagesInstance.storages.appStateStorage,
+    blockchain,
     blockGenerator,
     ommersPool,
     pendingTransactionsManager,

--- a/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
@@ -22,7 +22,7 @@ object BlockHeaderValidatorImpl {
 
   class PowCacheData(val cache: Array[Int], val dagSize: Long)
 
-  // FIXME: this is used to speed up ETS Blockchain tests. All blocks in those tests have low numbers (1, 2, 3 ...)
+  // FIXME [EC-331]: this is used to speed up ETS Blockchain tests. All blocks in those tests have low numbers (1, 2, 3 ...)
   // so keeping the cache for epoch 0 avoids recalculating it for each individual test. The difference in test runtime
   // can be dramatic - full suite: 26 hours vs 21 minutes on same machine
   // It might be desirable to find a better solution for this - one that doesn't keep this cache unnecessarily

--- a/src/main/scala/io/iohk/ethereum/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/OmmersValidator.scala
@@ -3,9 +3,8 @@ package io.iohk.ethereum.validators
 import akka.util.ByteString
 import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain}
 import io.iohk.ethereum.utils.BlockchainConfig
-import io.iohk.ethereum.validators.OmmersValidator.{OmmersError, OmmersValid}
-import io.iohk.ethereum.validators.OmmersValidator.{GetBlockHeaderByHash, GetNBlocksBack, OmmersError}
 import io.iohk.ethereum.validators.OmmersValidator.OmmersError._
+import io.iohk.ethereum.validators.OmmersValidator.{GetBlockHeaderByHash, GetNBlocksBack, OmmersError, OmmersValid}
 
 trait OmmersValidator {
 

--- a/src/main/scala/io/iohk/ethereum/validators/OmmersValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/OmmersValidator.scala
@@ -1,13 +1,32 @@
 package io.iohk.ethereum.validators
 
-import io.iohk.ethereum.domain.{BlockHeader, Blockchain}
+import akka.util.ByteString
+import io.iohk.ethereum.domain.{Block, BlockHeader, Blockchain}
 import io.iohk.ethereum.utils.BlockchainConfig
-import io.iohk.ethereum.validators.OmmersValidator.OmmersError
+import io.iohk.ethereum.validators.OmmersValidator.{GetBlockHeaderByHash, GetNBlocksBack, OmmersError}
 import io.iohk.ethereum.validators.OmmersValidator.OmmersError._
 
 trait OmmersValidator {
 
-  def validate(blockNumber: BigInt, ommers: Seq[BlockHeader], blockchain: Blockchain): Either[OmmersError, Unit]
+  def validate(
+    parentHash: ByteString,
+    blockNumber: BigInt,
+    ommers: Seq[BlockHeader],
+    getBlockHeaderByHash: GetBlockHeaderByHash,
+    getNBlocksBack: GetNBlocksBack): Either[OmmersError, Unit]
+
+  def validate(
+    parentHash: ByteString,
+    blockNumber: BigInt,
+    ommers: Seq[BlockHeader],
+    blockchain: Blockchain): Either[OmmersError, Unit] = {
+
+    val getBlockHeaderByHash: ByteString => Option[BlockHeader] = blockchain.getBlockHeaderByHash
+    val getNBlocksBack: (ByteString, Int) => List[Block] =
+      (_, n) => ((blockNumber - n) until blockNumber).toList.flatMap(blockchain.getBlockByNumber)
+
+    validate(parentHash, blockNumber, ommers, getBlockHeaderByHash, getNBlocksBack)
+  }
 
 }
 
@@ -21,6 +40,9 @@ object OmmersValidator {
     case object OmmersAncestorsError extends OmmersError
     case object OmmersDuplicatedError extends OmmersError
   }
+
+  type GetBlockHeaderByHash = ByteString => Option[BlockHeader]
+  type GetNBlocksBack = (ByteString, Int) => Seq[Block]
 }
 
 class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidator: BlockHeaderValidator) extends OmmersValidator {
@@ -40,21 +62,29 @@ class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidat
     *   - OmmersValidator.validateOmmersNotUsed
     *   - OmmersValidator.validateDuplicatedOmmers
     *
+    * @param parentHash    The hash of the parent of the block to which the ommers belong
     * @param blockNumber    The number of the block to which the ommers belong
     * @param ommers         The list of ommers to validate
-    * @param blockchain     from where the previous blocks are obtained
+    * @param getBlockHeaderByHash function to obtain an ancestor block header by hash
+    * @param getNBlocksBack function to obtain N blocks including one given by hash and its N-1 ancestors
     * @return ommers if valid, an [[OmmersValidator.OmmersError]] otherwise
     */
-  def validate(blockNumber: BigInt, ommers: Seq[BlockHeader], blockchain: Blockchain): Either[OmmersError, Unit] = {
+  def validate(
+    parentHash: ByteString,
+    blockNumber: BigInt,
+    ommers: Seq[BlockHeader],
+    getBlockHeaderByHash: GetBlockHeaderByHash,
+    getNBlocksBack: GetNBlocksBack): Either[OmmersError, Unit] = {
+
     if (ommers.isEmpty)
       Right(())
     else
       for {
         _ <- validateOmmersLength(ommers)
         _ <- validateDuplicatedOmmers(ommers)
-        _ <- validateOmmersHeaders(ommers, blockchain)
-        _ <- validateOmmersAncestors(blockNumber, ommers, blockchain)
-        _ <- validateOmmersNotUsed(blockNumber, ommers, blockchain)
+        _ <- validateOmmersHeaders(ommers, getBlockHeaderByHash)
+        _ <- validateOmmersAncestors(parentHash, blockNumber, ommers, getNBlocksBack)
+        _ <- validateOmmersNotUsed(parentHash, blockNumber, ommers, getNBlocksBack)
       } yield ()
   }
 
@@ -67,7 +97,7 @@ class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidat
     * @return ommers if valid, an [[OmmersLengthError]] otherwise
     */
   private def validateOmmersLength(ommers: Seq[BlockHeader]): Either[OmmersError, Unit] = {
-    if(ommers.length <= OmmerSizeLimit) Right(())
+    if (ommers.length <= OmmerSizeLimit) Right(())
     else Left(OmmersLengthError)
   }
 
@@ -77,11 +107,11 @@ class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidat
     * based on validations stated in section 11.1 of the YP
     *
     * @param ommers         The list of ommers to validate
-    * @param blockchain     from where the ommer's parents will be obtained
+    * @param getBlockByHash     function to obtain ommers' parents
     * @return ommers if valid, an [[OmmersNotValidError]] otherwise
     */
-  private def validateOmmersHeaders(ommers: Seq[BlockHeader], blockchain: Blockchain): Either[OmmersError, Unit] = {
-    if(ommers.forall(blockHeaderValidator.validate(_, blockchain).isRight)) Right(())
+  private def validateOmmersHeaders(ommers: Seq[BlockHeader], getBlockByHash: GetBlockHeaderByHash): Either[OmmersError, Unit] = {
+    if (ommers.forall(blockHeaderValidator.validate(_, getBlockByHash).isRight)) Right(())
     else Left(OmmersNotValidError)
   }
 
@@ -90,13 +120,19 @@ class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidat
     * Validates that each ommer is not too old and that it is a sibling as one of the current block's ancestors
     * based on validations stated in section 11.1 of the YP
     *
+    * @param parentHash  The hash of the parent of the block to which the ommers belong
     * @param blockNumber    The number of the block to which the ommers belong
     * @param ommers         The list of ommers to validate
-    * @param blockchain     from where the ommer's parents will be obtained
+    * @param getNBlocksBack     from where the ommers' parents will be obtained
     * @return ommers if valid, an [[OmmersUsedBeforeError]] otherwise
     */
-  private def validateOmmersAncestors(blockNumber: BigInt, ommers: Seq[BlockHeader], blockchain: Blockchain): Either[OmmersError, Unit] = {
-    val ancestorsOpt = collectAncestors(blockNumber, OmmerGenerationLimit, blockchain)
+  private def validateOmmersAncestors(
+    parentHash: ByteString,
+    blockNumber: BigInt,
+    ommers: Seq[BlockHeader],
+    getNBlocksBack: GetNBlocksBack): Either[OmmersError, Unit] = {
+
+    val ancestorsOpt = collectAncestors(parentHash, blockNumber, getNBlocksBack)
 
     val validOmmersAncestors: Seq[BlockHeader] => Boolean = ancestors =>
       ommers.forall{ ommer =>
@@ -104,7 +140,7 @@ class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidat
         val ommersParentIsAncestor = ancestors.exists(_.parentHash == ommer.parentHash)
         ommerIsNotAncestor && ommersParentIsAncestor
       }
-    if(ancestorsOpt.exists(validOmmersAncestors)) Right(())
+    if (ancestorsOpt.exists(validOmmersAncestors)) Right(())
     else Left(OmmersAncestorsError)
   }
 
@@ -113,15 +149,21 @@ class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidat
     * Validates that each ommer was not previously used
     * based on validations stated in the white paper (https://github.com/ethereum/wiki/wiki/White-Paper)
     *
+    * @param parentHash  The hash of the parent of the block to which the ommers belong
     * @param blockNumber    The number of the block to which the ommers belong
     * @param ommers         The list of ommers to validate
-    * @param blockchain     from where the ommer's parents will be obtained
+    * @param getNBlocksBack     from where the ommers' parents will be obtained
     * @return ommers if valid, an [[OmmersUsedBeforeError]] otherwise
     */
-  private def validateOmmersNotUsed(blockNumber: BigInt, ommers: Seq[BlockHeader], blockchain: Blockchain): Either[OmmersError, Unit] = {
-    val ommersFromAncestorsOpt = collectOmmersFromAncestors(blockNumber, OmmerGenerationLimit, blockchain)
+  private def validateOmmersNotUsed(
+    parentHash: ByteString,
+    blockNumber: BigInt,
+    ommers: Seq[BlockHeader],
+    getNBlocksBack: GetNBlocksBack): Either[OmmersError, Unit] = {
 
-    if(ommersFromAncestorsOpt.exists(ommers.intersect(_).isEmpty)) Right(())
+    val ommersFromAncestorsOpt = collectOmmersFromAncestors(parentHash, blockNumber, getNBlocksBack)
+
+    if (ommersFromAncestorsOpt.exists(ommers.intersect(_).isEmpty)) Right(())
     else Left(OmmersUsedBeforeError)
   }
 
@@ -134,27 +176,19 @@ class OmmersValidatorImpl(blockchainConfig: BlockchainConfig, blockHeaderValidat
     * @return ommers if valid, an [[OmmersDuplicatedError]] otherwise
     */
   private def validateDuplicatedOmmers(ommers: Seq[BlockHeader]): Either[OmmersError, Unit] = {
-    if(ommers.distinct.length == ommers.length) Right(())
+    if (ommers.distinct.length == ommers.length) Right(())
     else Left(OmmersDuplicatedError)
   }
 
-  private def collectAncestors(blockNumber: BigInt, numberOfBlocks: Int, blockchain: Blockchain): Option[Seq[BlockHeader]] = {
-    val ancestors: Seq[Option[BlockHeader]] = ancestorsBlockNumbers(blockNumber, numberOfBlocks)
-      .map{ num => blockchain.getBlockHeaderByNumber(num) }
-
-    if(ancestors.exists(_.isEmpty)) None
-    else Some(ancestors.flatten)
+  private def collectAncestors(parentHash: ByteString, blockNumber: BigInt, getNBlocksBack: GetNBlocksBack): Option[Seq[BlockHeader]] = {
+    val numberOfBlocks = blockNumber.min(OmmerGenerationLimit).toInt
+    val ancestors = getNBlocksBack(parentHash, numberOfBlocks).map(_.header)
+    Some(ancestors).filter(_.length == numberOfBlocks)
   }
 
-  private def collectOmmersFromAncestors(blockNumber: BigInt, numberOfBlocks: Int, blockchain: Blockchain): Option[Seq[BlockHeader]] = {
-    val ancestorsNumbers = ancestorsBlockNumbers(blockNumber, numberOfBlocks)
-    val ommersFromAncestors: Seq[Seq[BlockHeader]] = ancestorsNumbers
-      .flatMap{ num => blockchain.getBlockByNumber(num).map(_.body.uncleNodesList) }
-
-    if(ommersFromAncestors.length == ancestorsNumbers.length) Some(ommersFromAncestors.flatten)
-    else None
+  private def collectOmmersFromAncestors(parentHash: ByteString, blockNumber: BigInt, getNBlocksBack: GetNBlocksBack): Option[Seq[BlockHeader]] = {
+    val numberOfBlocks = blockNumber.min(OmmerGenerationLimit).toInt
+    val ancestors = getNBlocksBack(parentHash, numberOfBlocks).map(_.body.uncleNodesList)
+    Some(ancestors).filter(_.length == numberOfBlocks).map(_.flatten)
   }
-
-  private def ancestorsBlockNumbers(blockNumber: BigInt, numberOfBlocks: Int): Seq[BigInt] =
-    (blockNumber - numberOfBlocks).max(0) until blockNumber
 }

--- a/src/test/scala/io/iohk/ethereum/Mocks.scala
+++ b/src/test/scala/io/iohk/ethereum/Mocks.scala
@@ -4,18 +4,15 @@ import akka.util.ByteString
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BlockExecutionError.{StateBeforeFailure, TxsExecutionError}
 import io.iohk.ethereum.ledger.Ledger.BlockPreparationResult
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
-import io.iohk.ethereum.network.handshaker.{ConnectedState, DisconnectedState, Handshaker, HandshakerState}
 import io.iohk.ethereum.ledger._
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
+import io.iohk.ethereum.network.handshaker.{ConnectedState, DisconnectedState, Handshaker, HandshakerState}
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.validators.BlockHeaderError.HeaderNumberError
-import io.iohk.ethereum.validators.BlockValidator.BlockTransactionsHashError
-import io.iohk.ethereum.validators.OmmersValidator.{GetBlockHeaderByHash, GetNBlocksBack}
-import io.iohk.ethereum.validators.BlockHeaderError.{HeaderDifficultyError, HeaderNumberError}
 import io.iohk.ethereum.validators.BlockValidator.{BlockTransactionsHashError, BlockValid}
 import io.iohk.ethereum.validators.OmmersValidator.OmmersError.OmmersNotValidError
-import io.iohk.ethereum.validators.OmmersValidator.OmmersValid
+import io.iohk.ethereum.validators.OmmersValidator.{GetBlockHeaderByHash, GetNBlocksBack, OmmersValid}
 import io.iohk.ethereum.validators._
 import io.iohk.ethereum.vm._
 

--- a/src/test/scala/io/iohk/ethereum/Mocks.scala
+++ b/src/test/scala/io/iohk/ethereum/Mocks.scala
@@ -9,8 +9,9 @@ import io.iohk.ethereum.network.handshaker.{ConnectedState, DisconnectedState, H
 import io.iohk.ethereum.ledger._
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
-import io.iohk.ethereum.validators.BlockHeaderError.{HeaderDifficultyError, HeaderNumberError}
+import io.iohk.ethereum.validators.BlockHeaderError.HeaderNumberError
 import io.iohk.ethereum.validators.BlockValidator.BlockTransactionsHashError
+import io.iohk.ethereum.validators.OmmersValidator.{GetBlockHeaderByHash, GetNBlocksBack}
 import io.iohk.ethereum.validators.OmmersValidator.OmmersError.OmmersNotValidError
 import io.iohk.ethereum.validators._
 import io.iohk.ethereum.vm._
@@ -18,7 +19,7 @@ import io.iohk.ethereum.vm._
 object Mocks {
 
   class MockLedger(blockchain: BlockchainImpl, shouldExecuteCorrectly: (Block, BlockchainImpl) => Boolean) extends Ledger{
-    override def executeBlock(block: Block)
+    override def executeBlock(block: Block, alreadyValidated: Boolean = false)
     : Either[BlockExecutionError, Seq[Receipt]] = {
       if(shouldExecuteCorrectly(block, blockchain))
         Right(Nil)
@@ -73,14 +74,16 @@ object Mocks {
     }
 
     override val blockHeaderValidator: BlockHeaderValidator = new BlockHeaderValidator {
-      def validatePreImport(blockHeader: BlockHeader, blockchain: Blockchain): Either[BlockHeaderError, BlockHeader] =
-        Right(blockHeader)
-
-      def validate(blockHeader: BlockHeader, blockchain: Blockchain): Either[BlockHeaderError, BlockHeader] =
+      def validate(blockHeader: BlockHeader, getBlockHeaderByHash: ByteString => Option[BlockHeader]): Either[BlockHeaderError, BlockHeader] =
         Right(blockHeader)
     }
 
-    override val ommersValidator: OmmersValidator = (blockNumber: BigInt, ommers: Seq[BlockHeader], blockchain: Blockchain) => Right(())
+    override val ommersValidator: OmmersValidator =
+      (parentHash: ByteString,
+        blockNumber: BigInt,
+        ommers: Seq[BlockHeader],
+        getBlockHeaderByHash: GetBlockHeaderByHash,
+        getNBlocksBack: GetNBlocksBack) => Right(())
 
     override val signedTransactionValidator: SignedTransactionValidator =
       (stx: SignedTransaction, account: Account, blockHeader: BlockHeader, upfrontGasCost: UInt256, accumGasLimit: BigInt) => Right(())
@@ -95,15 +98,15 @@ object Mocks {
     }
 
     override val blockHeaderValidator = new BlockHeaderValidator {
-      def validate(blockHeader: BlockHeader, blockchain: Blockchain) = Left(HeaderNumberError)
-
-      def validatePreImport(blockHeader: BlockHeader, blockchain: Blockchain): Either[BlockHeaderError, BlockHeader] =
-        Left(HeaderDifficultyError)
+      def validate(blockHeader: BlockHeader, getBlockHeaderByHash: ByteString => Option[BlockHeader]) = Left(HeaderNumberError)
     }
 
-    override val ommersValidator = new OmmersValidator {
-      override def validate(blockNumber: BigInt, ommers: Seq[BlockHeader], blockchain: Blockchain) = Left(OmmersNotValidError)
-    }
+    override val ommersValidator: OmmersValidator =
+      (parentHash: ByteString,
+        blockNumber: BigInt,
+        ommers: Seq[BlockHeader],
+        getBlockHeaderByHash: GetBlockHeaderByHash,
+        getNBlocksBack: GetNBlocksBack) => Left(OmmersNotValidError)
 
     override val blockValidator = new BlockValidator {
       def validateHeaderAndBody(blockHeader: BlockHeader, blockBody: BlockBody) = Left(BlockTransactionsHashError)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -364,8 +364,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "return requested work" in new TestSetup {
-    (blockGenerator.generateBlockForMining _).expects(BigInt(1), Nil, *, *).returning(Right(PendingBlock(block, Nil)))
-    (appStateStorage.getBestBlockNumber _).expects().returning(0)
+    (blockGenerator.generateBlockForMining _).expects(parentBlock, Nil, *, *).returning(Right(PendingBlock(block, Nil)))
+    blockchain.save(parentBlock, Nil, parentBlock.header.difficulty, true)
 
     val response: ServiceResponse[GetWorkResponse] = ethService.getWork(GetWorkRequest())
     pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
@@ -518,8 +518,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   it should "return if node is mining base on getWork" in new TestSetup {
     ethService.getMining(GetMiningRequest()).futureValue shouldEqual Right(GetMiningResponse(false))
 
-    (blockGenerator.generateBlockForMining _).expects(*, *, *, *).returning(Right(PendingBlock(block, Nil)))
-    (appStateStorage.getBestBlockNumber _).expects().returning(0)
+    (blockGenerator.generateBlockForMining _).expects(parentBlock, *, *, *).returning(Right(PendingBlock(block, Nil)))
+    blockchain.save(parentBlock)
     ethService.getWork(GetWorkRequest())
 
     val response = ethService.getMining(GetMiningRequest())
@@ -550,8 +550,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "return if node is mining after time out" in new TestSetup {
-    (blockGenerator.generateBlockForMining _).expects(*, *, *, *).returning(Right(PendingBlock(block, Nil)))
-    (appStateStorage.getBestBlockNumber _).expects().returning(0)
+    (blockGenerator.generateBlockForMining _).expects(parentBlock, *, *, *).returning(Right(PendingBlock(block, Nil)))
+    blockchain.save(parentBlock)
     ethService.getWork(GetWorkRequest())
 
     Thread.sleep(miningConfig.activeTimeout.toMillis)
@@ -794,10 +794,32 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val uncle = Fixtures.Blocks.DaoForkBlock.header
     val uncleTd = uncle.difficulty
     val blockToRequestWithUncles = blockToRequest.copy(body = BlockBody(Nil, Seq(uncle)))
+
+
     val difficulty = 131072
+    val parentBlock = Block(
+      header = BlockHeader(
+        parentHash = ByteString.empty,
+        ommersHash = ByteString.empty,
+        beneficiary = ByteString.empty,
+        stateRoot = ByteString.empty,
+        transactionsRoot = ByteString.empty,
+        receiptsRoot = ByteString.empty,
+        logsBloom = ByteString.empty,
+        difficulty = difficulty,
+        number = 0,
+        gasLimit = 16733003,
+        gasUsed = 0,
+        unixTimestamp = 1494604900,
+        extraData = ByteString.empty,
+        mixHash = ByteString.empty,
+        nonce = ByteString.empty
+      ),
+      body = BlockBody(Nil, Nil)
+    )
     val block = Block(
       header = BlockHeader(
-        parentHash = ByteString(Hex.decode("fae40e0347c422194d9a0abd00e76774dd85b607ac8614b9bb0abd09ceee8df2")),
+        parentHash = parentBlock.header.hash,
         ommersHash = ByteString(Hex.decode("1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347")),
         beneficiary = ByteString(Hex.decode("000000000000000000000000000000000000002a")),
         stateRoot = ByteString(Hex.decode("2627314387b135a548040d3ca99dbf308265a3f9bd9246bee3e34d12ea9ff0dc")),
@@ -818,7 +840,7 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val mixHash = ByteString(Hex.decode("40d9bd2064406d7f22390766d6fe5eccd2a67aa89bf218e99df35b2dbb425fb1"))
     val nonce = ByteString(Hex.decode("ce1b500070aeec4f"))
     val seedHash = ByteString(Hex.decode("00" * 32))
-    val powHash = ByteString(Hex.decode("f5877d30b85d6cd0f80d2c4711e3cfb7d386e331f801f903d9ca52fc5e8f7cc2"))
+    val powHash = ByteString(Hex.decode("533f69824ee25d4f97d61ef9f5251d2dabaf0ccadcdf43484dc02c1ba7fafdee"))
     val target = ByteString((BigInt(2).pow(256) / difficulty).toByteArray)
 
     val v: Byte = 0x1c

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -507,8 +507,8 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
     val headerPowHash = s"0x${Hex.toHexString(kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)))}"
 
-    (appStateStorage.getBestBlockNumber _).expects().returns(1)
-    (blockGenerator.generateBlockForMining _).expects(*, *, *, *)
+    blockchain.save(parentBlock, Nil, parentBlock.header.difficulty, true)
+    (blockGenerator.generateBlockForMining _).expects(parentBlock, *, *, *)
       .returns(Right(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil)))
 
     val request: JsonRpcRequest = JsonRpcRequest(
@@ -542,8 +542,8 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
     val target = "0x1999999999999999999999999999999999999999999999999999999999999999"
     val headerPowHash = s"0x${Hex.toHexString(kec256(BlockHeader.getEncodedWithoutNonce(blockHeader)))}"
 
-    (appStateStorage.getBestBlockNumber _).expects().returns(1)
-    (blockGenerator.generateBlockForMining _).expects(*, *, *, *)
+    blockchain.save(parentBlock, Nil, parentBlock.header.difficulty, true)
+    (blockGenerator.generateBlockForMining _).expects(parentBlock, *, *, *)
       .returns(Right(PendingBlock(Block(blockHeader, BlockBody(Nil, Nil)), Nil)))
 
     val request: JsonRpcRequest = JsonRpcRequest(
@@ -1396,6 +1396,10 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
       extraData = ByteString("unused"),
       mixHash = ByteString("unused"),
       nonce = ByteString("unused"))
+
+    val block = Block(blockHeader, BlockBody(Nil, Nil))
+
+    val parentBlock = Block(blockHeader.copy(number = 1), BlockBody(Nil, Nil))
 
     val r: ByteString = ByteString(Hex.decode("a3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a1"))
     val s: ByteString = ByteString(Hex.decode("2d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee"))

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -1434,8 +1434,6 @@ class JsonRpcControllerSpec extends FlatSpec with Matchers with PropertyChecks w
       mixHash = ByteString("unused"),
       nonce = ByteString("unused"))
 
-    val block = Block(blockHeader, BlockBody(Nil, Nil))
-
     val parentBlock = Block(blockHeader.copy(number = 1), BlockBody(Nil, Nil))
 
     val r: ByteString = ByteString(Hex.decode("a3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a1"))

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockQueueSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockQueueSpec.scala
@@ -107,7 +107,7 @@ class BlockQueueSpec extends FlatSpec with Matchers with MockFactory {
     blockQueue.enqueueBlock(block2b)
     blockQueue.enqueueBlock(block3)
 
-    blockQueue.removeBranch(block3.header.hash) shouldEqual List(block1, block2a, block3)
+    blockQueue.getBranch(block3.header.hash, dequeue = true) shouldEqual List(block1, block2a, block3)
 
     blockQueue.isQueued(block3.header.hash) shouldBe false
     blockQueue.isQueued(block2a.header.hash) shouldBe false

--- a/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/mining/BlockGeneratorSpec.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration.FiniteDuration
 class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with Logger {
 
   "BlockGenerator" should "generate correct block with empty transactions" in new TestSetup {
-    val result: Either[BlockPreparationError, PendingBlock] = blockGenerator.generateBlockForMining(1, Nil, Nil, Address(testAddress))
+    val result: Either[BlockPreparationError, PendingBlock] = blockGenerator.generateBlockForMining(bestBlock, Nil, Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -41,7 +41,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
   }
 
   it should "generate correct block with transactions" in new TestSetup {
-    val result: Either[BlockPreparationError, PendingBlock] = blockGenerator.generateBlockForMining(1, Seq(signedTransaction), Nil, Address(testAddress))
+    val result: Either[BlockPreparationError, PendingBlock] = blockGenerator.generateBlockForMining(bestBlock, Seq(signedTransaction), Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -58,7 +58,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
   it should "filter out failing transactions" in new TestSetup {
     val result: Either[BlockPreparationError, PendingBlock] =
-      blockGenerator.generateBlockForMining(1, Seq(signedTransaction, duplicatedSignedTransaction), Nil, Address(testAddress))
+      blockGenerator.generateBlockForMining(bestBlock, Seq(signedTransaction, duplicatedSignedTransaction), Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -82,7 +82,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
       keyPair, Some(0x3d.toByte))
 
     val result: Either[BlockPreparationError, PendingBlock] =
-      blockGenerator.generateBlockForMining(1, Seq(txWitGasTooBigGasLimit, signedTransaction, duplicatedSignedTransaction), Nil, Address(testAddress))
+      blockGenerator.generateBlockForMining(bestBlock, Seq(txWitGasTooBigGasLimit, signedTransaction, duplicatedSignedTransaction), Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -124,7 +124,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
     val specificTx = SignedTransaction.sign(transaction.copy(nonce = transaction.nonce + 1), keyPair, Some(0x3d.toByte))
 
     val result: Either[BlockPreparationError, PendingBlock] =
-      blockGenerator.generateBlockForMining(1, Seq(generalTx, specificTx), Nil, Address(testAddress))
+      blockGenerator.generateBlockForMining(bestBlock, Seq(generalTx, specificTx), Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -144,7 +144,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
     val generalTx: SignedTransaction = SignedTransaction.sign(transaction.copy(nonce = transaction.nonce + 1), keyPair, None)
 
     val result: Either[BlockPreparationError, PendingBlock] =
-      blockGenerator.generateBlockForMining(1, Seq(generalTx, signedTransaction), Nil, Address(testAddress))
+      blockGenerator.generateBlockForMining(bestBlock, Seq(generalTx, signedTransaction), Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -164,7 +164,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
     val nextTransaction: SignedTransaction = SignedTransaction.sign(transaction.copy(nonce = signedTransaction.tx.nonce + 1), keyPair, Some(0x3d.toByte))
 
     val result: Either[BlockPreparationError, PendingBlock] =
-      blockGenerator.generateBlockForMining(1, Seq(nextTransaction, signedTransaction), Nil, Address(testAddress))
+      blockGenerator.generateBlockForMining(bestBlock, Seq(nextTransaction, signedTransaction), Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -196,7 +196,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
       keyPairFromPrvKey(privateKeyWithNoEthere), Some(0x3d.toByte))
 
     val result: Either[BlockPreparationError, PendingBlock] =
-      blockGenerator.generateBlockForMining(1, Seq(nextTransaction, signedFailingTransaction, signedTransaction),
+      blockGenerator.generateBlockForMining(bestBlock, Seq(nextTransaction, signedFailingTransaction, signedTransaction),
         Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
@@ -220,7 +220,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
       Some(0x3d.toByte))
 
     val result: Either[BlockPreparationError, PendingBlock] =
-      blockGenerator.generateBlockForMining(1, Seq(txWitSameNonceButLowerGasPrice, signedTransaction), Nil, Address(testAddress))
+      blockGenerator.generateBlockForMining(bestBlock, Seq(txWitSameNonceButLowerGasPrice, signedTransaction), Nil, Address(testAddress))
     result shouldBe a[Right[_, Block]]
 
     //mined with mantis + ethminer
@@ -290,6 +290,8 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
 
     val genesisDataLoader = new GenesisDataLoader(blockchain, blockchainConfig)
     genesisDataLoader.loadGenesisData()
+
+    val bestBlock = blockchain.getBestBlock()
 
     val miningConfig = new MiningConfig {
       override val coinbase: Address = Address(42)


### PR DESCRIPTION
[EC-319](https://iohk.myjetbrains.com/youtrack/issue/EC-319)

The easiest approach was taken which is to disallow orphaned blocks. The ranged difficulty validation proves to be a bit more complex when dealing with forks. We may still do it in a follow-up task (configurable with a switch), though there's probably not a lot to be gained for overall syncing speed.

However, the code as currently is may be somewhat over-engineered in the area of `Ledger` / `BlockQueue` in that from the start it was meant to handle orphaned blocks.

There might be a third alternative: have a size limit on the queue, and delay validation until the actual execution. For that to work, however, queued blocks need to be associated with the peers they were received from. That would require refactoring the `BlockQueue` out of being a Ledger component, and rather to cooperate with `RegularSync` actor.

Additional note: this PR contains a makeshift fix for `BlockchainSuite` execution speed. See the [FIXME comment](https://github.com/input-output-hk/mantis/pull/329/files#diff-ed0696ad21de04447815d732b96ed011R25) on `BlockHeaderValidatorImpl`.