### PR TITLE
Fix performance bottle neck in storages

### DIFF
--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -24,6 +24,17 @@ trait DataSource {
     */
   def get(namespace: Namespace, key: Key): Option[Value]
 
+
+  /**
+    * This function obtains the associated value to a key, if there exists one. It assumes that
+    * caller already properly serialized key. Useful when caller knows some pattern in data to
+    * avoid generic serialization.
+    *
+    * @param key
+    * @return the value associated with the passed key.
+    */
+  def getOptimized(key: Array[Byte]): Option[Array[Byte]]
+
   /**
     * This function updates the DataSource by deleting, updating and inserting new (key-value) pairs.
     *
@@ -34,6 +45,19 @@ trait DataSource {
     * @return the new DataSource after the removals and insertions were done.
     */
   def update(namespace: Namespace, toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource
+
+
+  /**
+    * This function updates the DataSource by deleting, updating and inserting new (key-value) pairs.
+    * It assumes that caller already properly serialized key and value.
+    * Useful when caller knows some pattern in data to avoid generic serialization.
+    *
+    * @param toRemove which includes all the keys to be removed from the DataSource.
+    * @param toUpsert which includes all the (key-value) pairs to be inserted into the DataSource.
+    *                 If a key is already in the DataSource its value will be updated.
+    * @return the new DataSource after the removals and insertions were done.
+    */
+  def updateOptimized(toRemove: Seq[Array[Byte]], toUpsert: Seq[(Array[Byte], Array[Byte])]): DataSource
 
   /**
     * This function updates the DataSource by deleting all the (key-value) pairs in it.

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/EphemDataSource.scala
@@ -27,6 +27,17 @@ class EphemDataSource(var storage: Map[IndexedSeq[Byte], IndexedSeq[Byte]]) exte
   override def close(): Unit = ()
 
   override def destroy(): Unit = ()
+
+  override def updateOptimized(toRemove: Seq[Array[Byte]], toUpsert: Seq[(Array[Byte], Array[Byte])]): DataSource = {
+    val afterRemoval = toRemove.foldLeft(storage)((storage, key) => storage - key.toIndexedSeq)
+    val afterUpdate = toUpsert.foldLeft(afterRemoval)((storage, toUpdate) =>
+      storage + (toUpdate._1.toIndexedSeq -> toUpdate._2.toIndexedSeq))
+    storage = afterUpdate
+    this
+
+  }
+
+  override def getOptimized(key: Array[Byte]): Option[Array[Byte]] = storage.get(key.toIndexedSeq).map(_.toArray)
 }
 
 object EphemDataSource {

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReferenceCountNodeStorage.scala
@@ -166,15 +166,21 @@ object ReferenceCountNodeStorage extends PruneSupport with Logger {
     * @param nodeStorage
     * @return
     */
-  private def getNodesToBeRemovedInPruning(blockNumber: BigInt, snapshotKeys: Seq[NodeHash], nodeStorage: NodeStorage): Seq[NodeHash] =
-    snapshotKeys.foldLeft(Seq.empty[Option[NodeHash]]) { (nodesToRemove, snapshotKey) =>
-      val toRemove = for {
-        snapshot <- nodeStorage.get(snapshotKey).map(snapshotFromBytes)
+  private def getNodesToBeRemovedInPruning(blockNumber: BigInt, snapshotKeys: Seq[NodeHash], nodeStorage: NodeStorage): Seq[NodeHash] = {
+    var nodesToRemove = List.empty[NodeHash]
+
+    snapshotKeys.foreach {hash =>
+      for {
+        snapshot <- nodeStorage.get(hash).map(snapshotFromBytes)
         node <- nodeStorage.get(snapshot.nodeKey).map(storedNodeFromBytes)
         if node.references == 0 && node.lastUsedByBlock <= blockNumber
-      } yield snapshot.nodeKey
-      nodesToRemove :+ toRemove
-    }.flatten
+      } yield {
+        nodesToRemove = snapshot.nodeKey :: nodesToRemove
+      }
+    }
+
+    nodesToRemove
+  }
 
   /**
     * Wrapper of MptNode in order to store number of references it has.


### PR DESCRIPTION
1. Replace builidng list of nodes to delete in pruning
from append to seq to prepend to list.
2. During serialization of nodes use the fact that
value is already array[Byte] and key is bytestring

As for potential improvements, during sync from master locally:

#### Syncing to 200k blocks
Baseline - 55min
Improved - 45min

#### 30min of syncing from some later block
Baseline:
```
22:06:15 [i.i.e.blockchain.sync.RegularSync] - Block: 756826. Peers: 1 (0 blacklisted)
22:16:20 [i.i.e.blockchain.sync.RegularSync] - Block: 762330. Peers: 1 (0 blacklisted)
10min - 5504
22:36:17 [i.i.e.blockchain.sync.RegularSync] - Block: 776538. Peers: 1 (0 blacklisted)
30 min - 19712 blocks
```

Improved:
```
11:30:18 [i.i.e.blockchain.sync.RegularSync] - Block: 756826. Peers: 1 (0 blacklisted)
11:40:19 [i.i.e.blockchain.sync.RegularSync] - Block: 762714. Peers: 1 (0 blacklisted)
10min - 5888
12:00:19 [i.i.e.blockchain.sync.RegularSync] - Block: 778266. Peers: 1 (0blacklisted)
30min - 21440
```
Diffrence is 1729 blocks in same unit of time, which is ~9% improvement
