### PR TITLE
[EC-423] Bug/hande tcp udp ports

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -71,7 +71,7 @@ mantis {
       nodes-limit = 1000
 
       # Initial delay for discovery scan
-      scan-initial-delay = 10.seconds
+      scan-initial-delay = 20.seconds
 
       # Scan interval for discovery
       scan-interval = 1.minute

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -83,7 +83,7 @@ class PeerManagerActor(
       val peerAddresses = managerState.outgoingPeers.values.map(_.remoteAddress).toSet
 
       val nodesToConnect = nodesInfo
-        .filterNot(n => peerAddresses.contains(n.node.addr)) // not already connected to
+        .filterNot(n => peerAddresses.contains(n.node.tcpSocketAddress)) // not already connected to
         .toSeq
         .sortBy(-_.addTimestamp)
         .take(peerConfiguration.maxOutgoingPeers - peerAddresses.size)

--- a/src/main/scala/io/iohk/ethereum/network/discovery/Node.scala
+++ b/src/main/scala/io/iohk/ethereum/network/discovery/Node.scala
@@ -53,11 +53,6 @@ object NodeParser extends Logger {
 
   type Error = String
 
-  private def combineValidations[A,B](obj: B, eithers: Either[A,B]*): Either[Set[A], B] = {
-    val errors = eithers.collect { case Left(e) => e }
-    if (errors.isEmpty) Right(obj) else Left(errors.toSet)
-  }
-
   private def validateTcpAddress(uri: URI): Either[Error, URI] = {
     Try(InetAddress.getByName(uri.getHost) -> uri.getPort) match {
       case Success(tcpAddress) if tcpAddress._2 != -1 => Right(uri)
@@ -93,6 +88,8 @@ object NodeParser extends Logger {
   }
 
   private def validateNodeUri(node: String): Either[Set[Error], URI] = {
+    import io.iohk.ethereum.utils.ValidationUtils._
+
     val uri = validateUri(node)
     uri match {
       case Left(error) => Left(Set(error))

--- a/src/main/scala/io/iohk/ethereum/network/discovery/Node.scala
+++ b/src/main/scala/io/iohk/ethereum/network/discovery/Node.scala
@@ -9,18 +9,40 @@ import org.spongycastle.util.encoders.Hex
 
 import scala.util.{Failure, Success, Try}
 
-case class Node(id: ByteString, addr: InetSocketAddress) {
+case class Node(id: ByteString, addr: InetAddress, tcpPort: Int, udpPort: Int) {
+
+  lazy val udpSocketAddress = new InetSocketAddress(addr, udpPort)
+  lazy val tcpSocketAddress = new InetSocketAddress(addr, tcpPort)
+
   def toUri: URI = {
-    val host = network.getHostName(addr.getAddress)
-    val port = addr.getPort
-    new URI(s"enode://${Hex.toHexString(id.toArray[Byte])}@$host:$port")
+    val host = network.getHostName(addr)
+    new URI(s"enode://${Hex.toHexString(id.toArray[Byte])}@$host:$tcpPort?discport=$udpPort")
   }
 }
 
 object Node {
+
+  // If there is no udp port specified or it is malformed use tcp as default
+  private def getUdpPort(uri: URI, default: Int): Int = {
+    Option(uri.getQuery).fold(default) { query =>
+      Try {
+        val params = query.split("=")
+        if (params(0) == "discport")
+          params(1).toInt
+        else
+          default
+      } match {
+        case Success(udpPort) => udpPort
+        case Failure(_) => default
+      }
+    }
+  }
+
   def fromUri(uri: URI): Node = {
     val nodeId = ByteString(Hex.decode(uri.getUserInfo))
-    Node(nodeId, new InetSocketAddress(uri.getHost, uri.getPort))
+    val address = InetAddress.getByName(uri.getHost)
+    val tcpPort = uri.getPort
+    Node(nodeId, address, tcpPort, getUdpPort(uri, tcpPort))
   }
 }
 
@@ -28,44 +50,69 @@ object NodeParser extends Logger {
   val NodeScheme = "enode"
   val NodeIdSize = 64
 
+
+  type Error = String
+
+  private def combineValidations[A,B](obj: B, eithers: Either[A,B]*): Either[Set[A], B] = {
+    val errors = eithers.collect { case Left(e) => e }
+    if (errors.isEmpty) Right(obj) else Left(errors.toSet)
+  }
+
+  private def validateTcpAddress(uri: URI): Either[Error, URI] = {
+    Try(InetAddress.getByName(uri.getHost) -> uri.getPort) match {
+      case Success(tcpAddress) if tcpAddress._2 != -1 => Right(uri)
+      case Success(_)  => Left(s"No defined port for uri $uri")
+      case Failure(_)  => Left(s"Error parsing ip address for $uri")
+    }
+  }
+
+  private def validateScheme(uri: URI): Either[Error, URI] = {
+    val scheme = Option(uri.getScheme).toRight(s"No defined scheme for uri $uri")
+
+    scheme.flatMap{ scheme =>
+      Either.cond(uri.getScheme == NodeScheme, uri, s"Invalid node scheme $scheme, it should be $NodeScheme")
+    }
+  }
+
+  private def validateNodeId(uri: URI): Either[Error, URI] = {
+    val nodeId = Try(ByteString(Hex.decode(uri.getUserInfo))) match {
+      case Success(id) => Right(id)
+      case Failure(_) => Left(s"Malformed nodeId for URI ${uri.toString}")
+    }
+
+    nodeId.flatMap(nodeId =>
+      Either.cond(nodeId.size == NodeIdSize, uri, s"Invalid node scheme $nodeId size, it should be $NodeScheme")
+    )
+  }
+
+  private def validateUri(uriString: String): Either[Error, URI] = {
+    Try(new URI(uriString)) match {
+      case Success(nUri) => Right(nUri)
+      case Failure(ex) => Left(s"Malformed URI for node $uriString")
+    }
+  }
+
+  private def validateNodeUri(node: String): Either[Set[Error], URI] = {
+    val uri = validateUri(node)
+    uri match {
+      case Left(error) => Left(Set(error))
+      case Right(nUri)  =>
+        val valScheme = validateScheme(nUri)
+        val valNodeId = validateNodeId(nUri)
+        val valTcpAddress = validateTcpAddress(nUri)
+        combineValidations(nUri, valScheme, valNodeId, valTcpAddress)
+    }
+  }
+
   /**
     * Parse a node string, for it to be valid it should have the format:
     * "enode://[128 char (64bytes) hex string]@[IPv4 address | '['IPv6 address']' ]:[port]"
     *
     * @param node to be parsed
-    * @return the parsed node, or the error detected during parsing
+    * @return the parsed node, or the errors detected during parsing
     */
-  def parseNode(node: String): Either[Set[Throwable], Node] = {
-
-    val maybeUri = Try(new URI(node))
-
-    val maybeScheme = maybeUri.map(_.getScheme).flatMap { scheme =>
-      if (scheme == NodeScheme) Success(scheme)
-      else Failure(new Exception(s"Invalid node scheme $scheme, it should be $NodeScheme"))
-    }
-
-    val maybeNodeId = maybeUri
-      .flatMap(uri => Try(ByteString(Hex.decode(uri.getUserInfo))))
-      .flatMap { nodeId =>
-        if (nodeId.size == NodeIdSize) Success(nodeId)
-        else Failure(new Exception(s"Invalid nodeId size ${nodeId.size}, it should be $NodeIdSize bytes long"))
-      }
-
-    val maybeAddress = maybeUri
-      .flatMap(uri => Try(InetAddress.getByName(uri.getHost) -> uri.getPort))
-      .flatMap{ case (host, port) => host match {
-        case _: Inet4Address | _: Inet6Address => Success(host -> port)
-        case _ =>
-          Failure(new Exception(s"Invalid host $host, only IPv4 and IPv6 addresses are currently supported"))
-      }}
-      .flatMap{ case (host, port) => Try(new InetSocketAddress(host, port))}
-
-    (maybeScheme, maybeNodeId, maybeAddress) match {
-      case (Success(_), Success(n), Success(addr)) =>
-        Right(Node(n, addr))
-      case _ =>
-        Left(Set(maybeScheme, maybeNodeId, maybeAddress).flatMap(_.toEither.left.toSeq))
-    }
+  def parseNode(node:String): Either[Set[Error], Node] = {
+    validateNodeUri(node).map(uri => Node.fromUri(uri))
   }
 
   /**
@@ -80,7 +127,7 @@ object NodeParser extends Logger {
       maybeNode match {
         case Right(node) => parsedNodes + node
         case Left(errors) =>
-          log.warn(s"Unable to parse node: $nodeString due to: ${errors.map(_.getMessage).mkString("; ")}")
+          log.warn(s"Unable to parse node: $nodeString due to: $errors")
           parsedNodes
       }
   }

--- a/src/main/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManager.scala
+++ b/src/main/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManager.scala
@@ -63,14 +63,15 @@ class PeerDiscoveryManager(
 
     case DiscoveryListener.MessageReceived(pong: Pong, from, packet) =>
       pingedNodes.get(packet.nodeId).foreach { newNodeInfo =>
+        val nodeInfoUpdatedTime = newNodeInfo.copy(addTimestamp = clock.millis())
         pingedNodes -= newNodeInfo.node.id
         if (nodesInfo.size < discoveryConfig.nodesLimit) {
-          nodesInfo += newNodeInfo.node.id -> newNodeInfo
+          nodesInfo += newNodeInfo.node.id -> nodeInfoUpdatedTime
           sendMessage(FindNode(ByteString(nodeStatusHolder().nodeId), expirationTimestamp), from)
         } else {
           val (earliestNode, _) = nodesInfo.minBy { case (_, node) => node.addTimestamp }
           nodesInfo -= earliestNode
-          nodesInfo += newNodeInfo.node.id -> newNodeInfo
+          nodesInfo += newNodeInfo.node.id -> nodeInfoUpdatedTime
         }
       }
 

--- a/src/main/scala/io/iohk/ethereum/utils/ValidationUtils.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/ValidationUtils.scala
@@ -1,0 +1,16 @@
+package io.iohk.ethereum.utils
+
+object ValidationUtils {
+
+  /**
+    * This function combines multiple validations on object.
+    *
+    * @param obj object to return if all validations pass .
+    * @param eithers list of required validations.
+    * @return object if all validations pass, else non-empty set of errors.
+    */
+  def combineValidations[A,B](obj: B, eithers: Either[A,B]*): Either[Set[A], B] = {
+    val errors = eithers.collect { case Left(e) => e }
+    if (errors.isEmpty) Right(obj) else Left(errors.toSet)
+  }
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -16,7 +16,7 @@ mantis {
 
   network.discovery.bootstrap-nodes = [
     "enode://375fc4e3712013120f392d909c57aead2461ba919130075e8fcd007e8326971a514741af0debff783ebdcb8c82ab72c8eee9a31adab629232e52d1e8e9b9b4b6@127.0.0.1:30340",
-    "enode://375fc4e3712013120f392d909c57aead2461ba919130075e8fcd007e8326971a514741af0debff783ebdcb8c82ab72c8eee9a31adab629232e52d1e8e9b9b4b6@10.0.0.0:30340"
+    "enode://375fc4e3712013120f392d909c57aead2461ba919130075e8fcd007e8326971a514741af0debff783ebdcb8c82ab72c8eee9a31adab629232e52d1e8e9b9b4b7@10.0.0.0:30340"
   ]
 
   network.rpc.apis = "eth,web3,net,personal,daedalus"

--- a/src/test/scala/io/iohk/ethereum/network/NodeParserSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/NodeParserSpec.scala
@@ -39,7 +39,7 @@ class NodeParserSpec extends FlatSpec with Matchers with PropertyChecks {
         node.isRight shouldEqual valid
 
         if (valid && !hasCustomUdp)
-          node.toOption.get.toUri.toString shouldBe nodeString +"?discport=30303"
+          node.toOption.get.toUri.toString shouldBe nodeString + "?discport=30303"
 
         if (valid && hasCustomUdp)
           node.toOption.get.toUri.toString shouldBe nodeString
@@ -68,7 +68,7 @@ class NodeParserSpec extends FlatSpec with Matchers with PropertyChecks {
       val node = NodeParser.parseNode(nodeString)
       node.isRight shouldEqual maybeExpectedOutput.nonEmpty
       if (maybeExpectedOutput.nonEmpty)
-        node.toOption.get.toUri.toString shouldBe maybeExpectedOutput.get+"?discport=30303"
+        node.toOption.get.toUri.toString shouldBe maybeExpectedOutput.get + "?discport=30303"
     }
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/NodeParserSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/NodeParserSpec.scala
@@ -7,35 +7,41 @@ import org.scalatest.{FlatSpec, Matchers}
 class NodeParserSpec extends FlatSpec with Matchers with PropertyChecks {
 
   it should "correctly parse IPv4 nodes" in {
-    val testVectors = Table[String, Boolean](
-      ("nodes", "isValid"),
+    val testVectors = Table[String, Boolean, Boolean](
+      ("nodes", "isValid", "hasCustomUdp"),
 
       ("enode://fba5a07e283d517a2680bcfc7aeb498ac2d246d756556a2ebd5edeb39496491c47a6d27e27f82833b7d7d12defc8de994de04bb58beb72472649f9a323006820@41.135.121.6:30303",
-        true),
+        true, false),
       (" enode://09c4a2fec7daed400e5e28564e23693b23b2cc5a019b612505631bbe7b9ccf709c1796d2a3d29ef2b045f210caf51e3c4f5b6d3587d43ad5d6397526fa6179@174.112.32.157:30303",
-        false), //Has invalid ' ' character
+        false, false), //Has invalid ' ' character
       ("http://6e538e7c1280f0a31ff08b382db5302480f775480b8e68f8febca0ceff81e4b19153c6f8bf60313b93bef2cc34d34e1df41317de0ce613a201d1660a788a03e2@52.206.67.235:30303",
-        false), //Has invalid scheme
+        false, false), //Has invalid scheme
       ("enode://5fbfb426fbb46f8b8c1bd3dd140f5b511da558cd37d60844b525909ab82e13a25ee722293c829e52cb65c2305b1637fa9a2ea4d6634a224d5f400bfe244ac0de@162-243-55-45:30303",
-        false), //Has invalid IP format
+        false, false), //Has invalid IP format
       ("enode://a5a07e283d517a2680bcfc7aeb498ac2d246d756556a2ebd5edeb39496491c47a6d27e27f82833b7d7d12defc8de994de04bb58beb72472649f9a323006820@41.135.121.6:30303",
-        false), //Has invalid node id size
+        false, false), //Has invalid node id size
       ("enode://zba5a07e283d517a2680bcfc7aeb498ac2d246d756556a2ebd5edeb39496491c47a6d27e27f82833b7d7d12defc8de994de04bb58beb72472649f9a323006820@41.135.121.6:30303",
-        false), //Node id has invalid 'z' character
+        false, false), //Node id has invalid 'z' character
       ("enode://@41.135.121.6:30303",
-        false), //Has no node id
-      ("enode://41.135.121.6:30303", false), //Has no node id
+        false, false), //Has no node id
+      ("enode://41.135.121.6:30303", false, false), //Has no node id
       ("enode://fba5a07e283d517a2680bcfc7aeb498ac2d246d756556a2ebd5edeb39496491c47a6d27e27f82833b7d7d12defc8de994de04bb58beb72472649f9a323006820@:30303",
-        false), //Has no IP
+        false, false), //Has no IP
       ("enode://fba5a07e283d517a2680bcfc7aeb498ac2d246d756556a2ebd5edeb39496491c47a6d27e27f82833b7d7d12defc8de994de04bb58beb72472649f9a323006820@41.135.121.6:",
-        false), //Has no port
-      ("", false) //Empty node string
+        false, false), //Has no port
+      ("", false, false),
+      ("enode://fba5a07e283d517a2680bcfc7aeb498ac2d246d756556a2ebd5edeb39496491c47a6d27e27f82833b7d7d12defc8de994de04bb58beb72472649f9a323006820@41.135.121.6:30303?discport=30305",
+        true, true) //custom discovery
     )
 
-    forAll(testVectors) { case (nodeString, valid) =>
+    forAll(testVectors) { case (nodeString, valid, hasCustomUdp) =>
         val node = NodeParser.parseNode(nodeString)
         node.isRight shouldEqual valid
-        if(valid)
+
+        if (valid && !hasCustomUdp)
+          node.toOption.get.toUri.toString shouldBe nodeString +"?discport=30303"
+
+        if (valid && hasCustomUdp)
           node.toOption.get.toUri.toString shouldBe nodeString
     }
   }
@@ -61,8 +67,8 @@ class NodeParserSpec extends FlatSpec with Matchers with PropertyChecks {
     forAll(testVectors) { case (nodeString, maybeExpectedOutput) =>
       val node = NodeParser.parseNode(nodeString)
       node.isRight shouldEqual maybeExpectedOutput.nonEmpty
-      if(maybeExpectedOutput.nonEmpty)
-        node.toOption.get.toUri.toString shouldBe maybeExpectedOutput.get
+      if (maybeExpectedOutput.nonEmpty)
+        node.toOption.get.toUri.toString shouldBe maybeExpectedOutput.get+"?discport=30303"
     }
   }
 

--- a/src/test/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManagerSpec.scala
@@ -11,7 +11,7 @@ import com.miguno.akka.testing.VirtualTime
 import io.iohk.ethereum.NormalPatience
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.network.discovery.DiscoveryListener._
-import io.iohk.ethereum.network.discovery.PeerDiscoveryManager.DiscoveryNodeInfo
+import io.iohk.ethereum.network.discovery.PeerDiscoveryManager.{DiscoveryNodeInfo, PingInfo}
 import io.iohk.ethereum.nodebuilder.{NodeKeyBuilder, SecureRandomBuilder}
 import io.iohk.ethereum.rlp.RLPEncoder
 import io.iohk.ethereum.utils.{Config, NodeStatus, ServerStatus}
@@ -40,7 +40,7 @@ class PeerDiscoveryManagerSpec extends FlatSpec with Matchers with MockFactory w
 
     val nodeInfo =  DiscoveryNodeInfo.fromNode(Node(pongDecoded.nodeId, remoteUdpAddress.getAddress, remoteUdpPort, remoteUdpPort))
 
-    discoveryPeerManager.underlyingActor.pingedNodes += nodeInfo.node.id -> nodeInfo
+    discoveryPeerManager.underlyingActor.pingedNodes += pingPingPacketDecoded.mdc -> PingInfo(nodeInfo, timestamp)
 
     discoveryPeerManager ! pongMessageReceiced
 
@@ -73,9 +73,6 @@ class PeerDiscoveryManagerSpec extends FlatSpec with Matchers with MockFactory w
 
     expectedMes.foreach(mess => dicoveryListner.expectMsg(mess))
     discoveryPeerManager.underlyingActor.pingedNodes.size shouldEqual neighbours.size
-    neighbours.foreach{n =>
-      discoveryPeerManager.underlyingActor.pingedNodes.get(n.nodeId) shouldBe defined
-    }
   }
 
   it should "correctly scan bootstrap nodes" in new TestSetup {

--- a/src/test/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/discovery/PeerDiscoveryManagerSpec.scala
@@ -49,7 +49,7 @@ class PeerDiscoveryManagerSpec extends FlatSpec with Matchers with MockFactory w
     Thread.sleep(1500)
     dicoveryListner.expectMsg(expectedFindNodeResponse)
     discoveryPeerManager.underlyingActor.nodesInfo.size shouldEqual 1
-    discoveryPeerManager.underlyingActor.nodesInfo.values.toSet should contain (nodeInfo)
+    discoveryPeerManager.underlyingActor.nodesInfo.values.toSet should contain (nodeInfo.copy(addTimestamp = 0))
   }
 
   it should "correctly respond to FindNode Message" in new TestSetup {

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -103,7 +103,7 @@ class PeerActorSpec extends FlatSpec with Matchers {
 
   it should "successfully connect to ETC peer" in new TestSetup {
     val uri = new URI(s"enode://${Hex.toHexString(remoteNodeId.toArray[Byte])}@localhost:9000")
-    val completeUri = new URI(s"enode://${Hex.toHexString(remoteNodeId.toArray[Byte])}@127.0.0.1:9000")
+    val completeUri = new URI(s"enode://${Hex.toHexString(remoteNodeId.toArray[Byte])}@127.0.0.1:9000?discport=9000")
     peer ! PeerActor.ConnectTo(uri)
     peer ! PeerActor.ConnectTo(uri)
 
@@ -140,7 +140,7 @@ class PeerActorSpec extends FlatSpec with Matchers {
 
   it should "successfully connect to and IPv6 peer" in new TestSetup {
     val uri = new URI(s"enode://${Hex.toHexString(remoteNodeId.toArray[Byte])}@[::]:9000")
-    val completeUri = new URI(s"enode://${Hex.toHexString(remoteNodeId.toArray[Byte])}@[0:0:0:0:0:0:0:0]:9000")
+    val completeUri = new URI(s"enode://${Hex.toHexString(remoteNodeId.toArray[Byte])}@[0:0:0:0:0:0:0:0]:9000?discport=9000")
     peer ! PeerActor.ConnectTo(uri)
 
     rlpxConnection.expectMsgClass(classOf[RLPxConnectionHandler.ConnectTo])


### PR DESCRIPTION
Now each peer can have udp and tcp ports specified separatly.

The logic of discovery needed to be changed, as the only way to get udp and tcp ports separately is from `neighbours` message.

Also, there are some minor changes that should help with bug that some times our discovery is stuck at some nodes count and wont progress because it missed one or more good peers. (it can still happen but it is rarer from my several runs)