### PR TITLE
Health checks

### DIFF
--- a/src/main/scala/io/iohk/ethereum/healthcheck/Healthcheck.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/Healthcheck.scala
@@ -1,0 +1,37 @@
+package io.iohk.ethereum.healthcheck
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/**
+ * Represents a health check, runs it and interprets the outcome.
+ * The outcome can be either a normal result, an application error, or
+ * an (unexpected) exception.
+ *
+ * @param description An one-word description of the health check.
+ * @param f           The function that runs the health check.
+ * @param mapResultToError A function that interprets the result.
+ * @param mapErrorToError  A function that interprets the application error.
+ * @param mapExceptionToError A function that interprets the (unexpected) exception.
+ * @tparam Error  The type of the application error.
+ * @tparam Result The type of the actual value expected by normal termination of `f`.
+ */
+case class Healthcheck[Error, Result](
+  description: String,
+  f: () ⇒ Future[Either[Error, Result]],
+  mapResultToError: Result ⇒ Option[String] = (_: Result) ⇒ None,
+  mapErrorToError: Error ⇒ Option[String] = (error: Error) ⇒ Some(String.valueOf(error)),
+  mapExceptionToError: Throwable ⇒ Option[String] = (t: Throwable) ⇒ Some(String.valueOf(t))
+) {
+
+  def apply()(implicit ec: ExecutionContext): Future[HealthcheckResult] = {
+    f().transform {
+      case Success(Left(error)) ⇒
+        Success(HealthcheckResult(description, mapErrorToError(error)))
+      case Success(Right(result)) ⇒
+        Success(HealthcheckResult(description, mapResultToError(result)))
+      case Failure(t) ⇒
+        Success(HealthcheckResult(description, mapExceptionToError(t)))
+    }
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResponse.scala
@@ -1,0 +1,5 @@
+package io.iohk.ethereum.healthcheck
+
+final case class HealthcheckResponse(checks: List[HealthcheckResult]) {
+  lazy val isOK: Boolean = checks.forall(_.isOK)
+}

--- a/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResult.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResult.scala
@@ -1,0 +1,18 @@
+package io.iohk.ethereum.healthcheck
+
+final case class HealthcheckResult private(description: String, status: String, error: Option[String]) {
+  assert(
+    status == HealthcheckStatus.OK && error.isEmpty || status == HealthcheckStatus.ERROR && error.isDefined
+  )
+
+  def isOK: Boolean = status == HealthcheckStatus.OK
+}
+
+object HealthcheckResult {
+  def apply(description: String, error: Option[String]): HealthcheckResult =
+    new HealthcheckResult(
+      description = description,
+      status = error.fold(HealthcheckStatus.OK)(_ ⇒ HealthcheckStatus.ERROR),
+      error = error
+    )
+}

--- a/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckStatus.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckStatus.scala
@@ -1,0 +1,6 @@
+package io.iohk.ethereum.healthcheck
+
+object HealthcheckStatus {
+  final val OK = "OK"
+  final val ERROR = "ERROR"
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerMetrics.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerMetrics.scala
@@ -13,4 +13,6 @@ class JsonRpcControllerMetrics(metrics: Metrics) extends MetricsContainer {
   final val MethodsSuccessCounter = metrics.counter("json.rpc.methods.success.counter")
   final val MethodsExceptionCounter = metrics.counter("json.rpc.methods.exception.counter")
   final val MethodsErrorCounter = metrics.counter("json.rpc.methods.error.counter")
+
+  final val HealhcheckErrorCounter = metrics.counter("json.rpc.healthcheck.error.counter")
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthcheck.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthcheck.scala
@@ -1,0 +1,9 @@
+package io.iohk.ethereum.jsonrpc
+
+import io.iohk.ethereum.healthcheck.Healthcheck
+
+object JsonRpcHealthcheck {
+  type T[R] = Healthcheck[JsonRpcError, R]
+
+  def apply[R](description: String, f: () ⇒ ServiceResponse[R]): T[R] = Healthcheck(description, f)
+}


### PR DESCRIPTION
We serve the `/healthcheck` endpoint by a small library that
supports the definition, execution and interpretation of
health checks.

We also introduce a metric that keeps track of erroneous
health checks, `json.rpc.healthcheck.error.counter`, which
is routed normally through the metrics export pipeline.

Ref CGKIELE-425

### Sample Use

From the command line, with `curl`:

```
$ curl -i TESTNET_URL/healthcheck
```

where we should replace `TESTNET_URL` with an actual testnet URL, port included. 

### Sample output
If at least one of the health checks returns error, then the endpoint responds with an error `500`.

```
HTTP/1.1 500 Internal Server Error
Server: akka-http/10.0.6
Date: Fri, 06 Jul 2018 08:46:58 GMT
Content-Type: application/json
Content-Length: 394

{
  "checks":[
    {
      "description":"peerCount",
      "status":"OK"
    },
    {
      "description":"earliestBlock",
      "status":"ERROR",
      "error":"java.lang.Exception: faulty getBlockByNumber(BlockByNumberRequest(Earliest,true))"
    },
    {
      "description":"latestBlock",
      "status":"OK"
    },
    {
      "description":"pendingBlock",
      "status":"OK"
    }
  ]
}
```

If all checks are OK then the endpoint responds with `200`.

```
HTTP/1.1 200 OK
Server: akka-http/10.0.6
Date: Fri, 06 Jul 2018 08:47:52 GMT
Content-Type: application/json
Content-Length: 292

{
  "checks":[
    {
      "description":"peerCount",
      "status":"OK"
    },
    {
      "description":"earliestBlock",
      "status":"OK"
    },
    {
      "description":"latestBlock",
      "status":"OK"
    },
    {
      "description":"pendingBlock",
      "status":"OK"
    }
  ]
}
```