### PR TITLE
Selective forging

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -241,9 +241,9 @@ mantis {
     # For example, in case of ethash, a section named `ethash` is used.
     protocol = ethash
 
-    # If true then the consensus protocol uses this node for mining.
-    # In the case of ethash PoW, this means mining new blocks, as specified by Ethereum.
-    # In the general case, the semantics are due to the specific consensus implementation.
+    # If `true` then the consensus protocol uses this node for mining.
+    # In the case of `ethash` consensus, this means mining new blocks, as specified by Ethereum.
+    # In the case of `atomix-raft` consensus, you need to set this to `true` for all nodes.
     mining-enabled = false
 
     # Minimum gas price to include the transaction in block to mine.

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftForger.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftForger.scala
@@ -84,7 +84,7 @@ class AtomixRaftForger(
 
   private def syncTheBlock(block: Block): Unit = {
     if(isLeader) {
-      log.info("***** Forged block " + block.header.number)
+      log.info(s"***** Forged block ${block.idTag}")
 
       syncController ! RegularSync.MinedBlock(block)
 

--- a/src/universal/conf/consensus.conf
+++ b/src/universal/conf/consensus.conf
@@ -10,9 +10,9 @@ mantis {
     # Also used by the generic `BlockGenerator`.
     # block-cashe-size = 30
 
-    # If true then the consensus protocol uses this node for mining.
-    # In the case of ethash PoW, this means mining new blocks, as specified by Ethereum.
-    # In the general case, the semantics are due to the specific consensus implementation.
+    # If `true` then the consensus protocol uses this node for mining.
+    # In the case of `ethash` consensus, this means mining new blocks, as specified by Ethereum.
+    # In the case of `atomix-raft` consensus, you need to set this to `true` for all nodes.
     # mining-enabled = false
 
     # Minimum gas price to include the transaction in block to mine.


### PR DESCRIPTION
`mining-enabled` has been silently ignored by the code in the case
of `atomix-raft` consensus. The code just assumes a value of
`true`. The assumption is correct regarding the current design,
since all nodes participate in the Raft consensus, but we need
more operational flexibility. In particular, we may need to
temporarily disable forging until a (recovering) node completely
syncs the blockchain and re-enable it afterwards, thus resuming
normal operation.

The current patch inspects the value of `mining-enabled` and acts
accordingly.

Ref CGKIELE-318