### PR TITLE
Enable configuring certificate keystore type

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -155,17 +155,21 @@ mantis {
       enabled = true
 
       # Listening address of JSON-RPC HTTP/HTTPS endpoint
-      interface = "127.0.0.1"
+      interface = "localhost"
 
       # Listening port of JSON-RPC HTTP/HTTPS endpoint
       port = 8546
 
-      # Path to the JKS keystore storing the certificate (used only for https)
-      # null value indicates no certificate is being used
+      # Path to the keystore storing the certificates (used only for https)
+      # null value indicates HTTPS is not being used
       certificate-keystore-path = null
 
-      # File with the password used for accessing the certificate (used only for https)
-      # null value indicates no certificate is being used
+      # Type of certificate keystore being used
+      # null value indicates HTTPS is not being used
+      certificate-keystore-type = null
+
+      # File with the password used for accessing the certificate keystore (used only for https)
+      # null value indicates HTTPS is not being used
       certificate-password-file = null
 
       # Enabled JSON-RPC APIs over the JSON-RPC endpoint

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcHttpsServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcHttpsServer.scala
@@ -24,12 +24,12 @@ class JsonRpcHttpsServer(val jsonRpcController: JsonRpcController, config: JsonR
   def run(): Unit = {
     implicit val materializer = ActorMaterializer()
 
-    val maybeSslContext = validateCertificateFiles(config.certificateKeyStorePath, config.certificatePasswordFile).flatMap{
-      case (certificatePath, passwordFile) =>
+    val maybeSslContext = validateCertificateFiles(config.certificateKeyStorePath, config.certificateKeyStoreType, config.certificatePasswordFile).flatMap{
+      case (keystorePath, keystoreType, passwordFile) =>
         val passwordReader = Source.fromFile(passwordFile)
         try {
           val password = passwordReader.getLines().mkString
-          obtainSSLContext(certificatePath, password)
+          obtainSSLContext(keystorePath, keystoreType, password)
         } finally {
           passwordReader.close()
         }
@@ -57,16 +57,23 @@ class JsonRpcHttpsServer(val jsonRpcController: JsonRpcController, config: JsonR
     * @param password for accessing the keystore with the certificate
     * @return the SSL context with the obtained certificate or an error if any happened
     */
-  private def obtainSSLContext(certificateKeyStorePath: String, password: String): HttpsSetupResult[SSLContext] = {
+  private def obtainSSLContext(certificateKeyStorePath: String, certificateKeyStoreType: String, password: String): HttpsSetupResult[SSLContext] = {
     val passwordCharArray: Array[Char] = password.toCharArray
 
-    val ks: KeyStore = KeyStore.getInstance("JKS")
-    val keyStoreInitResult: HttpsSetupResult[Unit] = Option(new FileInputStream(certificateKeyStorePath))
-      .toRight("Certificate keystore creation failed")
-      .flatMap { keyStore =>
-        Try(ks.load(keyStore, passwordCharArray)).toEither.left.map( _.getMessage) }
+    val maybeKeyStore: HttpsSetupResult[KeyStore] = Try(KeyStore.getInstance(certificateKeyStoreType))
+      .toOption.toRight(s"Certificate keystore invalid type set: $certificateKeyStoreType")
+    val keyStoreInitResult: HttpsSetupResult[KeyStore] = maybeKeyStore.flatMap{ keyStore =>
+      val keyStoreFileCreationResult = Option(new FileInputStream(certificateKeyStorePath))
+        .toRight("Certificate keystore file creation failed")
+      keyStoreFileCreationResult.flatMap { keyStoreFile =>
+        Try(keyStore.load(keyStoreFile, passwordCharArray)) match {
+          case Success(_) => Right(keyStore)
+          case Failure(err) => Left(err.getMessage)
+        }
+      }
+    }
 
-    keyStoreInitResult.map { _ =>
+    keyStoreInitResult.map { ks =>
       val keyManagerFactory: KeyManagerFactory = KeyManagerFactory.getInstance("SunX509")
       keyManagerFactory.init(ks, passwordCharArray)
 
@@ -83,15 +90,16 @@ class JsonRpcHttpsServer(val jsonRpcController: JsonRpcController, config: JsonR
   /**
     * Validates that the keystore certificate file and password file were configured and that the files exists
     *
-    * @param maybeCertificatePath, with the path to the keystore certificate if it was configured
+    * @param maybeKeystorePath, with the path to the certificate keystore if it was configured
     * @param maybePasswordFile, with the path to the password file if it was configured
     * @return the certificate path and password file or the error detected
     */
-  private def validateCertificateFiles(maybeCertificatePath: Option[String],
-                                       maybePasswordFile: Option[String]): HttpsSetupResult[(String, String)] =
-    (maybeCertificatePath, maybePasswordFile) match {
-      case (Some(certificatePath), Some(passwordFile)) =>
-        val certificateFileMissing = !new File(certificatePath).exists()
+  private def validateCertificateFiles(maybeKeystorePath: Option[String],
+                                       maybeKeystoreType: Option[String],
+                                       maybePasswordFile: Option[String]): HttpsSetupResult[(String, String, String)] =
+    (maybeKeystorePath, maybeKeystoreType, maybePasswordFile) match {
+      case (Some(keystorePath), Some(keystoreType), Some(passwordFile)) =>
+        val certificateFileMissing = !new File(keystorePath).exists()
         val passwordFileMissing = !new File(passwordFile).exists()
         if(certificateFileMissing && passwordFileMissing)
           Left("Certificate keystore path and password file configured but files are missing")
@@ -100,10 +108,9 @@ class JsonRpcHttpsServer(val jsonRpcController: JsonRpcController, config: JsonR
         else if(passwordFileMissing)
           Left("Certificate password file configured but file is missing")
         else
-          Right(certificatePath -> passwordFile)
-      case (None, None) => Left("Certificate keystore path and password file configuration required")
-      case (None, _) => Left("Certificate keystore path configuration required")
-      case (_, None) => Left("Certificate password file configuration required")
+          Right((keystorePath, keystoreType, passwordFile))
+      case _ =>
+        Left("HTTPS requires: certificate-keystore-path, certificate-keystore-type and certificate-password-file to be configured")
     }
 
   override def corsAllowedOrigins: HttpOriginRange = config.corsAllowedOrigins

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcHttpsServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcHttpsServer.scala
@@ -99,11 +99,11 @@ class JsonRpcHttpsServer(val jsonRpcController: JsonRpcController, config: JsonR
                                        maybePasswordFile: Option[String]): HttpsSetupResult[(String, String, String)] =
     (maybeKeystorePath, maybeKeystoreType, maybePasswordFile) match {
       case (Some(keystorePath), Some(keystoreType), Some(passwordFile)) =>
-        val certificateFileMissing = !new File(keystorePath).exists()
-        val passwordFileMissing = !new File(passwordFile).exists()
-        if(certificateFileMissing && passwordFileMissing)
+        val keystoreDirMissing = !new File(keystorePath).isDirectory
+        val passwordFileMissing = !new File(passwordFile).isFile
+        if(keystoreDirMissing && passwordFileMissing)
           Left("Certificate keystore path and password file configured but files are missing")
-        else if(certificateFileMissing)
+        else if(keystoreDirMissing)
           Left("Certificate keystore path configured but file is missing")
         else if(passwordFileMissing)
           Left("Certificate password file configured but file is missing")

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcServer.scala
@@ -82,6 +82,7 @@ object JsonRpcServer extends Logger {
     val interface: String
     val port: Int
     val certificateKeyStorePath: Option[String]
+    val certificateKeyStoreType: Option[String]
     val certificatePasswordFile: Option[String]
     val corsAllowedOrigins: HttpOriginRange
   }

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -97,6 +97,7 @@ object Config {
       }
 
       val certificateKeyStorePath: Option[String] = Try(rpcConfig.getString("certificate-keystore-path")).toOption
+      val certificateKeyStoreType: Option[String] = Try(rpcConfig.getString("certificate-keystore-type")).toOption
       val certificatePasswordFile: Option[String] = Try(rpcConfig.getString("certificate-password-file")).toOption
 
       def parseMultipleOrigins(origins: Seq[String]): HttpOriginRange = HttpOriginRange(origins.map(HttpOrigin(_)):_*)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcServerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/server/JsonRpcServerSpec.scala
@@ -89,6 +89,7 @@ class JsonRpcServerSpec extends FlatSpec with Matchers with ScalatestRouteTest {
       override val interface: String = ""
       override val port: Int = 123
       override val certificateKeyStorePath = None
+      override val certificateKeyStoreType = None
       override val certificatePasswordFile = None
       override val corsAllowedOrigins = HttpOriginRange.*
     }

--- a/src/universal/conf/network.conf
+++ b/src/universal/conf/network.conf
@@ -61,17 +61,21 @@ mantis {
       # enabled = true
 
       # Listening address of JSON-RPC HTTP/HTTPS endpoint
-      # interface = "127.0.0.1"
+      # interface = "localhost"
 
       # Listening port of JSON-RPC HTTP/HTTPS endpoint
       # port = 8546
 
-      # Path to the JKS keystore storing the certificate (used only for https)
-      # null value indicates no certificate keystore is being used
+      # Path to the keystore storing the certificates (used only for https)
+      # null value indicates HTTPS is not being used
       # certificate-keystore-path = null
 
-      # File with the password used for accessing the certificate (used only for https)
-      # null value indicates no certificate is being used
+      # Type of certificate keystore being used
+      # null value indicates HTTPS is not being used
+      # certificate-keystore-type = null
+
+      # File with the password used for accessing the certificate keystore (used only for https)
+      # null value indicates HTTPS is not being used
       # certificate-password-file = null
 
       # Enabled JSON-RPC APIs over the JSON-RPC endpoint

--- a/src/universal/conf/network.conf
+++ b/src/universal/conf/network.conf
@@ -71,7 +71,9 @@ mantis {
       # certificate-keystore-path = null
 
       # Type of certificate keystore being used
-      # null value indicates HTTPS is not being used
+      # Has to be null or one of the ones listed in:
+      #   https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#KeyStore
+      # A null value indicates HTTPS is not being used
       # certificate-keystore-type = null
 
       # File with the password used for accessing the certificate keystore (used only for https)


### PR DESCRIPTION
## Description

Enables configuring the type of certificate keystore being used.

This allows recreating a certificate keystore from a certificate and key files (using `openssl pkcs12 -export ...` command), which is needed for obtaining a keystore for the Mantis client based on the `server.crt` and `server.key` from [Daedalus](https://github.com/input-output-hk/daedalus/tree/master/tls).