### PR TITLE
Changed Mantis default log location to datadir

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,10 +10,10 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>mantis.log</file>
+        <file>${user.home}/.mantis/logs/mantis.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>mantis.%i.log.zip</fileNamePattern>
+            <fileNamePattern>${user.home}/.mantis/logs/mantis.%i.log.zip</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>10</maxIndex>
         </rollingPolicy>

--- a/src/universal/conf/logback.xml
+++ b/src/universal/conf/logback.xml
@@ -10,10 +10,10 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>mantis.log</file>
+        <file>${user.home}/.mantis/logs/mantis.log</file>
         <append>true</append>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>mantis.%i.log.zip</fileNamePattern>
+            <fileNamePattern>${user.home}/.mantis/logs/mantis.%i.log.zip</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>10</maxIndex>
         </rollingPolicy>


### PR DESCRIPTION
## Description

Changed Mantis default log and log zips location to `path/to/home/logs`.