### PR TITLE
Increase era duration for ethereum to 50milion blocks

### DIFF
--- a/src/universal/conf/ethereumHF.conf
+++ b/src/universal/conf/ethereumHF.conf
@@ -42,7 +42,7 @@ mantis {
     monetary-policy {
       first-era-block-reward = "5000000000000000000"
       first-era-reduced-block-reward = "3000000000000000000"
-      era-duration = 5000000
+      era-duration = 50000000
       reward-reduction-rate = 0
     }
 


### PR DESCRIPTION
basicly concept of eras is only relevat to ethereum classic, and on ethereum chain we want to be in 0 era. Current highest block on etherum chain is `5897827` so with old config we would end up in era 1, and block would fail to validate.
Setting it to 50,000,000 will be enough for next ~15 years with current block generation speed.