### PR TITLE
[EC-344] Pruning should keep some old MPT Nodes

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -417,6 +417,8 @@ mantis {
     mode = "basic"
 
     # The amount of block history kept before pruning
+    # Note: if fast-sync clients choose target block offset greater than this value, mantis may not be able to
+    # correctly act as a fast-sync server
     history = 1000
   }
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
@@ -37,37 +37,36 @@ class ReferenceCountNodeStorage(nodeStorage: NodeStorage, blockNumber: Option[Bi
     val bn = blockNumber.get
     // Process upsert changes. As the same node might be changed twice within the same update, we need to keep changes
     // within a map. There is also stored the snapshot version before changes
-    val upsertChanges = applyUpsertChanges(toUpsert)
-    val changes = applyRemovalChanges(toRemove, upsertChanges)
+    val upsertChanges = applyUpsertChanges(toUpsert, bn)
+    val changes = applyRemovalChanges(toRemove, upsertChanges, bn)
 
-    val (toRemoveUpdated, toUpsertUpdated, snapshots) =
-      changes.foldLeft(Seq.empty[NodeHash], Seq.empty[(NodeHash, NodeEncoded)], Seq.empty[StoredNodeSnapshot]) {
-        case ((removeAcc, upsertAcc, snapshotAcc), (key, (storedNode, theSnapshot))) =>
-          // If no more references, move it to the list to be removed
-          if (storedNode.references == 0) (removeAcc :+ key, upsertAcc, snapshotAcc :+ theSnapshot)
-          else (removeAcc, upsertAcc :+ (key -> storedNodeToBytes(storedNode)), snapshotAcc :+ theSnapshot)
+    val (toUpsertUpdated, snapshots) =
+      changes.foldLeft(Seq.empty[(NodeHash, NodeEncoded)], Seq.empty[StoredNodeSnapshot]) {
+        case ((upsertAcc, snapshotAcc), (key, (storedNode, theSnapshot))) =>
+          // Update it in DB
+          (upsertAcc :+ (key -> storedNodeToBytes(storedNode)), snapshotAcc :+ theSnapshot)
       }
 
     val snapshotToSave: Seq[(NodeHash, Array[Byte])] = getSnapshotsToSave(bn, snapshots)
-    nodeStorage.update(toRemoveUpdated, toUpsertUpdated ++ snapshotToSave)
+    nodeStorage.update(Nil, toUpsertUpdated ++ snapshotToSave)
     this
   }
 
-  private def applyUpsertChanges(toUpsert: Seq[(NodeHash, NodeEncoded)]): Changes =
+  private def applyUpsertChanges(toUpsert: Seq[(NodeHash, NodeEncoded)], blockNumber: BigInt): Changes =
     toUpsert.foldLeft(Map.empty[NodeHash, (StoredNode, StoredNodeSnapshot)]) { (storedNodes, toUpsertItem) =>
       val (nodeKey, nodeEncoded) = toUpsertItem
       val (storedNode, snapshot) = getFromChangesOrStorage(nodeKey, storedNodes)
         .getOrElse(StoredNode.withoutReferences(nodeEncoded) -> StoredNodeSnapshot(nodeKey, None)) // if it's new, return an empty stored node
 
-      storedNodes + (nodeKey -> (storedNode.incrementReferences(1), snapshot))
+      storedNodes + (nodeKey -> (storedNode.incrementReferences(1, blockNumber), snapshot))
     }
 
-  private def applyRemovalChanges(toRemove: Seq[NodeHash], changes: Map[NodeHash, (StoredNode, StoredNodeSnapshot)]): Changes =
+  private def applyRemovalChanges(toRemove: Seq[NodeHash], changes: Map[NodeHash, (StoredNode, StoredNodeSnapshot)], blockNumber: BigInt): Changes =
     toRemove.foldLeft(changes) { (storedNodes, nodeKey) =>
       val maybeStoredNode: Option[(StoredNode, StoredNodeSnapshot)] = getFromChangesOrStorage(nodeKey, storedNodes)
 
       maybeStoredNode.fold(storedNodes) {
-        case (storedNode, snapshot) => storedNodes + (nodeKey -> (storedNode.decrementReferences(1), snapshot))
+        case (storedNode, snapshot) => storedNodes + (nodeKey -> (storedNode.decrementReferences(1, blockNumber), snapshot))
       }
     }
 
@@ -78,7 +77,7 @@ class ReferenceCountNodeStorage(nodeStorage: NodeStorage, blockNumber: Option[Bi
       val getSnapshotKeyFn = getSnapshotKey(blockNumber)(_)
       val blockNumberSnapshotsCount: BigInt = nodeStorage.get(snapshotCountKey).map(snapshotsCountFromBytes).getOrElse(0)
       val snapshotsToSave = snapshots.zipWithIndex.map { case (snapshot, index) =>
-        getSnapshotKeyFn(blockNumberSnapshotsCount + index + 1) -> snapshotToBytes(snapshot)
+        getSnapshotKeyFn(blockNumberSnapshotsCount + index) -> snapshotToBytes(snapshot)
       }
       // Save snapshots and latest snapshot index
       (snapshotCountKey -> snapshotsCountToBytes(blockNumberSnapshotsCount + snapshotsToSave.size)) +: snapshotsToSave
@@ -105,8 +104,9 @@ object ReferenceCountNodeStorage extends PruneSupport with Logger {
     log.debug(s"Pruning block $blockNumber")
 
     withSnapshotCount(blockNumber, nodeStorage) { (snapshotsCountKey, snapshotCount) =>
-      val snapshotKeys = snapshotKeysUpTo(blockNumber, snapshotCount)
-      nodeStorage.update(snapshotsCountKey +: snapshotKeys, Nil)
+      val snapshotKeys: Seq[NodeHash] = snapshotKeysUpTo(blockNumber, snapshotCount)
+      val toBeRemoved = getNodesToBeRemovedInPruning(blockNumber, snapshotKeys, nodeStorage)
+      nodeStorage.update((snapshotsCountKey +: snapshotKeys) ++ toBeRemoved, Nil)
     }
 
     log.debug(s"Pruned block $blockNumber")
@@ -146,23 +146,42 @@ object ReferenceCountNodeStorage extends PruneSupport with Logger {
 
   private def snapshotKeysUpTo(blockNumber: BigInt, snapshotCount: BigInt): Seq[ByteString] = {
     val getSnapshotKeyFn = getSnapshotKey(blockNumber)(_)
-    (BigInt(0) to snapshotCount).map(snapshotIndex => getSnapshotKeyFn(snapshotIndex))
+    (BigInt(0) until snapshotCount).map(snapshotIndex => getSnapshotKeyFn(snapshotIndex))
   }
+
+  /**
+    * Within snapshots stored for this block, it looks for Nodes that are not longer being used in order to remove them
+    * from DB. To do so, it looks for nodes whom snapshot reference count is 0
+    * @param blockNumber
+    * @param snapshotKeys
+    * @param nodeStorage
+    * @return
+    */
+  private def getNodesToBeRemovedInPruning(blockNumber: BigInt, snapshotKeys: Seq[NodeHash], nodeStorage: NodeStorage): Seq[NodeHash] =
+    snapshotKeys.foldLeft(Seq.empty[Option[NodeHash]]) { (nodesToRemove, snapshotKey) =>
+      val toRemove = for {
+        snapshot <- nodeStorage.get(snapshotKey).map(snapshotFromBytes)
+        node <- nodeStorage.get(snapshot.nodeKey).map(storedNodeFromBytes)
+        if node.references == 0 && node.lastUsedByBlock <= blockNumber
+      } yield snapshot.nodeKey
+      nodesToRemove :+ toRemove
+    }.flatten
 
   /**
     * Wrapper of MptNode in order to store number of references it has.
     *
     * @param nodeEncoded Encoded Mpt Node to be used in MerklePatriciaTrie
     * @param references  Number of references the node has. Each time it's updated references are increased and everytime it's deleted, decreased
+    * @param lastUsedByBlock Block Number where this node was last used
     */
-  case class StoredNode(nodeEncoded: ByteString, references: Int) {
-    def incrementReferences(amount: Int): StoredNode = copy(references = references + amount)
+  case class StoredNode(nodeEncoded: ByteString, references: Int, lastUsedByBlock: BigInt) {
+    def incrementReferences(amount: Int, blockNumber: BigInt): StoredNode = copy(references = references + amount, lastUsedByBlock = blockNumber)
 
-    def decrementReferences(amount: Int): StoredNode = copy(references = references - amount)
+    def decrementReferences(amount: Int, blockNumber: BigInt): StoredNode = copy(references = references - amount, lastUsedByBlock = blockNumber)
   }
 
   object StoredNode {
-    def withoutReferences(nodeEncoded: Array[Byte]): StoredNode = new StoredNode(ByteString(nodeEncoded), 0)
+    def withoutReferences(nodeEncoded: Array[Byte]): StoredNode = new StoredNode(ByteString(nodeEncoded), 0, 0)
   }
 
   /**

--- a/src/main/scala/io/iohk/ethereum/db/storage/encoding/package.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/encoding/package.scala
@@ -21,11 +21,11 @@ package object encoding {
 
   private val storedNodeEncDec = new RLPDecoder[StoredNode] with RLPEncoder[StoredNode] {
     override def decode(rlp: RLPEncodeable): StoredNode = rlp match {
-      case RLPList(nodeEncoded, references) => StoredNode(nodeEncoded, references)
+      case RLPList(nodeEncoded, references, lastUsedByBlock) => StoredNode(nodeEncoded, references, lastUsedByBlock)
       case _ => throw new RuntimeException("Error when decoding stored node")
     }
 
-    override def encode(obj: StoredNode): RLPEncodeable = RLPList(obj.nodeEncoded, obj.references)
+    override def encode(obj: StoredNode): RLPEncodeable = RLPList(obj.nodeEncoded, obj.references, obj.lastUsedByBlock)
   }
 
   private val snapshotEncDec = new RLPDecoder[StoredNodeSnapshot] with RLPEncoder[StoredNodeSnapshot] {

--- a/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
 
-  "ReferenceCountNodeStorage" should "should not remove a key if no more references until pruning" in new TestSetup {
+  "ReferenceCountNodeStorage" should "not remove a key if no more references until pruning" in new TestSetup {
     val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
 
     val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(4, storage)
@@ -20,19 +20,76 @@ class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
     storage.get(key1) shouldBe None
   }
 
-  it should "not delete a key that's still referenced when pruning" in new TestSetup {
+  it should "not remove a key that was inserted after deletion when pruning" in new TestSetup {
     val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
 
+    val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(1, storage)
+    val (key1, val1) :: Nil = inserted.toList
+
+    val storage2 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(2))
+    storage2.remove(key1)
+    storage2.get(key1).get shouldEqual val1
+
+    val storage3 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(3))
+    storage3.put(key1, val1)
+    storage3.get(key1).get shouldEqual val1
+
+    val storage4 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(4))
+    storage4.remove(key1)
+    storage3.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(1, nodeStorage)
+    storage3.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(2, nodeStorage)
+    storage3.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(3, nodeStorage)
+    storage3.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(4, nodeStorage)
+    storage3.get(key1) shouldEqual None
+
+  }
+
+  it should "not remove a key that it's still referenced when pruning" in new TestSetup {
+    val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
+
+    val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(1, storage)
+    val (key1, val1) :: Nil = inserted.toList
+
+    val storage2 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(2))
+    storage2.put(key1, val1)
+    storage2.get(key1).get shouldEqual val1
+
+    val storage3 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(3))
+    storage3.remove(key1)
+    storage3.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(1, nodeStorage)
+    storage3.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(2, nodeStorage)
+    storage3.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(3, nodeStorage)
+    storage3.get(key1).get shouldEqual val1
+  }
+
+  it should "not delete a key that's was referenced in later blocks when pruning" in new TestSetup {
+
+    val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
     val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(4, storage)
     val (key1, val1) :: (key2, val2) :: (key3, val3) :: (key4, val4) :: Nil = inserted.toList
 
-    storage.remove(key4) // remove key4 at block 1, it should be prunned
+    storage.remove(key1) // remove key1 at block 1
+    storage.remove(key4) // remove key4 at block 1, it should be pruned
 
     val storage2 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(2))
 
     storage2.put(key1, val1).remove(key1) // add key1 again and remove it at block 2
     storage2.remove(key2).put(key2, val2) // remove and add key2 at block 2
-    storage2.remove(key3) // Remve at block 2
+    storage2.remove(key3) // Remove at block 2
 
     storage2.get(key1).get shouldEqual val1
     storage2.get(key2).get shouldEqual val2
@@ -42,6 +99,12 @@ class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
     storage2.get(key1).get shouldEqual val1
     storage2.get(key2).get shouldEqual val2
     storage2.get(key3).get shouldEqual val3
+    storage2.get(key4) shouldBe None
+
+    ReferenceCountNodeStorage.prune(2, nodeStorage)
+    storage2.get(key1) shouldBe None
+    storage2.get(key2).get shouldEqual val2
+    storage2.get(key3) shouldBe None
     storage2.get(key4) shouldBe None
   }
 
@@ -56,14 +119,14 @@ class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
   it should "allow to rollback operations" in new TestSetup {
     val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
 
-    val inserted = insertRangeKeys(4, storage)
+    val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(4, storage)
     val (key1, val1) :: (key2, val2) :: xs = inserted.toList
 
     storage.remove(key1).remove(key2)
 
     val storage2 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(2))
     val key3 = ByteString("anotherKey")
-    val val3 = ByteString("anotherValue").toArray[Byte]
+    val val3: Array[Byte] = ByteString("anotherValue").toArray[Byte]
     storage2.put(key3, val3)
 
     storage2.get(key3).get shouldEqual val3
@@ -76,18 +139,18 @@ class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
 
   }
 
-  it should "allow pruning" in new TestSetup {
+  it should "allow rollbacks after pruning" in new TestSetup {
 
     val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
 
-    val inserted = insertRangeKeys(4, storage)
+    val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(4, storage)
     val (key1, val1) :: (key2, val2) :: xs = inserted.toList
 
     storage.remove(key1).remove(key2)
 
     val storage2 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(2))
     val key3 = ByteString("anotherKey")
-    val val3 = ByteString("anotherValue").toArray[Byte]
+    val val3: Array[Byte] = ByteString("anotherValue").toArray[Byte]
     storage2.put(key3, val3)
 
     dataSource.storage.size shouldEqual (5 + 2 + 7) // 5 keys + 2 block index + 7 snapshots

--- a/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorageSpec.scala
@@ -6,33 +6,43 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
 
-  "ReferenceCountNodeStorage" should "should remove a key if no more references" in new TestSetup {
+  "ReferenceCountNodeStorage" should "should not remove a key if no more references until pruning" in new TestSetup {
     val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
 
-    val inserted = insertRangeKeys(4, storage)
+    val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(4, storage)
     val (key1, val1) = inserted.head
 
     storage.remove(key1)
+    storage.get(key1).get shouldEqual val1
+
+    ReferenceCountNodeStorage.prune(1, nodeStorage)
+
     storage.get(key1) shouldBe None
   }
 
-  it should "not delete a key that's still referenced" in new TestSetup {
+  it should "not delete a key that's still referenced when pruning" in new TestSetup {
     val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
 
-    val inserted = insertRangeKeys(4, storage)
-    val (key1, val1) :: (key2, val2) :: xs = inserted.toList
+    val inserted: Seq[(ByteString, Array[Byte])] = insertRangeKeys(4, storage)
+    val (key1, val1) :: (key2, val2) :: (key3, val3) :: (key4, val4) :: Nil = inserted.toList
 
-    storage.put(key1, val1).remove(key1) // add key1 again and remove it
-    storage.remove(key2).put(key2, val2) // remove and add key2
+    storage.remove(key4) // remove key4 at block 1, it should be prunned
 
-    storage.get(key1).get sameElements val1.toArray[Byte]
-    storage.get(key2).get sameElements val2.toArray[Byte]
+    val storage2 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(2))
 
-    // After removal, they should be remmoved
-    storage.remove(key1)
-    storage.remove(key2)
-    storage.get(key1) shouldEqual None
-    storage.get(key2) shouldEqual None
+    storage2.put(key1, val1).remove(key1) // add key1 again and remove it at block 2
+    storage2.remove(key2).put(key2, val2) // remove and add key2 at block 2
+    storage2.remove(key3) // Remve at block 2
+
+    storage2.get(key1).get shouldEqual val1
+    storage2.get(key2).get shouldEqual val2
+    storage2.get(key3).get shouldEqual val3
+
+    ReferenceCountNodeStorage.prune(1, nodeStorage)
+    storage2.get(key1).get shouldEqual val1
+    storage2.get(key2).get shouldEqual val2
+    storage2.get(key3).get shouldEqual val3
+    storage2.get(key4) shouldBe None
   }
 
   it should "not throw an error when deleting a key that does not exist" in new TestSetup {
@@ -43,49 +53,25 @@ class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
     dataSource.storage.size shouldEqual 0
   }
 
-  it should "allow to rollback operations within the same block" in new TestSetup {
+  it should "allow to rollback operations" in new TestSetup {
     val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
 
     val inserted = insertRangeKeys(4, storage)
     val (key1, val1) :: (key2, val2) :: xs = inserted.toList
 
     storage.remove(key1).remove(key2)
-    val key3 = ByteString("anotherKey")
-    val val3 = ByteString("anotherValue").toArray[Byte]
-    storage.put(key3, val3)
 
-    storage.get(key1) shouldEqual None
-    storage.get(key2) shouldEqual None
-    storage.get(key3).get sameElements val3
-
-    ReferenceCountNodeStorage.rollback(1, nodeStorage)
-
-    storage.get(key1).get sameElements val1
-    storage.get(key2).get sameElements val2
-    storage.get(key3) shouldEqual None
-
-  }
-
-  it should "allow to rollback operations from a specific block" in new TestSetup {
-    val storage = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(1))
-
-    val inserted = insertRangeKeys(4, storage)
-    val (key1, val1) :: (key2, val2) :: xs = inserted.toList
-
-    storage.remove(key1).remove(key2)
-    val key3 = ByteString("anotherKey")
-    val val3 = ByteString("anotherValue").toArray[Byte]
     val storage2 = new ReferenceCountNodeStorage(nodeStorage, blockNumber = Some(2))
+    val key3 = ByteString("anotherKey")
+    val val3 = ByteString("anotherValue").toArray[Byte]
     storage2.put(key3, val3)
 
-    storage2.get(key1) shouldEqual None
-    storage2.get(key2) shouldEqual None
-    storage2.get(key3).get sameElements val3
+    storage2.get(key3).get shouldEqual val3
 
     ReferenceCountNodeStorage.rollback(2, nodeStorage)
 
-    storage2.get(key1) shouldEqual None
-    storage2.get(key2) shouldEqual None
+    storage2.get(key1).get shouldEqual val1
+    storage2.get(key2).get shouldEqual val2
     storage2.get(key3) shouldEqual None
 
   }
@@ -104,15 +90,15 @@ class ReferenceCountNodeStorageSpec extends FlatSpec with Matchers {
     val val3 = ByteString("anotherValue").toArray[Byte]
     storage2.put(key3, val3)
 
-    dataSource.storage.size shouldEqual (3 + 2 + 7) // 3 keys + 2 block index + 7 snapshots
+    dataSource.storage.size shouldEqual (5 + 2 + 7) // 5 keys + 2 block index + 7 snapshots
 
     ReferenceCountNodeStorage.prune(1, nodeStorage)
-    dataSource.storage.size shouldEqual (3 + 1 + 1) // 5 keys + 1 block index + 1 snapshots
+    dataSource.storage.size shouldEqual (3 + 1 + 1) // 3 keys + 1 block index + 1 snapshots
 
     // Data is correct
     storage2.get(key1) shouldEqual None
     storage2.get(key2) shouldEqual None
-    storage2.get(key3).get sameElements val3
+    storage2.get(key3).get shouldEqual val3
 
     // We can still rollback without error
     ReferenceCountNodeStorage.rollback(2, nodeStorage)

--- a/src/universal/conf/storage.conf
+++ b/src/universal/conf/storage.conf
@@ -27,6 +27,8 @@ mantis {
     # mode = "basic"
 
     # The amount of block history kept before pruning
+    # Note: if fast-sync clients choose target block offset greater than this value, mantis may not be able to
+    # correctly act as a fast-sync server
     # history = 1000
   }
 }


### PR DESCRIPTION
## Description

After latest pruning algorithm change in order to handle chain reorgs made in https://github.com/input-output-hk/mantis/pull/325, two issues were introduced:
- Mantis Fast Sync Server broken after new pruning implementation
- Miner reports and error if it requests work while applying a block

## Reason
Latest implementation only keeps latest version of MPT nodes in db. Deleted ones are moved to a stash area where they can be taken in case of a rollback but cannot be accessed in order to serve it to other services (miner, fast sync host actor).

## Fix
The following change delays MPT node removal from DB until it's pruned. In order to do so, it checks if it's no longer needed looking for:
- Zero references in the latest version
- It wasn't referenced by any other change in later blocks
