### PR TITLE
Promote logs of business impact from DEBUG

### DIFF
--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/BlacklistSupport.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/BlacklistSupport.scala
@@ -18,11 +18,11 @@ trait BlacklistSupport {
   def blacklist(peerId: PeerId, duration: FiniteDuration, reason: String): Unit = {
     if (duration > Duration.Zero) {
       undoBlacklist(peerId)
-      log.debug(s"Blacklisting peer ($peerId), $reason")
+      log.info(s"Blacklisting peer ($peerId), $reason")
       val unblacklistCancellable = scheduler.scheduleOnce(duration, self, UnblacklistPeer(peerId))
       blacklistedPeers :+= (peerId, unblacklistCancellable)
     } else {
-      log.debug(s"Peer ($peerId) would be blacklisted (reason: $reason), but blacklisting duration is zero")
+      log.info(s"Peer ($peerId) would be blacklisted (reason: $reason), but blacklisting duration is zero [= $duration]")
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -89,7 +89,11 @@ class RegularSync(
       resumeRegularSync()
 
     case PrintStatus =>
-      log.info(s"Block: ${appStateStorage.getBestBlockNumber()}. Peers: ${handshakedPeers.size} (${blacklistedPeers.size} blacklisted)")
+      val number = appStateStorage.getBestBlockNumber()
+      val numberHex = number.toString(16)
+      val handshakedPeerCount = handshakedPeers.size
+      val blacklistedPeerCount = blacklistedPeers.size
+      log.info(s"Best Block: ${number} (= 0x${numberHex}). Handshaked Peers: ${handshakedPeerCount}. Blacklisted: ${blacklistedPeerCount}")
   }
 
   def handleAdditionalMessages: Receive = handleNewBlockMessages orElse handleMinedBlock orElse handleNewBlockHashesMessages
@@ -127,7 +131,11 @@ class RegularSync(
           .block(newBlock)
           .send()
 
-        val importResult = Try(ledger.importBlock(newBlock))
+        val importResult = RegularSync.tryImportBlock(
+          context = "handleNewBlockMessages",
+          regularSync = this,
+          block = newBlock
+        )
 
         importResult match {
           case Success(result) => result match {
@@ -299,7 +307,11 @@ class RegularSync(
     //we allow inclusion of mined block only if we are not syncing / reorganising chain
     case MinedBlock(block) =>
       if (notDownloading()) {
-        val importResult = Try(ledger.importBlock(block))
+        val importResult = RegularSync.tryImportBlock(
+          context = "handleMinedBlock",
+          regularSync = this,
+          block = block
+        )
 
         importResult match {
           case Success(result) => result match {
@@ -364,7 +376,8 @@ class RegularSync(
     bestPeer match {
       case Some(peer) =>
         val blockNumber = appStateStorage.getBestBlockNumber() + 1
-        log.debug(s"Requesting $blockHeadersPerRequest headers, starting from $blockNumber")
+        val blockNumberHex = blockNumber.toString(16)
+        log.info(s"Requesting $blockHeadersPerRequest headers, starting block $blockNumber [= 0x${blockNumberHex}] from ${peer.id}")
         requestBlockHeaders(peer, GetBlockHeaders(Left(blockNumber), blockHeadersPerRequest, skip = 0, reverse = false))
 
       case None =>
@@ -395,30 +408,37 @@ class RegularSync(
     } else {
       val MissingStateNodeRetry(requestedHash, blockPeer, blocksToRetry) = missingStateNodeRetry.get
       val receivedHash = kec256(nodes.head)
+      val receivedHashHex = Hex.toHexString(receivedHash.toArray)
+      val requestedHashHex = Hex.toHexString(requestedHash.toArray)
 
       if (receivedHash != requestedHash) {
-        log.debug(s"Received missing state node has different hash than requested")
-        resumeWithDifferentPeer(peer, "wrong state node hash")
+        log.info(s"Received missing state node has different hash 0x${receivedHashHex} than requested 0x${requestedHash}")
+        resumeWithDifferentPeer(peer, s"wrong state node hash, requested 0x${requestedHashHex}, received 0x${receivedHashHex}")
       } else {
-        val nextBlockNumber = blocksToRetry.head.header.number
+        val nextBlock = blocksToRetry.head
+        val nextBlockNumber = nextBlock.header.number
+        val nextBlockNumberHex = nextBlockNumber.toString(16)
+
         // note that we do not analyse whether the node is a leaf, extension or a branch, thus we only
         // handle one state node at a time and retry executing block - this may require multiple attempts
         blockchain.saveNode(requestedHash, nodes.head.toArray, nextBlockNumber)
         missingStateNodeRetry = None
-        log.info(s"Inserted missing state node: ${Hex.toHexString(requestedHash.toArray)}. " +
-          s"Retrying execution starting with block $nextBlockNumber")
+        log.info(s"Inserted missing state node: 0x${requestedHashHex}. " +
+          s"Retrying execution starting with block ${nextBlock.idTag}")
         handleBlocks(blockPeer, blocksToRetry)
       }
     }
   }
 
   private def handleBlockBranchResolution(peer: Peer, message: Seq[BlockHeader]) = {
-    if (message.nonEmpty && message.last.hash == headersQueue.head.parentHash) {
+    val messageNonEmpty: Boolean = message.nonEmpty
+    val sameHashes: Boolean = message.last.hash == headersQueue.head.parentHash
+    if (messageNonEmpty && sameHashes) {
       headersQueue = message ++ headersQueue
       processBlockHeaders(peer, headersQueue)
     } else {
       //we did not get previous blocks, there is no way to resolve, blacklist peer and continue download
-      resumeWithDifferentPeer(peer, "failed to resolve branch")
+      resumeWithDifferentPeer(peer, s"failed to resolve branch, messageNonEmpty=${messageNonEmpty}, sameHashes=${sameHashes}, both should be true")
     }
     resolvingBranches = false
   }
@@ -432,8 +452,25 @@ class RegularSync(
     scheduleResume()
   }
 
+  private def headersLogInfo(headers: Seq[BlockHeader]): String = {
+    if(headers.nonEmpty) {
+      val howmany = headers.size
+      val firstNumber = headers.head.number
+      val firstNumberHex = firstNumber.toString(16)
+      val lastNumber = headers.last.number
+      val lastNumberHex = lastNumber.toString(16)
+
+      s"${howmany} headers: [$firstNumber (= 0x$firstNumberHex), $lastNumber (= 0x$lastNumberHex)]"
+    } else "[]"
+  }
+
+  private def blocksLogInfo(blocks: Seq[Block]): String =
+    headersLogInfo(blocks.map(_.header))
+
   private def processBlockHeaders(peer: Peer, headers: Seq[BlockHeader]) = ledger.resolveBranch(headers) match {
     case NewBetterBranch(oldBranch) =>
+      log.info(s"[NewBetterBranch] ${headersLogInfo(headers)}, oldBranch: ${blocksLogInfo(oldBranch)}")
+
       val transactionsToAdd = oldBranch.flatMap(_.body.transactionList)
       pendingTransactionsManager ! PendingTransactionsManager.AddTransactions(transactionsToAdd.toList)
       val hashes = headers.take(blockBodiesPerRequest).map(_.hash)
@@ -443,11 +480,15 @@ class RegularSync(
       oldBranch.headOption.foreach { h => ommersPool ! AddOmmers(h.header) }
 
     case NoChainSwitch =>
+      log.info(s"[NoChainSwitch] ${headersLogInfo(headers)}")
+
       //add first block from branch as ommer
       headers.headOption.foreach { h => ommersPool ! AddOmmers(h) }
       scheduleResume()
 
     case UnknownBranch =>
+      log.info(s"[UnknownBranch] ${headersLogInfo(headers)}")
+
       if (resolvingBranches) {
         log.debug("fail to resolve branch, branch too long, it may indicate malicious peer")
         resumeWithDifferentPeer(peer, "failed to resolve branch")
@@ -459,8 +500,15 @@ class RegularSync(
         resolvingBranches = true
       }
 
-    case InvalidBranch =>
-      log.debug("Got block header that does not have parent")
+    case e: InvalidBranch =>
+      e match {
+        case InvalidBranchNoChain =>
+          log.info(s"[InvalidBranchNoChain] ${headersLogInfo(headers)}")
+
+        case InvalidBranchLastBlockNumberIsSmall =>
+          log.info(s"[InvalidBranchLastBlockNumberIsSmall] ${headersLogInfo(headers)}")
+      }
+
       resumeWithDifferentPeer(peer)
   }
 
@@ -494,9 +542,17 @@ class RegularSync(
   private def handleBlocks(peer: Peer, blocks: Seq[Block]) = {
     val (importedBlocks, errorOpt) = importBlocks(blocks.toList)
 
-    if (importedBlocks.nonEmpty) {
-      log.debug(s"got new blocks up till block: ${importedBlocks.last.header.number} " +
-        s"with hash ${Hex.toHexString(importedBlocks.last.header.hash.toArray[Byte])}")
+    if(importedBlocks.nonEmpty) {
+      val howmany = importedBlocks.size
+
+      if(howmany == 1) {
+        val block = importedBlocks.head
+        log.debug(s"Handled 1 new block ${block.idTag}")
+      } else {
+        val firstBlock = importedBlocks.last
+        val lastBlock = importedBlocks.head
+        log.info(s"Handled ${howmany} new blocks, from block ${firstBlock.idTag} to ${lastBlock.idTag}")
+      }
     }
 
     errorOpt match {
@@ -525,24 +581,34 @@ class RegularSync(
     }
   }
 
-  @tailrec
   private def importBlocks(blocks: List[Block], importedBlocks: List[Block] = Nil): (List[Block], Option[Any]) =
+    importBlocks(1, blocks.size, blocks, importedBlocks)
+
+  @tailrec
+  private[this] def importBlocks(count: Int, initialBlocksSize: Int, blocks: List[Block], importedBlocks: List[Block]): (List[Block], Option[Any]) =
     blocks match {
       case Nil =>
         (importedBlocks, None)
 
       case block :: tail =>
-        Try(ledger.importBlock(block)) match {
+        val importedSize = importedBlocks.size
+        val importResult = RegularSync.tryImportBlock(
+          context = s"importBlocks/$count/$initialBlocksSize/$importedSize",
+          regularSync = this,
+          block = block
+        )
+
+        importResult match {
           case Success(result) =>
             result match {
               case BlockImportedToTop(_, _) =>
-                importBlocks(tail, block :: importedBlocks)
+                importBlocks(count + 1, initialBlocksSize, tail, block :: importedBlocks)
 
               case ChainReorganised(_, newBranch, _) =>
-                importBlocks(tail, newBranch.reverse ::: importedBlocks)
+                importBlocks(count + 1, initialBlocksSize, tail, newBranch.reverse ::: importedBlocks)
 
               case r @ (DuplicateBlock | BlockEnqueued) =>
-                importBlocks(tail, importedBlocks)
+                importBlocks(count + 1, initialBlocksSize, tail, importedBlocks)
 
               case err @ (UnknownParent | BlockImportFailed(_)) =>
                 (importedBlocks, Some(err))
@@ -620,4 +686,29 @@ object RegularSync {
   case class MinedBlock(block: Block)
 
   case class MissingStateNodeRetry(nodeId: ByteString, p: Peer, blocksToRetry: Seq[Block])
+
+  // Utility method that tries to import the block and gives an opportunity for unified logging treatment.
+  def tryImportBlock(context: String, regularSync: RegularSync, block: Block): Try[BlockImportResult] = {
+    val log = regularSync.log
+    val ledger = regularSync.ledger
+
+    val triedResult = Try(ledger.importBlock(block))
+    triedResult match {
+      case Success(result) ⇒
+        result match {
+          case BlockImportedToTop(imported: List[Block], totalDifficulties: List[BigInt]) ⇒
+          case BlockEnqueued ⇒
+          case DuplicateBlock ⇒
+          case ChainReorganised(oldBranch: List[Block], newBranch: List[Block], totalDifficulties: List[BigInt]) ⇒
+          case bif @ BlockImportFailed(error: String) ⇒
+            log.error(s"[$context] Block: ${block.idTag}. $bif")
+          case UnknownParent ⇒
+        }
+
+      case Failure(t) ⇒
+        log.error(s"Could not import block ${block.idTag}", t)
+    }
+
+    triedResult
+  }
 }

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidator.scala
@@ -29,7 +29,22 @@ object BlockHeaderError {
   case object HeaderTimestampError extends BlockHeaderError
   case object HeaderDifficultyError extends BlockHeaderError
   case object HeaderGasUsedError extends BlockHeaderError
-  case object HeaderGasLimitError extends BlockHeaderError
+
+  sealed trait HeaderGasLimitError extends BlockHeaderError
+  case class HeaderGasLimitErrorConst(constant: BigInt, gasLimit: BigInt) extends HeaderGasLimitError
+
+  // We use an Option to signify if the value was part of the validation calculation,
+  // So Some(minLimit) means that io.iohk.ethereum.consensus.validators.BlockHeaderValidator#MinGasLimit
+  // was used in the calculation.
+  case class HeaderGasLimitErrorBounds(
+    minLimit: Option[BigInt],
+    gasLimit: BigInt,
+    maxLimit: Option[BigInt],
+    eip106BlockNumber: Option[BigInt],
+    gasLimitDiff: Option[BigInt],
+    gasLimitDiffLimit: Option[BigInt]
+  ) extends HeaderGasLimitError
+
   case object HeaderNumberError extends BlockHeaderError
   case object HeaderPoWError extends BlockHeaderError
 }

--- a/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
@@ -71,9 +71,10 @@ case class BlockHeader(
 
   lazy val hashAsHexString: String = Hex.toHexString(hash.toArray)
 
-  def idTag: String =
-    s"$number: $hashAsHexString"
-
+  def idTag: String = {
+    val numberHex = number.toString(16)
+    s"$number (= 0x$numberHex : 0x$hashAsHexString)"
+  }
 }
 
 object BlockHeader {

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -114,10 +114,10 @@ case class SignedTransaction (
 
   override def toString: String = {
     s"""SignedTransaction {
-         |tx: $tx
-         |signature: $signature
-         |sender: ${Hex.toHexString(senderAddress.bytes.toArray)}
-         |}""".stripMargin
+       |tx: $tx
+       |signature: $signature
+       |sender: ${Hex.toHexString(senderAddress.bytes.toArray)}
+       |}""".stripMargin
   }
 
   def isChainSpecific: Boolean =

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BlockExecutionError.{StateBeforeFailure, TxsExecutionError}
 import io.iohk.ethereum.ledger.Ledger._
 import io.iohk.ethereum.utils.{BlockchainConfig, Logger}
-import io.iohk.ethereum.vm.{PC => _, _}
+import io.iohk.ethereum.vm.{PC ⇒ _, _}
 
 import scala.annotation.tailrec
 
@@ -50,13 +50,13 @@ class BlockPreparator(
     val minerAccount = getAccountToPay(minerAddress, worldStateProxy)
     val minerReward = blockRewardCalculator.calcBlockMinerReward(block.header.number, block.body.uncleNodesList.size)
     val afterMinerReward = worldStateProxy.saveAccount(minerAddress, minerAccount.increaseBalance(UInt256(minerReward)))
-    log.debug(s"Paying block ${block.header.number} reward of $minerReward to miner with account address $minerAddress")
+    log.debug(s"Paying block ${block.idTag} reward of $minerReward to miner with account address $minerAddress")
 
     block.body.uncleNodesList.foldLeft(afterMinerReward) { (ws, ommer) =>
       val ommerAddress = Address(ommer.beneficiary)
       val account = getAccountToPay(ommerAddress, ws)
       val ommerReward = blockRewardCalculator.calcOmmerMinerReward(block.header.number, ommer.number)
-      log.debug(s"Paying block ${block.header.number} reward of $ommerReward to ommer with account address $ommerAddress")
+      log.debug(s"Paying block ${block.idTag} reward of $ommerReward to ommer with account address $ommerAddress")
       ws.saveAccount(ommerAddress, account.increaseBalance(UInt256(ommerReward)))
     }
   }
@@ -215,11 +215,10 @@ class BlockPreparator(
 
     val world2 = (deleteAccountsFn andThen deleteTouchedAccountsFn andThen persistStateFn)(worldAfterPayments)
 
-    log.debug(
-      s"""Transaction ${stx.hashAsHexString} execution end. Summary:
-         | - Error: ${result.error}.
-         | - Total Gas to Refund: $totalGasToRefund
-         | - Execution gas paid to miner: $executionGasToPayToMiner""".stripMargin)
+    val refundSummary = s"totalGasToRefund=$totalGasToRefund"
+    val executionGasToPaySummary = s"executionGasToPayToMiner=$executionGasToPayToMiner"
+    val errorSummary = result.error.fold("no error")(error ⇒ s"error=$error")
+    log.info(s"Tx ${stx.hashAsHexString} summary: $refundSummary, $executionGasToPaySummary, $errorSummary")
 
     TxResult(world2, executionGasToPayToMiner, resultWithErrorHandling.logs, result.returnData, result.error)
   }
@@ -278,7 +277,7 @@ class BlockPreparator(
               statusCode = statusCode,
               returnData = returnData)
 
-            log.debug(s"Receipt generated for tx ${stx.hashAsHexString}, $receipt")
+            log.info(s"Receipt for tx ${stx.hashAsHexString} of block ${blockHeader.idTag}: $receipt")
 
             executeTransactions(otherStxs, newWorld, blockHeader, receipt.cumulativeGasUsed, acumReceipts :+ receipt)
           case Left(error) => Left(TxsExecutionError(stx, StateBeforeFailure(world, acumGas, acumReceipts), error.toString))

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -12,7 +12,6 @@ import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils._
 import io.iohk.ethereum.utils.events._
 import io.iohk.ethereum.vm._
-import org.spongycastle.util.encoders.Hex
 
 trait Ledger {
   def consensus: Consensus
@@ -58,7 +57,8 @@ trait Ledger {
    *         - [[io.iohk.ethereum.ledger.NewBetterBranch]] - the headers form a better branch than our current main chain
    *         - [[io.iohk.ethereum.ledger.NoChainSwitch]] - the headers do not form a better branch
    *         - [[io.iohk.ethereum.ledger.UnknownBranch]] - the parent of the first header is unknown (caller should obtain more headers)
-   *         - [[io.iohk.ethereum.ledger.InvalidBranch]] - headers do not form a chain or last header number is less than current best block number
+   *         - [[io.iohk.ethereum.ledger.InvalidBranchNoChain]] - headers do not form a chain
+   *         - [[io.iohk.ethereum.ledger.InvalidBranchLastBlockNumberIsSmall]] - last header number is less than current best block number
    */
   def resolveBranch(headers: Seq[BlockHeader]): BranchResolutionResult
 
@@ -100,12 +100,12 @@ class LedgerImpl(
 
   // scalastyle:off method.length
   def importBlock(block: Block): BlockImportResult = {
-    val validationResult = validateBlockBeforeExecution(block)
+    val validationResult = validateBlockBeforeExecution("importBlock", block)
     validationResult match {
       case Left(ValidationBeforeExecError(HeaderParentNotFoundError)) =>
         val isGenesis = block.header.number == 0 && blockchain.genesisHeader.hash == block.header.hash
         if (isGenesis){
-          log.debug(s"Ignoring duplicate genesis block: (${block.idTag})")
+          log.info(s"Ignoring duplicate genesis block: ${block.idTag}")
           DuplicateBlock
         } else {
           log.debug(s"Block(${block.idTag}) has no known parent")
@@ -113,7 +113,7 @@ class LedgerImpl(
         }
 
       case Left(ValidationBeforeExecError(reason)) =>
-        log.debug(s"Block(${block.idTag}) failed pre-import validation")
+        log.debug(s"Block ${block.idTag} failed pre-import validation. Reason: ${reason}")
         BlockImportFailed(reason.toString)
 
       case Right(_) =>
@@ -162,7 +162,7 @@ class LedgerImpl(
     }
 
     importedBlocks.foreach { b =>
-      log.debug(s"Imported new block (${b.header.number}: ${Hex.toHexString(b.header.hash.toArray)}) to the top of chain")
+      log.info(s"Imported new block ${b.idTag} to the top of chain")
       Event.ok("block imported")
         .metric(b.header.number.longValue)
         .block(b)
@@ -321,21 +321,11 @@ class LedgerImpl(
     }
   }
 
-  /**
-    * Finds a relation of a given list of headers to the current chain
-    * Note:
-    *   - the headers should form a chain (headers ordered by number)
-    *   - last header number should be greater or equal than current best block number
-    * @param headers - a list of headers to be checked
-    * @return One of:
-    *         - [[NewBetterBranch]] - the headers form a better branch than our current main chain
-    *         - [[NoChainSwitch]] - the headers do not form a better branch
-    *         - [[UnknownBranch]] - the parent of the first header is unknown (caller should obtain more headers)
-    *         - [[InvalidBranch]] - headers do not form a chain or last header number is less than current best block number
-    */
   def resolveBranch(headers: Seq[BlockHeader]): BranchResolutionResult = {
-    if (!doHeadersFormChain(headers) || headers.last.number < blockchain.getBestBlockNumber())
-      InvalidBranch
+    if (!doHeadersFormChain(headers))
+      InvalidBranchNoChain
+    else if (headers.last.number < blockchain.getBestBlockNumber())
+      InvalidBranchLastBlockNumberIsSmall
     else {
       val parentIsKnown = blockchain.getBlockHeaderByHash(headers.head.parentHash).isDefined
 
@@ -396,23 +386,30 @@ class LedgerImpl(
   }
 
   def executeBlock(block: Block, alreadyValidated: Boolean = false): Either[BlockExecutionError, Seq[Receipt]] = {
+    val context = "executeBlock"
 
-    val preExecValidationResult = if (alreadyValidated) Right(block) else validateBlockBeforeExecution(block)
+    val preExecValidationResult = if (alreadyValidated) Right(block) else validateBlockBeforeExecution(context, block)
 
     val blockExecResult = for {
       _ <- preExecValidationResult
 
-      execResult <- executeBlockTransactions(block)
+      execResult <- executeBlockTransactions(context, block)
       BlockResult(resultingWorldStateProxy, gasUsed, receipts) = execResult
       worldToPersist = _blockPreparator.payBlockReward(block, resultingWorldStateProxy)
       worldPersisted = InMemoryWorldStateProxy.persistState(worldToPersist) //State root hash needs to be up-to-date for validateBlockAfterExecution
 
-      _ <- validateBlockAfterExecution(block, worldPersisted.stateRootHash, receipts, gasUsed)
+      _ <- validateBlockAfterExecution(context, block, worldPersisted.stateRootHash, receipts, gasUsed)
 
     } yield receipts
 
-    if(blockExecResult.isRight)
-      log.debug(s"Block ${block.header.number} (with hash: ${block.header.hashAsHexString}) executed correctly")
+    blockExecResult match {
+      case Left(error) ⇒
+        log.info(s"Block ${block.idTag} executed with error(s): ${error.reason}")
+
+      case _ ⇒
+        log.debug(s"Block ${block.idTag} executed correctly")
+    }
+
     blockExecResult
   }
 
@@ -421,8 +418,11 @@ class LedgerImpl(
     *
     * @param block
     */
-  private[ledger] def executeBlockTransactions(block: Block):
-  Either[BlockExecutionError, BlockResult] = {
+  private[ledger] def executeBlockTransactions(block: Block): Either[BlockExecutionError, BlockResult] = {
+    executeBlockTransactions("", block)
+  }
+
+  private[ledger] def executeBlockTransactions(context: String, block: Block): Either[BlockExecutionError, BlockResult] = {
     val parentStateRoot = blockchain.getBlockHeaderByHash(block.header.parentHash).map(_.stateRoot)
     val initialWorld =
       blockchain.getWorldStateProxy(
@@ -437,11 +437,20 @@ class LedgerImpl(
       case _ => initialWorld
     }
 
-    log.debug(s"About to execute ${block.body.transactionList.size} txs from block ${block.header.number} (with hash: ${block.header.hashAsHexString})")
+    val transactionCount = block.body.transactionList.size
+    if(transactionCount > 0) {
+      log.debug(s"About to execute ${transactionCount} txs from block ${block.idTag}")
+    }
+
     val blockTxsExecResult = _blockPreparator.executeTransactions(block.body.transactionList, inputWorld, block.header)
     blockTxsExecResult match {
-      case Right(_) => log.debug(s"All txs from block ${block.header.hashAsHexString} were executed successfully")
-      case Left(error) => log.debug(s"Not all txs from block ${block.header.hashAsHexString} were executed correctly, due to ${error.reason}")
+      case Right(_) =>
+        if(transactionCount > 0) {
+          log.info(s"All ${transactionCount} txs from block ${block.idTag} were executed successfully")
+        }
+
+      case Left(error) =>
+        log.error(s"[$context] Not all ${transactionCount} txs from block ${block.idTag} were executed correctly, due to ${error.reason}")
     }
     blockTxsExecResult
   }
@@ -483,12 +492,18 @@ class LedgerImpl(
     }
   }
 
-  private def validateBlockBeforeExecution(block: Block): Either[ValidationBeforeExecError, BlockExecutionSuccess] = {
-    consensus.validators.validateBlockBeforeExecution(
+  private[ledger] def validateBlockBeforeExecution(context: String, block: Block): Either[ValidationBeforeExecError, BlockExecutionSuccess] = {
+    val result = consensus.validators.validateBlockBeforeExecution(
       block = block,
       getBlockHeaderByHash = getHeaderFromChainOrQueue,
       getNBlocksBack = getNBlocksBackFromChainOrQueue
     )
+
+    result.left.foreach { error ⇒
+      log.error(s"[$context/validateBeforeExecution] Block: ${block.idTag}. Reason: ${error.reason}")
+    }
+
+    result
   }
 
   private[ledger] def validateBlockAfterExecution(
@@ -497,13 +512,35 @@ class LedgerImpl(
     receipts: Seq[Receipt],
     gasUsed: BigInt
   ): Either[BlockExecutionError, BlockExecutionSuccess] = {
-
-    consensus.validators.validateBlockAfterExecution(
+    validateBlockAfterExecution(
+      context = "",
       block = block,
       stateRootHash = stateRootHash,
       receipts = receipts,
       gasUsed = gasUsed
     )
+  }
+
+  private[ledger] def validateBlockAfterExecution(
+    context: String,
+    block: Block,
+    stateRootHash: ByteString,
+    receipts: Seq[Receipt],
+    gasUsed: BigInt
+  ): Either[BlockExecutionError, BlockExecutionSuccess] = {
+
+    val result = consensus.validators.validateBlockAfterExecution(
+      block = block,
+      stateRootHash = stateRootHash,
+      receipts = receipts,
+      gasUsed = gasUsed
+    )
+
+    result.left.foreach { error ⇒
+      log.error(s"[$context/validateAfterExecution] Block: ${block.idTag}. Reason: ${error.reason}")
+    }
+
+    result
   }
 
   /**
@@ -585,7 +622,12 @@ sealed trait BranchResolutionResult
 case class  NewBetterBranch(oldBranch: Seq[Block]) extends BranchResolutionResult
 case object NoChainSwitch extends BranchResolutionResult
 case object UnknownBranch extends BranchResolutionResult
-case object InvalidBranch extends BranchResolutionResult
+
+sealed trait InvalidBranch extends BranchResolutionResult
+// headers do not form a chain
+case object InvalidBranchNoChain extends InvalidBranch
+// last header number is not greater or equal than current best block number
+case object InvalidBranchLastBlockNumberIsSmall extends InvalidBranch
 
 sealed trait BlockStatus
 case object InChain       extends BlockStatus

--- a/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
@@ -79,7 +79,8 @@ object Metrics extends Logger {
   final val Prefix = "mantis" // TODO there are several other strings of this value. Can we consolidate?
   final val PrefixDot = Prefix + "."
 
-  private[this] def onMeterAdded(m: Meter): Unit = log.info(s"New ${} metric: " + m.getId.getName)
+  private[this] def onMeterAdded(m: Meter): Unit =
+    log.debug(s"New ${m.getClass.getSimpleName} metric: " + m.getId.getName)
 
   /**
    * Instantiates and configures the metrics "service". This should happen once in the lifetime of the application.

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/RegularSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/RegularSyncSpec.scala
@@ -347,7 +347,7 @@ class RegularSyncSpec extends TestKit(ActorSystem("RegularSync_system")) with Wo
       "handle invalid branch" in new TestSetup {
         val newBlocks = (1 to 2).map(_ => getBlock())
 
-        (ledger.resolveBranch _).expects(newBlocks.map(_.header)).returning(InvalidBranch)
+        (ledger.resolveBranch _).expects(newBlocks.map(_.header)).returning(InvalidBranchNoChain)
 
         sendBlockHeadersFromBlocks(newBlocks)
 

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -176,7 +176,7 @@ class BlockImportSpec extends FlatSpec with Matchers with MockFactory {
 
   "Branch resolution" should "report an invalid branch when headers do not form a chain" in new TestSetup with MockBlockchain {
     val headers = getChainHeaders(1, 10).reverse
-    ledger.resolveBranch(headers) shouldEqual InvalidBranch
+    ledger.resolveBranch(headers) shouldEqual InvalidBranchNoChain
   }
 
   // scalastyle:off magic.number
@@ -184,7 +184,7 @@ class BlockImportSpec extends FlatSpec with Matchers with MockFactory {
     val headers = getChainHeaders(1, 10)
     setBestBlockNumber(11)
 
-    ledger.resolveBranch(headers) shouldEqual InvalidBranch
+    ledger.resolveBranch(headers) shouldEqual InvalidBranchLastBlockNumberIsSmall
   }
 
   it should "report an unknown branch in the parent of the first header is unknown" in new TestSetup with MockBlockchain {


### PR DESCRIPTION
to (usually) INFO. The idea is to avoid the verbosity of DEBUG
and yet be able to understand what is going on, especially
regarding the blockchain progress (or lack thereof). The
usefulness and effectiveness of this patch has been verified
while debugging a real case in production.

Also:

- augment `HeaderGasLimitError` with context to aid debugging
- provide two sub-cases for `InvalidBranch`, thus making the
  precise error clearer
- augment `Block`'s `idTag` with extra info to aid debugging
- use `block.idTag` as the default way to identify a block
  when logging

Ref CGKIELE-397