### PR TITLE
[EC-522] Make fastSync more resisilent to failures

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -132,10 +132,10 @@ class FastSync(
         requestedHeaders.get(peer).foreach{ requestedNum =>
           removeRequestHandler(sender())
           requestedHeaders -= peer
-          if (blockHeaders.size <= requestedNum)
+          if (blockHeaders.nonEmpty && blockHeaders.size <= requestedNum && blockHeaders.head.number == syncState.bestBlockHeaderNumber + 1)
             handleBlockHeaders(peer, blockHeaders)
           else
-            blacklist(peer.id, blacklistDuration, "wrong number of headers in response")
+            blacklist(peer.id, blacklistDuration, "wrong blockheaders response (empty or not chain forming)")
         }
 
       case ResponseReceived(peer, BlockBodies(blockBodies), timeTaken) =>


### PR DESCRIPTION
Handling of two cases:
1. Handle the case when we are constantly receiving 0 headers from one peer. As we are choosing our blockheader peer as first free peer, it could happen that we will ask headers from a peer which constantly send us 0, it can greatly impair our syncing.
2. Handle case when peer will send us header from the future e.g our best block is `10` and we requested blocks from `11` to `20`, and peer sends us block/blocks which start from block `5000`.  Of course, this block will fail validation, but it will change our best block to `5000 - N - 1`. Currently `N` is equal to `2048` so our best block number would be `2951` which is obviously incorrect.
We are always asking our peers for headers from `bestBlock + 1`, so if we receive some headers from beyond that we can assume something is wrong: maybe malicious peer, maybe some error on another peer side, or we have some hidden bug in our code (i could not find any suspicious)