### PR TITLE
Riemann poc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val commonSettings = Seq(
 
 // Temp resolver for LevelDB fork
 resolvers += "stepsoft" at "http://nexus.mcsherrylabs.com/repository/releases/"
+resolvers += "Clojars" at "http://clojars.org/repo"
 
 val dep = {
   val akkaVersion = "2.4.17"
@@ -54,6 +55,7 @@ val dep = {
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
     "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.0.0",
     "com.twitter" %% "util-collection" % "18.4.0",
+    "com.googlecode.protobuf-java-format" % "protobuf-java-format" % "1.4",
 
     // Pluggable Consensus: AtomixRaft
     "io.atomix" % "atomix" % "2.1.0-beta1",
@@ -73,7 +75,8 @@ val dep = {
     // Metrics (Datadog export)
     "io.micrometer" % "micrometer-registry-statsd" % micrometerVersion,
     "io.projectreactor" % "reactor-core" % reactorCoreVersion,
-    "io.projectreactor.ipc" % "reactor-netty" % reactorNettyVersion
+    "io.projectreactor.ipc" % "reactor-netty" % reactorNettyVersion,
+    "io.riemann" % "riemann-java-client" % "0.4.6"
   )
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -28,17 +28,17 @@ mantis {
   # Uncomment this to specify, otherwise use the default implementation
   # secure-random-algo = "NativePRNG"
 
-  network {
+  # riemann {
+  #   host = "localhost"
+  #   port = 5555
+  #   buffer-size = 1000
+  #   batch-size = 10
+  #   auto-flush-ms = 1000
+  #   # optional hostname to send to Riemann server, if not provided the client will use InetAddress.getLocalHost().getHostName()
+  #   # host-name = "my-node"
+  # }
 
-    # riemann {
-    #   host = "localhost"
-    #   port = 5555
-    #   buffer-size = 1000
-    #   batch-size = 10
-    #   auto-flush-ms = 1000
-    #   # optional hostname to send to Riemann server, if not provided the client will use InetAddress.getLocalHost().getHostName()
-    #   # host-name = "my-node"
-    # }
+  network {
 
     # Ethereum protocol version
     protocol-version = 63

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 mantis {
+
   # Identifier used when connecting to other clients
   client-id = "mantis"
 
@@ -28,6 +29,17 @@ mantis {
   # secure-random-algo = "NativePRNG"
 
   network {
+
+    # riemann {
+    #   host = "localhost"
+    #   port = 5555
+    #   buffer-size = 1000
+    #   batch-size = 10
+    #   auto-flush-ms = 1000
+    #   # optional hostname to send to Riemann server, if not provided the client will use InetAddress.getLocalHost().getHostName()
+    #   # host-name = "my-node"
+    # }
+
     # Ethereum protocol version
     protocol-version = 63
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -14,7 +14,6 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.rlp.RLPImplicits._
-import io.iohk.ethereum.utils.ToRiemann._
 import io.iohk.ethereum.utils.Riemann
 import org.json4s.{CustomSerializer, DefaultFormats, Formats, JString, JValue}
 import org.spongycastle.util.encoders.Hex

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -48,18 +48,18 @@ class GenesisDataLoader(
           Try(Source.fromResource(customGenesisFile))
         } match {
           case Success(customGenesis) =>
-            Riemann.ok("genesis loading").attribute("file", customGenesisFile)
+            Riemann.ok("genesis loading").attribute("file", customGenesisFile).send
             try {
               customGenesis.getLines().mkString
             } finally {
               customGenesis.close()
             }
           case Failure(ex) =>
-            Riemann.exception("genesis loading", ex).attribute("file", customGenesisFile)
+            Riemann.exception("genesis loading", ex).attribute("file", customGenesisFile).send
             throw ex
         }
       case None =>
-        Riemann.ok("genesis loading")
+        Riemann.ok("genesis loading").send
         val src = Source.fromResource("blockchain/default-genesis.json")
         try {
           src.getLines().mkString
@@ -70,9 +70,9 @@ class GenesisDataLoader(
 
     loadGenesisData(genesisJson) match {
       case Success(_) =>
-        Riemann.ok("genesis loaded")
+        Riemann.ok("genesis loaded").send
       case Failure(ex) =>
-        Riemann.exception("genesis loaded", ex)
+        Riemann.exception("genesis loaded", ex).send
         throw ex
     }
   }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -16,6 +16,8 @@ import io.iohk.ethereum.network.p2p.messages.PV63.MptNodeEncoders._
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.PV63._
 import io.iohk.ethereum.network.Peer
+import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.ToRiemann._
 import io.iohk.ethereum.utils.Config.SyncConfig
 import org.spongycastle.util.encoders.Hex
 
@@ -107,12 +109,12 @@ class FastSync(
     //Delay before starting to persist snapshot. It should be 0, as the presence of it marks that fast sync was started
     private val persistStateSnapshotDelay: FiniteDuration = 0.seconds
     private val syncStatePersistCancellable = scheduler.schedule(persistStateSnapshotDelay, persistStateSnapshotInterval, self, PersistSyncState)
-    private val printStatusCancellable = scheduler.schedule(printStatusInterval, printStatusInterval, self, PrintStatus)
+    private val reportStatusCancellable = scheduler.schedule(reportStatusInterval, reportStatusInterval, self, PrintStatus)
     private val heartBeat = scheduler.schedule(syncRetryInterval, syncRetryInterval * 2, self, ProcessSyncing)
 
     def receive: Receive = handleCommonMessages orElse {
       case ProcessSyncing => processSyncing()
-      case PrintStatus => printStatus()
+      case PrintStatus => reportStatus()
       case PersistSyncState => persistSyncState()
 
       case ResponseReceived(peer, BlockHeaders(blockHeaders), timeTaken) =>
@@ -432,19 +434,16 @@ class FastSync(
       }
     }
 
-    private def printStatus() = {
-      val formatPeer: (Peer) => String = peer => s"${peer.remoteAddress.getAddress.getHostAddress}:${peer.remoteAddress.getPort}"
-      log.info(
-        s"""|Block: ${appStateStorage.getBestBlockNumber()}/${initialSyncState.targetBlock.number}.
-            |Peers waiting_for_response/connected: ${assignedHandlers.size}/${handshakedPeers.size} (${blacklistedPeers.size} blacklisted).
-            |State: ${syncState.downloadedNodesCount}/${syncState.totalNodesCount} nodes.
-            |""".stripMargin.replace("\n", " "))
-      log.debug(
-        s"""|Connection status: connected(${assignedHandlers.values.map(formatPeer).toSeq.sorted.mkString(", ")})/
-            |handshaked(${handshakedPeers.keys.map(formatPeer).toSeq.sorted.mkString(", ")})
-            | blacklisted(${blacklistedPeers.map { case (id, _) => id.value }.mkString(", ")})
-            |""".stripMargin.replace("\n", " ")
-      )
+    private def reportStatus() = {
+      Riemann.ok("block number").metric(appStateStorage.getBestBlockNumber().longValue).send()
+      Riemann.ok("block target").metric(initialSyncState.targetBlock.number.longValue).send()
+      Riemann.ok("peers waiting").metric(assignedHandlers.size).send()
+      Riemann.ok("peers connected").metric(handshakedPeers.size).send()
+      Riemann.ok("nodes downloaded").metric(syncState.downloadedNodesCount).send()
+      Riemann.ok("nodes total").metric(syncState.totalNodesCount).send()
+      assignedHandlers.values.map { peer => peer.toRiemann.service("peer connected").send() }
+      handshakedPeers.keys.map { peer => peer.toRiemann.service("peer handshaked").send() }
+      blacklistedPeers.map { case (id, _) => id.toRiemann.service("peer blacklisted").send() }
     }
 
     private def insertBlocks(requestedHashes: Seq[ByteString], blockBodies: Seq[BlockBody]): Unit = {
@@ -482,7 +481,7 @@ class FastSync(
     def cleanup(): Unit = {
       heartBeat.cancel()
       syncStatePersistCancellable.cancel()
-      printStatusCancellable.cancel()
+      reportStatusCancellable.cancel()
       syncStateStorageActor ! PoisonPill
       fastSyncStateStorage.purge()
     }
@@ -490,9 +489,9 @@ class FastSync(
     def processDownloads(): Unit = {
       if (unassignedPeers.isEmpty) {
         if (assignedHandlers.nonEmpty) {
-          log.debug("There are no available peers, waiting for responses")
+          Riemann.warning("no available peers")
         } else {
-          log.debug("There are no peers to download from, scheduling a retry in {}", syncRetryInterval)
+          Riemann.warning("no peers").attribute("retry-interval", syncRetryInterval.toString)
           scheduler.scheduleOnce(syncRetryInterval, self, ProcessSyncing)
         }
       } else {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -17,7 +17,6 @@ import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.PV63._
 import io.iohk.ethereum.network.Peer
 import io.iohk.ethereum.utils.Riemann
-import io.iohk.ethereum.utils.ToRiemann._
 import io.iohk.ethereum.utils.Config.SyncConfig
 import org.spongycastle.util.encoders.Hex
 
@@ -443,7 +442,7 @@ class FastSync(
       Riemann.ok("nodes total").metric(syncState.totalNodesCount).send()
       assignedHandlers.values.map { peer => peer.toRiemann.service("peer connected").send() }
       handshakedPeers.keys.map { peer => peer.toRiemann.service("peer handshaked").send() }
-      blacklistedPeers.map { case (id, _) => id.toRiemann.service("peer blacklisted").send() }
+      blacklistedPeers.map { case (id, _) => Riemann.ok("peer blacklisted").attribute("id", id.value).send() }
     }
 
     private def insertBlocks(requestedHashes: Seq[ByteString], blockBodies: Seq[BlockBody]): Unit = {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -434,15 +434,15 @@ class FastSync(
     }
 
     private def reportStatus() = {
-      Riemann.ok("block number").metric(appStateStorage.getBestBlockNumber().longValue).send()
-      Riemann.ok("block target").metric(initialSyncState.targetBlock.number.longValue).send()
-      Riemann.ok("peers waiting").metric(assignedHandlers.size).send()
-      Riemann.ok("peers connected").metric(handshakedPeers.size).send()
-      Riemann.ok("nodes downloaded").metric(syncState.downloadedNodesCount).send()
-      Riemann.ok("nodes total").metric(syncState.totalNodesCount).send()
-      assignedHandlers.values.map { peer => peer.toRiemann.service("peer connected").send() }
-      handshakedPeers.keys.map { peer => peer.toRiemann.service("peer handshaked").send() }
-      blacklistedPeers.map { case (id, _) => Riemann.ok("peer blacklisted").attribute("id", id.value).send() }
+      Riemann.ok("block number").metric(appStateStorage.getBestBlockNumber().longValue).send
+      Riemann.ok("block target").metric(initialSyncState.targetBlock.number.longValue).send
+      Riemann.ok("peers waiting").metric(assignedHandlers.size).send
+      Riemann.ok("peers connected").metric(handshakedPeers.size).send
+      Riemann.ok("nodes downloaded").metric(syncState.downloadedNodesCount).send
+      Riemann.ok("nodes total").metric(syncState.totalNodesCount).send
+      assignedHandlers.values.map { peer => peer.toRiemann.service("peer connected").send }
+      handshakedPeers.keys.map { peer => peer.toRiemann.service("peer handshaked").send }
+      blacklistedPeers.map { case (id, _) => Riemann.ok("peer blacklisted").attribute("id", id.value).send }
     }
 
     private def insertBlocks(requestedHashes: Seq[ByteString], blockBodies: Seq[BlockBody]): Unit = {
@@ -488,9 +488,9 @@ class FastSync(
     def processDownloads(): Unit = {
       if (unassignedPeers.isEmpty) {
         if (assignedHandlers.nonEmpty) {
-          Riemann.warning("no available peers")
+          Riemann.warning("no available peers").send
         } else {
-          Riemann.warning("no peers").attribute("retry-interval", syncRetryInterval.toString)
+          Riemann.warning("no peers").attribute("retry-interval", syncRetryInterval.toString).send
           scheduler.scheduleOnce(syncRetryInterval, self, ProcessSyncing)
         }
       } else {

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftForger.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftForger.scala
@@ -14,6 +14,7 @@ import io.iohk.ethereum.metrics.Metrics
 import io.iohk.ethereum.nodebuilder.Node
 import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransactionsResponse
+import io.iohk.ethereum.utils.Riemann
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -85,6 +86,10 @@ class AtomixRaftForger(
   private def syncTheBlock(block: Block): Unit = {
     if(isLeader) {
       log.info(s"***** Forged block ${block.idTag}")
+      Riemann.ok("block forge")
+        .metric(block.header.number.longValue)
+        .attribute("number", block.header.number.toString)
+        .attribute("id-tag", block.idTag).send
 
       syncController ! RegularSync.MinedBlock(block)
 

--- a/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
@@ -6,6 +6,7 @@ import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
 import io.iohk.ethereum.rlp.{RLPList, encode => rlpEncode}
 import io.iohk.ethereum.utils.ToRiemann
 import io.iohk.ethereum.utils.Riemann
+import io.riemann.riemann.client.EventDSL
 import org.spongycastle.util.encoders.Hex
 
 case class BlockHeader(
@@ -23,7 +24,7 @@ case class BlockHeader(
     unixTimestamp: Long,
     extraData: ByteString,
     mixHash: ByteString,
-    nonce: ByteString) {
+    nonce: ByteString) extends ToRiemann {
 
   override def toString: String = {
     s"""BlockHeader {
@@ -44,6 +45,23 @@ case class BlockHeader(
        |nonce: ${Hex.toHexString(nonce.toArray[Byte])}
        |}""".stripMargin
   }
+
+
+  override def toRiemann: EventDSL =
+    Riemann.ok("blockheader")
+      .attribute("parentHash", Hex.toHexString(parentHash.toArray[Byte]))
+      .attribute("ommersHash", Hex.toHexString(ommersHash.toArray[Byte]))
+      .attribute("beneficiary", Hex.toHexString(beneficiary.toArray[Byte]))
+      .attribute("stateRoot", Hex.toHexString(stateRoot.toArray[Byte]))
+      .attribute("transactionsRoot", Hex.toHexString(transactionsRoot.toArray[Byte]))
+      .attribute("receiptsRoot", Hex.toHexString(receiptsRoot.toArray[Byte]))
+      .attribute("logsBloom", Hex.toHexString(logsBloom.toArray[Byte]))
+      .attribute("difficulty", difficulty.toString)
+      .attribute("number", number.toString)
+      .attribute("gasLimit", gasLimit.toString)
+      .attribute("gasUsed", gasUsed.toString)
+      .attribute("unixTimestamp", unixTimestamp.toString)
+      .attribute("extraData", Hex.toHexString(extraData.toArray[Byte]))
 
   /**
     * calculates blockHash for given block header
@@ -67,20 +85,4 @@ object BlockHeader {
     }
     rlpEncode(rlpEncoded)
   }
-
-  implicit val blockHeaderToRiemann: ToRiemann[BlockHeader] =
-    header => Riemann.ok("blockheader")
-      .attribute("parentHash", Hex.toHexString(header.parentHash.toArray[Byte]))
-      .attribute("ommersHash", Hex.toHexString(header.ommersHash.toArray[Byte]))
-      .attribute("beneficiary", Hex.toHexString(header.beneficiary.toArray[Byte]))
-      .attribute("stateRoot", Hex.toHexString(header.stateRoot.toArray[Byte]))
-      .attribute("transactionsRoot", Hex.toHexString(header.transactionsRoot.toArray[Byte]))
-      .attribute("receiptsRoot", Hex.toHexString(header.receiptsRoot.toArray[Byte]))
-      .attribute("logsBloom", Hex.toHexString(header.logsBloom.toArray[Byte]))
-      .attribute("difficulty", header.difficulty.toString)
-      .attribute("number", header.number.toString)
-      .attribute("gasLimit", header.gasLimit.toString)
-      .attribute("gasUsed", header.gasUsed.toString)
-      .attribute("unixTimestamp", header.unixTimestamp.toString)
-      .attribute("extraData", Hex.toHexString(header.extraData.toArray[Byte]))
 }

--- a/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
@@ -4,6 +4,8 @@ import akka.util.ByteString
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockHeaderImplicits._
 import io.iohk.ethereum.rlp.{RLPList, encode => rlpEncode}
+import io.iohk.ethereum.utils.ToRiemann
+import io.iohk.ethereum.utils.Riemann
 import org.spongycastle.util.encoders.Hex
 
 case class BlockHeader(
@@ -53,6 +55,7 @@ case class BlockHeader(
 
   def idTag: String =
     s"$number: $hashAsHexString"
+
 }
 
 object BlockHeader {
@@ -64,4 +67,20 @@ object BlockHeader {
     }
     rlpEncode(rlpEncoded)
   }
+
+  implicit val blockHeaderToRiemann: ToRiemann[BlockHeader] =
+    header => Riemann.ok("blockheader")
+      .attribute("parentHash", Hex.toHexString(header.parentHash.toArray[Byte]))
+      .attribute("ommersHash", Hex.toHexString(header.ommersHash.toArray[Byte]))
+      .attribute("beneficiary", Hex.toHexString(header.beneficiary.toArray[Byte]))
+      .attribute("stateRoot", Hex.toHexString(header.stateRoot.toArray[Byte]))
+      .attribute("transactionsRoot", Hex.toHexString(header.transactionsRoot.toArray[Byte]))
+      .attribute("receiptsRoot", Hex.toHexString(header.receiptsRoot.toArray[Byte]))
+      .attribute("logsBloom", Hex.toHexString(header.logsBloom.toArray[Byte]))
+      .attribute("difficulty", header.difficulty.toString)
+      .attribute("number", header.number.toString)
+      .attribute("gasLimit", header.gasLimit.toString)
+      .attribute("gasUsed", header.gasUsed.toString)
+      .attribute("unixTimestamp", header.unixTimestamp.toString)
+      .attribute("extraData", Hex.toHexString(header.extraData.toArray[Byte]))
 }

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -5,9 +5,9 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.handshaker.Handshaker.NextMessage
 import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.Versions
-import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Capability, Disconnect, Hello}
+import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Capability, Disconnect, Hello, helloToRiemann}
 import io.iohk.ethereum.utils.{Config, Logger, ServerStatus}
-
+import io.iohk.ethereum.utils.ToRiemann._
 
 case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfiguration) extends InProgressState[PeerInfo] with Logger {
 
@@ -24,7 +24,7 @@ case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfigura
   override def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = {
 
     case hello: Hello =>
-      log.debug("Protocol handshake finished with peer ({})", hello)
+      hello.toRiemann.description("Protocol handshake finished").send
       if (hello.capabilities.contains(Capability("eth", Versions.PV63.toByte)))
         EtcNodeStatusExchangeState(handshakerConfiguration)
       else {

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -5,9 +5,8 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.handshaker.Handshaker.NextMessage
 import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.Versions
-import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Capability, Disconnect, Hello, helloToRiemann}
+import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Capability, Disconnect, Hello}
 import io.iohk.ethereum.utils.{Config, Logger, ServerStatus}
-import io.iohk.ethereum.utils.ToRiemann._
 
 case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfiguration) extends InProgressState[PeerInfo] with Logger {
 

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
@@ -9,7 +9,6 @@ import io.iohk.ethereum.network.p2p.messages.Versions
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect.Reasons
 import io.iohk.ethereum.utils.Logger
-import io.iohk.ethereum.utils.ToRiemann._
 
 case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConfiguration) extends InProgressState[PeerInfo] with Logger {
 

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
@@ -4,10 +4,12 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.handshaker.Handshaker.NextMessage
 import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
+import io.iohk.ethereum.network.p2p.messages.CommonMessages._
 import io.iohk.ethereum.network.p2p.messages.Versions
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect.Reasons
 import io.iohk.ethereum.utils.Logger
+import io.iohk.ethereum.utils.ToRiemann._
 
 case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConfiguration) extends InProgressState[PeerInfo] with Logger {
 
@@ -58,7 +60,7 @@ case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConf
       totalDifficulty = totalDifficulty,
       bestHash = bestBlockHeader.hash,
       genesisHash = blockchain.genesisHeader.hash)
-    log.debug(s"sending status $status")
+    status.toRiemann.send
     status
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/p2p/Message.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/Message.scala
@@ -2,6 +2,8 @@ package io.iohk.ethereum.network.p2p
 
 import akka.util.ByteString
 import io.iohk.ethereum.network.p2p.Message.Version
+import io.iohk.ethereum.utils.ToRiemann
+import io.riemann.riemann.client.EventDSL
 
 import scala.util.Try
 
@@ -9,7 +11,7 @@ object Message {
   type Version = Int
 }
 
-trait Message {
+trait Message extends ToRiemann {
   def code: Int
 }
 
@@ -21,6 +23,8 @@ trait MessageSerializable extends Message {
   def toBytes: Array[Byte]
 
   def underlyingMsg: Message
+
+  override def toRiemann: EventDSL = underlyingMsg.toRiemann
 
 }
 

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
@@ -8,6 +8,8 @@ import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
 import io.iohk.ethereum.utils.{BlockchainConfig, Config}
 import org.spongycastle.util.encoders.Hex
+import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.ToRiemann
 
 
 object CommonMessages {
@@ -44,7 +46,16 @@ object CommonMessages {
          |genesisHash: ${Hex.toHexString(genesisHash.toArray[Byte])}
          |}""".stripMargin
     }
+
   }
+
+  implicit val statusToRiemann: ToRiemann[Status] =
+    status => Riemann.ok("node status")
+      .attribute("protocolVersion", status.protocolVersion.toString)
+      .attribute("networkId", status.networkId.toString)
+      .attribute("totalDifficulty", status.totalDifficulty.toString)
+      .attribute("bestHash", Hex.toHexString(status.bestHash.toArray[Byte]))
+      .attribute("genesisHash", Hex.toHexString(status.genesisHash.toArray[Byte]))
 
   object SignedTransactions {
 

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/CommonMessages.scala
@@ -9,7 +9,7 @@ import io.iohk.ethereum.rlp._
 import io.iohk.ethereum.utils.{BlockchainConfig, Config}
 import org.spongycastle.util.encoders.Hex
 import io.iohk.ethereum.utils.Riemann
-import io.iohk.ethereum.utils.ToRiemann
+import io.riemann.riemann.client.EventDSL
 
 
 object CommonMessages {
@@ -47,15 +47,15 @@ object CommonMessages {
          |}""".stripMargin
     }
 
-  }
+    override def toRiemann: EventDSL =
+      Riemann.ok("node status")
+        .attribute("protocolVersion", protocolVersion.toString)
+        .attribute("networkId", networkId.toString)
+        .attribute("totalDifficulty", totalDifficulty.toString)
+        .attribute("bestHash", Hex.toHexString(bestHash.toArray[Byte]))
+        .attribute("genesisHash", Hex.toHexString(genesisHash.toArray[Byte]))
 
-  implicit val statusToRiemann: ToRiemann[Status] =
-    status => Riemann.ok("node status")
-      .attribute("protocolVersion", status.protocolVersion.toString)
-      .attribute("networkId", status.networkId.toString)
-      .attribute("totalDifficulty", status.totalDifficulty.toString)
-      .attribute("bestHash", Hex.toHexString(status.bestHash.toArray[Byte]))
-      .attribute("genesisHash", Hex.toHexString(status.genesisHash.toArray[Byte]))
+  }
 
   object SignedTransactions {
 
@@ -108,6 +108,9 @@ object CommonMessages {
 
   case class SignedTransactions(txs: Seq[SignedTransaction]) extends Message {
     override def code: Int = SignedTransactions.code
+    override def toRiemann: EventDSL =
+      Riemann.ok("signedtransactions")
+        .metric(code)
   }
 
   object NewBlock {
@@ -163,5 +166,10 @@ object CommonMessages {
          |totalDifficulty: $totalDifficulty
          |}""".stripMargin
     }
+    override def toRiemann: EventDSL =
+      Riemann.ok("new block")
+        .attribute("totalDifficulty", totalDifficulty.toString)
+        .attribute("block", block.toString)
+
   }
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV61.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV61.scala
@@ -5,6 +5,8 @@ import io.iohk.ethereum.network.p2p.{Message, MessageSerializableImplicit}
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
+import io.riemann.riemann.client.EventDSL
+import io.iohk.ethereum.utils.Riemann
 
 object PV61 {
 
@@ -30,6 +32,7 @@ object PV61 {
 
   case class NewBlockHashes(hashes: Seq[ByteString]) extends Message {
     override def code: Int = NewBlockHashes.code
+    override def toRiemann: EventDSL = Riemann.ok("new block hashes").metric(code).attribute("type", "PV61")
   }
 
   object BlockHashesFromNumber {
@@ -54,6 +57,10 @@ object PV61 {
 
   case class BlockHashesFromNumber(number: BigInt, maxBlocks: BigInt) extends Message {
     override def code: Int = BlockHashesFromNumber.code
+    override def toRiemann: EventDSL = Riemann.ok("block hashes from number")
+      .metric(code)
+      .attribute("number", number.toString)
+      .attribute("maxBlocks", maxBlocks.toString)
   }
 
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV62.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV62.scala
@@ -7,6 +7,8 @@ import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.{RLPList, _}
 import org.spongycastle.util.encoders.Hex
+import io.riemann.riemann.client.EventDSL
+import io.iohk.ethereum.utils.Riemann
 
 object PV62 {
   object BlockHash {
@@ -61,6 +63,7 @@ object PV62 {
 
   case class NewBlockHashes(hashes: Seq[BlockHash]) extends Message {
     override def code: Int = NewBlockHashes.code
+    override def toRiemann: EventDSL = Riemann.ok("new block hashes").metric(code).attribute("type", "PV62")
   }
 
   object GetBlockHeaders {
@@ -106,6 +109,12 @@ object PV62 {
           |}
      """.stripMargin
     }
+    override def toRiemann: EventDSL = Riemann.ok("get block headers")
+      .metric(code)
+      .attribute("block", block.fold(a => a, b => Hex.toHexString(b.toArray[Byte])).toString)
+      .attribute("maxHeaders", maxHeaders.toString)
+      .attribute("skip", skip.toString)
+      .attribute("reverse", reverse.toString)
   }
 
   object BlockHeaderImplicits {
@@ -224,6 +233,7 @@ object PV62 {
 
   case class BlockBodies(bodies: Seq[BlockBody]) extends Message {
     val code: Int = BlockBodies.code
+    override def toRiemann: EventDSL = Riemann.ok("block bodies").metric(code)
   }
 
   object BlockHeaders {
@@ -252,6 +262,7 @@ object PV62 {
 
   case class BlockHeaders(headers: Seq[BlockHeader]) extends Message {
     override def code: Int = BlockHeaders.code
+    override def toRiemann: EventDSL = Riemann.ok("block headers").metric(code)
   }
 
   object GetBlockBodies {
@@ -284,5 +295,8 @@ object PV62 {
          |}
      """.stripMargin
     }
+    override def toRiemann: EventDSL = Riemann.ok("get block bodies")
+      .metric(code)
+      .attribute("hashes", hashes.map(h => Hex.toHexString(h.toArray[Byte])).toString)
   }
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV63.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/PV63.scala
@@ -8,8 +8,8 @@ import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
 import org.spongycastle.util.encoders.Hex
-
-
+import io.riemann.riemann.client.EventDSL
+import io.iohk.ethereum.utils.Riemann
 
 object PV63 {
 
@@ -40,6 +40,9 @@ object PV63 {
          |}
        """.stripMargin
     }
+    override def toRiemann: EventDSL = Riemann.ok("get node data")
+      .metric(code)
+      .attribute("hashes", mptElementsHashes.map(e => Hex.toHexString(e.toArray[Byte])).toString)
   }
 
   object AccountImplicits {
@@ -115,6 +118,9 @@ object PV63 {
          |}
        """.stripMargin
     }
+    override def toRiemann: EventDSL = Riemann.ok("block headers")
+      .metric(code)
+      .attribute("values", values.map(b => Hex.toHexString(b.toArray[Byte])).toString)
   }
 
   object GetReceipts {
@@ -143,6 +149,9 @@ object PV63 {
          |}
        """.stripMargin
     }
+    override def toRiemann: EventDSL = Riemann.ok("get receipts")
+      .metric(code)
+      .attribute("blockHashes", blockHashes.map(e => Hex.toHexString(e.toArray[Byte])).toString)
   }
 
   object TxLogEntryImplicits {
@@ -243,5 +252,6 @@ object PV63 {
 
   case class Receipts(receiptsForBlocks: Seq[Seq[Receipt]]) extends Message {
     override def code: Int = Receipts.code
+    override def toRiemann: EventDSL = Riemann.ok("receipts").metric(code)
   }
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/WireProtocol.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/WireProtocol.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
 import org.spongycastle.util.encoders.Hex
-import io.iohk.ethereum.utils.ToRiemann
+import io.riemann.riemann.client.EventDSL
 import io.iohk.ethereum.utils.Riemann
 
 object WireProtocol {
@@ -76,15 +76,16 @@ object WireProtocol {
          |nodeId: ${Hex.toHexString(nodeId.toArray[Byte])}
          |}""".stripMargin
     }
-  }
 
-  implicit val helloToRiemann: ToRiemann[Hello] =
-    hello => Riemann.ok("protocol hello")
-      .attribute("p2pVersion", hello.p2pVersion.toString)
-      .attribute("clientId", hello.clientId.toString)
-      .attribute("capabilities", hello.capabilities.toString)
-      .attribute("listenPort", hello.listenPort.toString)
-      .attribute("nodeId", Hex.toHexString(hello.nodeId.toArray[Byte]).toString)
+    override def toRiemann: EventDSL = {
+      Riemann.ok("protocol hello")
+        .attribute("p2pVersion", p2pVersion.toString)
+        .attribute("clientId", clientId.toString)
+        .attribute("capabilities", capabilities.toString)
+        .attribute("listenPort", listenPort.toString)
+        .attribute("nodeId", Hex.toHexString(nodeId.toArray[Byte]).toString)
+    }
+  }
 
   object Disconnect {
     object Reasons {
@@ -141,6 +142,10 @@ object WireProtocol {
 
       s"Disconnect($message)"
     }
+    override def toRiemann: EventDSL = {
+      Riemann.ok("protocol disconnect")
+        .attribute("reason", this.toString)
+    }
   }
 
   object Ping {
@@ -160,6 +165,10 @@ object WireProtocol {
 
   case class Ping() extends Message {
     override val code: Int = Ping.code
+    override def toRiemann: EventDSL = {
+      Riemann.ok("protocol ping")
+        .metric(code)
+    }
   }
 
   object Pong {
@@ -179,6 +188,10 @@ object WireProtocol {
 
   case class Pong() extends Message {
     override val code: Int = Pong.code
+    override def toRiemann: EventDSL = {
+      Riemann.ok("protocol pong")
+        .metric(code)
+    }
   }
 
 }

--- a/src/main/scala/io/iohk/ethereum/network/p2p/messages/WireProtocol.scala
+++ b/src/main/scala/io/iohk/ethereum/network/p2p/messages/WireProtocol.scala
@@ -7,6 +7,8 @@ import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp._
 import org.spongycastle.util.encoders.Hex
+import io.iohk.ethereum.utils.ToRiemann
+import io.iohk.ethereum.utils.Riemann
 
 object WireProtocol {
 
@@ -75,6 +77,14 @@ object WireProtocol {
          |}""".stripMargin
     }
   }
+
+  implicit val helloToRiemann: ToRiemann[Hello] =
+    hello => Riemann.ok("protocol hello")
+      .attribute("p2pVersion", hello.p2pVersion.toString)
+      .attribute("clientId", hello.clientId.toString)
+      .attribute("capabilities", hello.capabilities.toString)
+      .attribute("listenPort", hello.listenPort.toString)
+      .attribute("nodeId", Hex.toHexString(hello.nodeId.toArray[Byte]).toString)
 
   object Disconnect {
     object Reasons {

--- a/src/main/scala/io/iohk/ethereum/network/peer.scala
+++ b/src/main/scala/io/iohk/ethereum/network/peer.scala
@@ -3,9 +3,26 @@ package io.iohk.ethereum.network
 import java.net.InetSocketAddress
 
 import akka.actor.ActorRef
+import io.iohk.ethereum.utils.ToRiemann
+import io.iohk.ethereum.utils.Riemann
 
 case class PeerId(value: String) extends AnyVal
 
+object PeerId {
+  implicit val peerIdToRiemann: ToRiemann[PeerId] =
+    peerId => Riemann.ok("peer-id").attribute("id", peerId.value)
+}
+
 case class Peer(remoteAddress: InetSocketAddress, ref: ActorRef, incomingConnection: Boolean) {
   def id: PeerId = PeerId(ref.path.name)
+}
+
+object Peer {
+
+  implicit val peerToRiemann: ToRiemann[Peer] =
+    peer => Riemann.ok("peer")
+      .attribute("remote-host", peer.remoteAddress.getAddress.getHostAddress)
+      .attribute("remote-port", peer.remoteAddress.getPort.toString)
+      .attribute("incoming-connection", peer.incomingConnection.toString)
+
 }

--- a/src/main/scala/io/iohk/ethereum/network/peer.scala
+++ b/src/main/scala/io/iohk/ethereum/network/peer.scala
@@ -5,24 +5,15 @@ import java.net.InetSocketAddress
 import akka.actor.ActorRef
 import io.iohk.ethereum.utils.ToRiemann
 import io.iohk.ethereum.utils.Riemann
+import io.riemann.riemann.client.EventDSL
 
 case class PeerId(value: String) extends AnyVal
 
-object PeerId {
-  implicit val peerIdToRiemann: ToRiemann[PeerId] =
-    peerId => Riemann.ok("peer-id").attribute("id", peerId.value)
-}
-
-case class Peer(remoteAddress: InetSocketAddress, ref: ActorRef, incomingConnection: Boolean) {
+case class Peer(remoteAddress: InetSocketAddress, ref: ActorRef, incomingConnection: Boolean) extends ToRiemann {
   def id: PeerId = PeerId(ref.path.name)
-}
-
-object Peer {
-
-  implicit val peerToRiemann: ToRiemann[Peer] =
-    peer => Riemann.ok("peer")
-      .attribute("remote-host", peer.remoteAddress.getAddress.getHostAddress)
-      .attribute("remote-port", peer.remoteAddress.getPort.toString)
-      .attribute("incoming-connection", peer.incomingConnection.toString)
-
+  override def toRiemann: EventDSL =
+    Riemann.ok("peer")
+      .attribute("remote-host", remoteAddress.getAddress.getHostAddress)
+      .attribute("remote-port", remoteAddress.getPort.toString)
+      .attribute("incoming-connection", incomingConnection.toString)
 }

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -46,22 +46,22 @@ object Config {
 
   val secureRandomAlgo: Option[String] = getOptionalString(config, "secure-random-algo")
 
+  val riemann = getOptionalConfig(config, "riemann") match {
+    case None => None
+    case Some(riemannConfig) => Some(new RiemannConfiguration(
+                                       riemannConfig.getString("host"),
+                                       riemannConfig.getInt("port"),
+                                       riemannConfig.getInt("batch-size"),
+                                       riemannConfig.getInt("buffer-size"),
+                                       riemannConfig.getInt("auto-flush-ms"),
+                                       getOptionalString(riemannConfig, "host-name").getOrElse(InetAddress.getLocalHost().getHostName())
+                                     ))
+  }
+
   object Network {
     private val networkConfig = config.getConfig("network")
 
     val protocolVersion = networkConfig.getInt("protocol-version")
-
-    val riemann = getOptionalConfig(networkConfig, "riemann") match {
-      case None => None
-      case Some(riemannConfig) => Some(new RiemannConfiguration(
-        riemannConfig.getString("host"),
-        riemannConfig.getInt("port"),
-        riemannConfig.getInt("batch-size"),
-        riemannConfig.getInt("buffer-size"),
-        riemannConfig.getInt("auto-flush-ms"),
-        getOptionalString(riemannConfig, "host-name").getOrElse(InetAddress.getLocalHost().getHostName())
-      ))
-    }
 
     object Server {
       private val serverConfig = networkConfig.getConfig("server-address")

--- a/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
@@ -259,14 +259,6 @@ class RiemannStdoutClient extends IRiemannClient {
 
 }
 
-trait ToRiemann[A] {
-  def toRiemann(a: A): EventDSL
-}
-
-object ToRiemann {
-  def apply[A](implicit t: ToRiemann[A]): ToRiemann[A] = t
-
-  implicit class ToRiemannOps[A: ToRiemann](a: A) {
-    def toRiemann = ToRiemann[A].toRiemann(a)
-  }
+trait ToRiemann {
+  def toRiemann: EventDSL
 }

--- a/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
@@ -1,0 +1,272 @@
+package io.iohk.ethereum.utils
+
+import io.riemann.riemann.client.RiemannClient
+import io.riemann.riemann.client.Transport
+import io.riemann.riemann.client.EventDSL
+import io.riemann.riemann.client.IRiemannClient
+import io.riemann.riemann.client.IPromise
+import io.riemann.riemann.client.Promise
+import io.riemann.riemann.client.ChainPromise
+import io.riemann.riemann.Proto.Event
+import io.riemann.riemann.Proto.Msg
+import java.net.InetAddress
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.BlockingQueue
+import java.util.LinkedList
+import java.io.IOException
+import scala.collection.JavaConverters._
+import java.util.concurrent.Executors
+import concurrent.{ExecutionContext, Future}
+import com.googlecode.protobuf.format.FormatFactory
+
+trait Riemann extends Logger {
+
+  private val hostName = Config.Network.riemann
+    .map { c =>
+      c.hostName
+    }
+    .getOrElse(InetAddress.getLocalHost().getHostName())
+
+  private val riemannClient = {
+    log.debug("create new RiemannClient")
+    val c = {
+      Config.Network.riemann match {
+        case Some(config) => {
+          log.debug(
+            s"create new riemann batch client connecting to ${config.host}:${config.port}")
+          val client = new RiemannBatchClient(config)
+          try {
+            client.connect()
+            client
+          } catch {
+            case e: IOException =>
+              log.error(e.toString)
+              log.error(
+                "failed to create riemann batch client, falling back to stdout client")
+              new RiemannStdoutClient()
+          }
+        }
+        case None => {
+          log.debug("create new stdout riemann client")
+          new RiemannStdoutClient()
+        }
+      }
+    }
+    c.connect()
+    log.debug("riemann client connected")
+    c
+  }
+
+  def close: Unit = riemannClient.close()
+
+  def defaultEvent: EventDSL = {
+    val event = new EventDSL(riemannClient)
+    val microsenconds =
+      TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis());
+    event.time(microsenconds).host(hostName)
+  }
+
+  def ok(service: String): EventDSL = defaultEvent.state("ok").service(service)
+  def warning(service: String): EventDSL = defaultEvent.state("warning").service(service)
+  def error(service: String): EventDSL = defaultEvent.state("error").service(service)
+  def exception(service: String, t: Throwable): EventDSL = {
+    // Format message and stacktrace
+    val desc = new StringBuilder();
+    desc.append(t.toString())
+    desc.append("\n\n");
+    t.getStackTrace.map { e =>
+      desc.append(e)
+      desc.append("\n")
+    }
+    defaultEvent
+      .service(service)
+      .state("error")
+      .tag("exception")
+      .tag(t.getClass().getSimpleName())
+      .description(desc.toString())
+  }
+  def critical(service: String): EventDSL = defaultEvent.state("critical").service(service)
+
+}
+
+object Riemann extends Riemann with Logger {}
+
+class RiemannBatchClient(config: RiemannConfiguration)
+    extends IRiemannClient
+    with Logger {
+  private def promise[A](v: A): Promise[A] = {
+    val p: Promise[A] = new Promise()
+    p.deliver(v)
+    p
+  }
+  private def simpleMsg(event: Event) = {
+    val msg = Msg.newBuilder().addEvents(event).build()
+    promise(msg)
+  }
+  private val jsonFormatter =
+    (new FormatFactory()).createFormatter(FormatFactory.Formatter.JSON)
+
+  protected val queue: BlockingQueue[Event] = new ArrayBlockingQueue(
+    config.bufferSize)
+
+  private val client = RiemannClient.tcp(config.host, config.port)
+
+  protected def sendBatch: Unit = {
+    val batch: LinkedList[Event] = new LinkedList()
+    queue.drainTo(batch, config.batchSize)
+    try {
+      log.trace("try to send batch")
+      val p = client.sendEvents(batch)
+      client.flush()
+      val result = p.deref()
+      log.trace(s"sent batch with result: $result")
+    } catch {
+      case e: IOException =>
+        log.error(e.toString)
+        batch.asScala
+          .map { event =>
+            {
+              System.err.println(s"${jsonFormatter.printToString(event)}")
+            }
+          }
+    }
+  }
+
+  implicit val context =
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(20))
+
+  val f = Future {
+    while (true) {
+      if (queue.size() > 0) {
+        log.trace("sending batch of Riemann events")
+        sendBatch
+        log.trace("sent batch of Riemann events")
+      } else {
+        log.trace("wait for next batch of Riemann events")
+        Thread.sleep(5000)
+      }
+    }
+  }
+
+  val flusher = Future {
+    while (true) {
+      Thread.sleep(config.autoFlushMilliseconds)
+      log.trace("auto flush riemann queue")
+      client.flush()
+    }
+  }
+
+  override def connect() = client.connect()
+  override def sendEvent(event: Event) = {
+    val res = queue.offer(event)
+    if (!res) {
+      log.error("Riemann buffer full")
+      System.err.println(s"${jsonFormatter.printToString(event)}")
+    }
+    simpleMsg(event)
+  }
+  override def sendMessage(msg: Msg): IPromise[Msg] = client.sendMessage(msg)
+
+  override def event(): EventDSL = {
+    new EventDSL(this)
+  }
+  override def query(q: String): IPromise[java.util.List[Event]] =
+    client.query(q)
+  override def sendEvents(events: java.util.List[Event]): IPromise[Msg] = {
+    val p = new ChainPromise[Msg]
+    events.asScala.map { e =>
+      val clientPromise = sendEvent(e)
+      p.attach(clientPromise)
+    }
+    p
+  }
+  override def sendEvents(events: Event*): IPromise[Msg] = {
+    val p = new ChainPromise[Msg]
+    events.map { e =>
+      val clientPromise = sendEvent(e)
+      p.attach(clientPromise)
+    }
+    p
+  }
+  override def sendException(service: String, t: Throwable): IPromise[Msg] =
+    client.sendException(service, t)
+  override def close(): Unit = client.close()
+  override def flush(): Unit = client.flush()
+  override def isConnected(): Boolean = client.isConnected
+  override def reconnect(): Unit = client.reconnect()
+  override def transport(): Transport = this
+}
+
+class RiemannStdoutClient extends IRiemannClient {
+  private var connected = false
+  private def promise[A](v: A): Promise[A] = {
+    val p: Promise[A] = new Promise()
+    p.deliver(v)
+    p
+  }
+  private def simpleMsg(event: Event) = {
+    val msg = Msg.newBuilder().addEvents(event).build()
+    promise(msg)
+  }
+  private val jsonFormatter =
+    (new FormatFactory()).createFormatter(FormatFactory.Formatter.JSON)
+  override def connect() = {
+    connected = true
+  }
+  override def sendEvent(event: Event) = {
+    println(s"${jsonFormatter.printToString(event)}")
+    simpleMsg(event)
+  }
+  override def sendMessage(msg: Msg): IPromise[Msg] = {
+    println(s"${jsonFormatter.printToString(msg)}")
+    promise(msg)
+  }
+  override def event(): EventDSL = {
+    new EventDSL(this)
+  }
+  override def query(q: String): IPromise[java.util.List[Event]] = {
+    promise(new java.util.LinkedList())
+  }
+  override def sendEvents(events: java.util.List[Event]): IPromise[Msg] = {
+    events.asScala.map { e =>
+      println(s"${jsonFormatter.printToString(e)}")
+    }
+    val msg = Msg.newBuilder().build()
+    promise(msg)
+  }
+  override def sendEvents(events: Event*): IPromise[Msg] = {
+    events.map { e =>
+      println(s"${jsonFormatter.printToString(e)}")
+    }
+    val msg = Msg.newBuilder().build()
+    promise(msg)
+  }
+  override def sendException(service: String, t: Throwable): IPromise[Msg] = {
+    System.err.println(s"service: ${service}\n${t}")
+    val msg = Msg.newBuilder().build()
+    promise(msg)
+  }
+  override def close(): Unit = {
+    connected = false
+  }
+  override def flush(): Unit = {}
+  override def isConnected(): Boolean = connected
+  override def reconnect(): Unit = {
+    connected = true
+  }
+  override def transport(): Transport = this
+
+}
+
+trait ToRiemann[A] {
+  def toRiemann(a: A): EventDSL
+}
+
+object ToRiemann {
+  def apply[A](implicit t: ToRiemann[A]): ToRiemann[A] = t
+
+  implicit class ToRiemannOps[A: ToRiemann](a: A) {
+    def toRiemann = ToRiemann[A].toRiemann(a)
+  }
+}

--- a/verify.sbt
+++ b/verify.sbt
@@ -103,7 +103,10 @@ verifyDependencies in verify ++= Seq(
   "io.netty" % "netty-handler-proxy" sha1 "c914a01d61b4ab42031c4336140b8bfee1b6ba5c",
   "io.netty" % "netty-codec-socks" sha1 "40c89bc61d0d998b0c137cee94338981b7b44758",
   "io.netty" % "netty-transport-native-epoll" sha1 "71827dd2c47e89153a9257d87d6752c47d1faa9c",
-  "io.netty" % "netty-transport-native-unix-common" sha1 "91cac0a82088282fbf76880fc2554c0f2b32e5b2"
+  "io.netty" % "netty-transport-native-unix-common" sha1 "91cac0a82088282fbf76880fc2554c0f2b32e5b2",
+  "io.riemann" % "riemann-java-client" sha1 "36918e406a758ec201ecf360fe00918ee6d92878",
+  "io.netty" % "netty" sha1 "e044dd5d3f3e328686c8d5816cc5f2c86693f634",
+  "com.googlecode.protobuf-java-format" % "protobuf-java-format" sha1 "b8163b6940102c1808814471476f5293dfb419df"
 )
 
 verifyOptions in verify := VerifyOptions(


### PR DESCRIPTION
* events are batched up to be more efficient
* batches are sent once the batch is full and periodically
* events are also buffered
* backpressure causes events to overflow into stdout (as JSON)
* connection failure causes overflow to stdout JSON
* if you do not add riemann configuration then this simply
  provides a JSON stdout logger

With this you should avoid calls to `log.debug` `log.info` etc and send Riemann events instead. Logging should be reserved for detailed debugging/tracing only.

If this is merged then pretty much every `log.{info,debug,error}` can be migrated to a riemann service without really affecting the functionality.