### PR TITLE
Feature/multilaunch

### DIFF
--- a/src/main/scala/io/iohk/ethereum/App.scala
+++ b/src/main/scala/io/iohk/ethereum/App.scala
@@ -5,8 +5,8 @@ object App {
 
   def main(args: Array[String]): Unit = {
 
-    private val launchMantis = "mantis"
-    private val launchKeytool = "keytool"
+    val launchMantis = "mantis"
+    val launchKeytool = "keytool"
 
       args.headOption match {
         case None => Mantis.main(args.tail)

--- a/src/main/scala/io/iohk/ethereum/App.scala
+++ b/src/main/scala/io/iohk/ethereum/App.scala
@@ -1,54 +1,22 @@
 package io.iohk.ethereum
 
-import io.iohk.ethereum.blockchain.sync.SyncController
-import io.iohk.ethereum.mining.Miner
-import io.iohk.ethereum.network.discovery.DiscoveryListener
-import io.iohk.ethereum.network.{PeerManagerActor, ServerActor}
-import io.iohk.ethereum.utils.Logger
-import io.iohk.ethereum.nodebuilder.Node
-
-import scala.concurrent.Await
-import scala.util.{Failure, Success, Try}
 
 object App {
 
   def main(args: Array[String]): Unit = {
 
-    new Node with Logger {
+    private val launchMantis = "mantis"
+    private val launchKeytool = "keytool"
 
-      def tryAndLogFailure(f: () => Any): Unit = Try(f()) match {
-        case Failure(e) => log.warn("Error while shutting down...", e)
-        case Success(_) =>
+      args.headOption match {
+        case None => Mantis.main(args.tail)
+        case Some(`launchMantis`) => Mantis.main(args.tail)
+        case Some(`launchKeytool`) => KeyTool.main(args.tail)
+        case Some(unknown) =>
+          println(s"Unrecognised launcher option, " +
+            s"first parameter must be $launchKeytool or $launchMantis")
       }
 
-      override def shutdown(): Unit = {
-        tryAndLogFailure(() => Await.ready(actorSystem.terminate, shutdownTimeoutDuration))
-        tryAndLogFailure(() => storagesInstance.dataSources.closeAll())
-      }
-
-      genesisDataLoader.loadGenesisData()
-
-      peerManager ! PeerManagerActor.StartConnecting
-      server ! ServerActor.StartServer(networkConfig.Server.listenAddress)
-
-      if (discoveryConfig.discoveryEnabled) {
-        discoveryListener ! DiscoveryListener.Start
-      }
-
-      syncController ! SyncController.Start
-
-      if (miningConfig.miningEnabled) {
-        miner ! Miner.StartMining
-      }
-
-      peerDiscoveryManager // unlazy
-
-      maybeJsonRpcServer match {
-        case Right(jsonRpcServer) if jsonRpcServerConfig.enabled => jsonRpcServer.run()
-        case Left(error) if jsonRpcServerConfig.enabled => log.error(error)
-        case _=> //Nothing
-      }
-    }
 
   }
 }

--- a/src/main/scala/io/iohk/ethereum/App.scala
+++ b/src/main/scala/io/iohk/ethereum/App.scala
@@ -9,7 +9,7 @@ object App {
     val launchKeytool = "keytool"
 
       args.headOption match {
-        case None => Mantis.main(args.tail)
+        case None => Mantis.main(args)
         case Some(`launchMantis`) => Mantis.main(args.tail)
         case Some(`launchKeytool`) => KeyTool.main(args.tail)
         case Some(unknown) =>

--- a/src/main/scala/io/iohk/ethereum/App.scala
+++ b/src/main/scala/io/iohk/ethereum/App.scala
@@ -1,7 +1,9 @@
 package io.iohk.ethereum
 
+import io.iohk.ethereum.utils.Logger
 
-object App {
+
+object App extends Logger {
 
   def main(args: Array[String]): Unit = {
 
@@ -13,7 +15,7 @@ object App {
         case Some(`launchMantis`) => Mantis.main(args.tail)
         case Some(`launchKeytool`) => KeyTool.main(args.tail)
         case Some(unknown) =>
-          println(s"Unrecognised launcher option, " +
+          log.error(s"Unrecognised launcher option, " +
             s"first parameter must be $launchKeytool or $launchMantis")
       }
 

--- a/src/main/scala/io/iohk/ethereum/KeyTool.scala
+++ b/src/main/scala/io/iohk/ethereum/KeyTool.scala
@@ -1,0 +1,7 @@
+package io.iohk.ethereum
+
+
+object KeyTool {
+
+  def main(args: Array[String]): Unit = sun.security.tools.keytool.Main.main(args)
+}

--- a/src/main/scala/io/iohk/ethereum/Mantis.scala
+++ b/src/main/scala/io/iohk/ethereum/Mantis.scala
@@ -1,0 +1,54 @@
+package io.iohk.ethereum
+
+import io.iohk.ethereum.blockchain.sync.SyncController
+import io.iohk.ethereum.mining.Miner
+import io.iohk.ethereum.network.discovery.DiscoveryListener
+import io.iohk.ethereum.network.{PeerManagerActor, ServerActor}
+import io.iohk.ethereum.nodebuilder.Node
+import io.iohk.ethereum.utils.Logger
+
+import scala.concurrent.Await
+import scala.util.{Failure, Success, Try}
+
+object Mantis {
+
+  def main(args: Array[String]): Unit = {
+
+    new Node with Logger {
+
+      def tryAndLogFailure(f: () => Any): Unit = Try(f()) match {
+        case Failure(e) => log.warn("Error while shutting down...", e)
+        case Success(_) =>
+      }
+
+      override def shutdown(): Unit = {
+        tryAndLogFailure(() => Await.ready(actorSystem.terminate, shutdownTimeoutDuration))
+        tryAndLogFailure(() => storagesInstance.dataSources.closeAll())
+      }
+
+      genesisDataLoader.loadGenesisData()
+
+      peerManager ! PeerManagerActor.StartConnecting
+      server ! ServerActor.StartServer(networkConfig.Server.listenAddress)
+
+      if (discoveryConfig.discoveryEnabled) {
+        discoveryListener ! DiscoveryListener.Start
+      }
+
+      syncController ! SyncController.Start
+
+      if (miningConfig.miningEnabled) {
+        miner ! Miner.StartMining
+      }
+
+      peerDiscoveryManager // unlazy
+
+      maybeJsonRpcServer match {
+        case Right(jsonRpcServer) if jsonRpcServerConfig.enabled => jsonRpcServer.run()
+        case Left(error) if jsonRpcServerConfig.enabled => log.error(error)
+        case _=> //Nothing
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
We need to expose the Keytool functionality to the installer such that it runs on Mac and windows without depending on java being installed. 

Keytool (the binary) is not necessarily re distributable (!) 
The usual way of creating a script won't work as they depend on the JDK being installed.  

This quick hack works and importantly allows us to test the installers soonest. 
A dedicated keytool project could replace this for 1.0. 