### PR TITLE
fix: update docker image version for scheduled ETS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 
   full_ETS:
     docker:
-      - image: rtkaczyk/mantis-circleci:v4
+      - image: rtkaczyk/mantis-circleci:v6
     steps:
       - checkout
 


### PR DESCRIPTION
(cheery picked from `phase/iele` branch