### PR TITLE
add homestead-block-number, eip150-block-number, and eip161-block-num…

### DIFF
--- a/src/universal/conf/testmode.conf
+++ b/src/universal/conf/testmode.conf
@@ -14,7 +14,10 @@ mantis {
   pruning.mode = "archive"
 
   blockchain = {
+    homestead-block-number = "0"
+    eip150-block-number = "0"
     eip160-block-number = "0"
+    eip161-block-number = "0"
   }
 
   network.rpc {


### PR DESCRIPTION
KEVM uses these three config settings to decide what hard fork to operate under when invoked via the EvmConfig of the external VM protocol. In order to use mantis in testmode to execute the solidity test suite using the KEVM VM, this change to testmode.conf is necessary, since Mantis does not seem to respect the test_setChainParams configuration values for these settings.