### PR TITLE
[EC-395] Optimisation of ethash algorithm

### DIFF
--- a/src/main/scala/io/iohk/ethereum/crypto/package.scala
+++ b/src/main/scala/io/iohk/ethereum/crypto/package.scala
@@ -34,7 +34,7 @@ package object crypto {
   def kec256(input: ByteString): ByteString =
     ByteString(kec256(input.toArray))
 
-  def kec512(input: Array[Byte]): Array[Byte] = {
+  def kec512(input: Array[Byte]): Array[Byte] = synchronized {
     kec512engine.digest(input)
   }
 

--- a/src/main/scala/io/iohk/ethereum/crypto/package.scala
+++ b/src/main/scala/io/iohk/ethereum/crypto/package.scala
@@ -17,6 +17,8 @@ package object crypto {
   val curveParams: X9ECParameters = SECNamedCurves.getByName("secp256k1")
   val curve: ECDomainParameters = new ECDomainParameters(curveParams.getCurve, curveParams.getG, curveParams.getN, curveParams.getH)
 
+  val kec512engine = new Keccak512
+
   def kec256(input: Array[Byte], start: Int, length: Int): Array[Byte] = {
     val digest = new Keccak256
     digest.update(input, start, length)
@@ -32,10 +34,8 @@ package object crypto {
   def kec256(input: ByteString): ByteString =
     ByteString(kec256(input.toArray))
 
-  def kec512(input: Array[Byte]*): Array[Byte] = {
-    val digest = new Keccak512
-    input.foreach(i => digest.update(i))
-    digest.digest
+  def kec512(input: Array[Byte]): Array[Byte] = {
+    kec512engine.digest(input)
   }
 
   def generateKeyPair(secureRandom: SecureRandom): AsymmetricCipherKeyPair = {

--- a/src/main/scala/io/iohk/ethereum/utils/ByteUtils.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/ByteUtils.scala
@@ -107,17 +107,17 @@ object ByteUtils {
     sb.toString()
   }
 
-  def bytesToInts(bytes: Array[Byte]): Array[Int] =
-    bytes.grouped(4).map(getIntFromWord).toArray
+  def bytesToInts(bytes: Array[Byte]): Array[Int] = {
+    val buffer =  ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+    val ints = new Array[Int](bytes.length / 4)
+    buffer.asIntBuffer().get(ints)
+    ints
+  }
 
-  def intsToBytes(input: Array[Int]): Array[Byte] = {
-    input.flatMap { i =>
-      Array(
-        (i & 0xFF).toByte,
-        ((i >> 8) & 0xFF).toByte,
-        ((i >> 16) & 0xFF).toByte,
-        ((i >> 24) & 0xFF).toByte)
-    }
+  def intsToBytes(ints: Array[Int]): Array[Byte] = {
+    val buf = ByteBuffer.allocate(ints.length * 4).order(ByteOrder.LITTLE_ENDIAN)
+    buf.asIntBuffer().put(ints)
+    buf.array()
   }
 
   def getIntFromWord(arr: Array[Byte]): Int = {


### PR DESCRIPTION
Main improvements by:
1. rewriting foreach as while loops, and avoiding allocation of `Range` object ( `scalac` compiler should do this under the hood, but as it seems it fails sometimes)

2. Avoiding Allocation new Keccak512 engine during each hash computation as it is quite expensive. And taking digest always reset engine to starting state. 

3. optimising array translations between byte and int array.  changing `scala` constructs `map` and `flatMaps` to operations on`ByteFuffers`.  

As it stands  current bottleneck is point `3`, but as I rewritten those to manually manipulating bytes on pre-allocated arrays,  point of contention just moved to https://github.com/input-output-hk/mantis/pull/377/files#diff-0dafe97cd157b1f1432980a711be1ebdR196, and there was only little speedup (1 - 2%) so i left it as it is, because `ByteBuffer` implementation is much simpler.

And I think we cant do much about https://github.com/input-output-hk/mantis/pull/377/files#diff-0dafe97cd157b1f1432980a711be1ebdR196, as it is just this algorithm complexity and it is implemented similarly in other clients.

During test of syncing from one master node number of blocks imported during `10 min` increased from `40448` to `71936`.
Attached recording shows as bottleneck moves from allocating `Range` objects, to byte array to int array conversion as mentioned in point `3`

[PerfNoPerfRecordings.zip](https://github.com/input-output-hk/mantis/files/1600299/PerfNoPerfRecordings.zip)

[perfNoPerfComp.txt](https://github.com/input-output-hk/mantis/files/1600295/perfNoPerfComp.txt)




  