### PR TITLE
[EC-358] fix branch resolution depth

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -376,17 +376,11 @@ mantis {
     # time between 2 consecutive requests to peer when doing fast sync, this is to prevent flagging us as spammer
     fastsync-throttle = 2 seconds
 
-    # When we receive a block that we don't have a parent for, it means we found a fork. To resolve it, we need to query the
-    # same peer for previous blocks, until we find one that we have a parent for. This setting determines the batch size
-    # of such query (number of blocks returned in a single query). 12 becaue it is confirmation depth in ethereum
-    branch-resolution-batch-size = 12
-
-    # number fo block headers batches to process when resolving branches in block chain
-    # this limits length of branch in chain that will be resolved while doing regular sync
-    # if branch is longer resolution will be aborted because of risk of out of memory error
-    # too long branch may also indicate malicious peer, 24 (2 x branch-resolution-batch-size) because confirmation depth in ethereum is ~12 blocks
-    # so we allow branches of 2x confirmation depth
-    branch-resolution-max-requests = 2
+    # When we receive a branch that is not rooted in our chain (we don't have a parent for the first header), it means
+    # we found a fork. To resolve it, we need to query the same peer for previous headers, to find a common ancestor.
+    # This setting determines how many additional headers we request. The default of 12 may be regarded as confirmation
+    # depth in ethereum (https://www.reddit.com/r/ethereum/comments/4eplsv/how_many_confirms_is_considered_safe_in_ethereum/)
+    branch-resolution-request-size = 12
 
     # threshold for storing non-main-chain blocks in queue.
     # if: current_best_block_number - block_number > max-queued-block-number-behind

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -191,7 +191,6 @@ class RegularSync(
     case ResponseReceived(peer: Peer, BlockHeaders(headers), timeTaken) =>
       log.info("Received {} block headers in {} ms", headers.size, timeTaken)
       waitingForActor = None
-      println(s"got ${headers.size}, resolvingBranches = ${resolvingBranches}")
       if (resolvingBranches) handleBlockBranchResolution(peer, headers.reverse)
       else handleBlockHeaders(peer, headers)
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -264,8 +264,8 @@ class RegularSync(
     } else {
       //we did not get previous blocks, there is no way to resolve, blacklist peer and continue download
       resumeWithDifferentPeer(peer, "failed to resolve branch")
-      resolvingBranches = false
     }
+    resolvingBranches = false
   }
 
   private def handleBlockHeaders(peer: Peer, message: Seq[BlockHeader]) = if (message.nonEmpty) {
@@ -296,7 +296,6 @@ class RegularSync(
       if (resolvingBranches) {
         log.debug("fail to resolve branch, branch too long, it may indicate malicious peer")
         resumeWithDifferentPeer(peer, "failed to resolve branch")
-        resolvingBranches = false
       } else {
         val request = GetBlockHeaders(Right(headersQueue.head.parentHash), branchResolutionRequestSize, skip = 0, reverse = true)
         requestBlockHeaders(peer, request)

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -136,9 +136,8 @@ object Config {
     val persistStateSnapshotInterval: FiniteDuration
 
     val checkForNewBlockInterval: FiniteDuration
-    val branchResolutionBatchSize: Int
+    val branchResolutionRequestSize: Int
     val blockChainOnlyPeersPoolSize: Int
-    val branchResolutionMaxRequests: Int
     val fastSyncThrottle: FiniteDuration
 
     val maxQueuedBlockNumberAhead: Int
@@ -172,9 +171,8 @@ object Config {
           syncConfig.getDuration("persist-state-snapshot-interval").toMillis.millis
 
         val checkForNewBlockInterval: FiniteDuration = syncConfig.getDuration("check-for-new-block-interval").toMillis.millis
-        val branchResolutionBatchSize: Int = syncConfig.getInt("branch-resolution-batch-size")
+        val branchResolutionRequestSize: Int = syncConfig.getInt("branch-resolution-request-size")
         val blockChainOnlyPeersPoolSize: Int = syncConfig.getInt("fastsync-block-chain-only-peers-pool")
-        val branchResolutionMaxRequests: Int = syncConfig.getInt("branch-resolution-max-requests")
         val fastSyncThrottle: FiniteDuration = syncConfig.getDuration("fastsync-throttle").toMillis.millis
 
         val maxQueuedBlockNumberBehind: Int = syncConfig.getInt("max-queued-block-number-behind")

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -334,12 +334,11 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter with
       override val printStatusInterval: FiniteDuration = 1.hour
       override val persistStateSnapshotInterval: FiniteDuration = 20.seconds
       override val targetBlockOffset: Int = 500
-      override val branchResolutionBatchSize: Int = 20
+      override val branchResolutionRequestSize: Int = 20
       override val blacklistDuration: FiniteDuration = 5.seconds
       override val syncRetryInterval: FiniteDuration = 1.second
       override val checkForNewBlockInterval: FiniteDuration = 1.second
       override val startRetryInterval: FiniteDuration = 500.milliseconds
-      override val branchResolutionMaxRequests: Int = 100
       override val blockChainOnlyPeersPoolSize: Int = 100
       override val maxConcurrentRequests: Int = 10
       override val blockHeadersPerRequest: Int = 10
@@ -405,12 +404,11 @@ class SyncControllerSpec extends FlatSpec with Matchers with BeforeAndAfter with
       override val printStatusInterval: FiniteDuration = 1.hour
       override val persistStateSnapshotInterval: FiniteDuration = 20.seconds
       override val targetBlockOffset: Int = 500
-      override val branchResolutionBatchSize: Int = 20
+      override val branchResolutionRequestSize: Int = 20
       override val blacklistDuration: FiniteDuration = 5.seconds
       override val syncRetryInterval: FiniteDuration = 1.second
       override val checkForNewBlockInterval: FiniteDuration = checkingForNewBlockInterval
       override val startRetryInterval: FiniteDuration = 500.milliseconds
-      override val branchResolutionMaxRequests: Int = 100
       override val blockChainOnlyPeersPoolSize: Int = 100
       override val maxConcurrentRequests: Int = 10
       override val blockHeadersPerRequest: Int = 10


### PR DESCRIPTION
Branch resolution has been simplified by making a single request (of configurable size) for additional headers. Therefore no additional constraints for branch length are required.

This has been tested by revoking the fix made in #352 and forcing the issue to occur. After re-applying the said fix, syncing resumed immediately - previously it wouldn't have happened unless a peer chose to ignore our request for 200 headers and responded instead with something between 1 and 13 headers (which probably would have happened eventually).