### PR TITLE
Export build-related info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ project/plugins/project/
 *.log
 *.log.zip
 .evm-runner_history
+buildinfo.properties

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,7 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.
 addSbtPlugin("uk.co.josephearl" % "sbt-verify" % "0.4.1")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.6"

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
@@ -1,12 +1,13 @@
 package io.iohk.ethereum.nodebuilder
 
 import io.iohk.ethereum.blockchain.sync.SyncController
+import io.iohk.ethereum.buildinfo.MantisBuildInfo
 import io.iohk.ethereum.consensus.StdConsensusBuilder
 import io.iohk.ethereum.metrics.Metrics
 import io.iohk.ethereum.network.discovery.DiscoveryListener
 import io.iohk.ethereum.network.{PeerManagerActor, ServerActor}
 import io.iohk.ethereum.testmode.{TestLedgerBuilder, TestmodeConsensusBuilder}
-import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.utils.{Config, JsonUtils}
 
 import scala.concurrent.Await
 import scala.util.{Failure, Success, Try}
@@ -61,7 +62,15 @@ abstract class BaseNode extends Node {
     nodeMetrics.Start.trigger()
   }
 
+  private[this] def logBuildInfo(): Unit = {
+    val json = JsonUtils.pretty(MantisBuildInfo.toMap)
+
+    log.info(s"buildInfo = \n$json")
+  }
+
   def start(): Unit = {
+    logBuildInfo()
+
     startMetrics()
 
     loadGenesisData()

--- a/src/main/scala/io/iohk/ethereum/utils/JsonUtils.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/JsonUtils.scala
@@ -1,0 +1,8 @@
+package io.iohk.ethereum.utils
+
+import org.json4s.DefaultFormats
+import org.json4s.native.Serialization
+
+object JsonUtils {
+  def pretty[A <: AnyRef](obj: A): String = Serialization.writePretty(obj)(DefaultFormats)
+}


### PR DESCRIPTION
From a running node, it is now possible to know exactly which
commit the code is based on, along with some other metadata.

This _buildinfo_ is exported via the logging subsystem when the
node boots, and it is also available under the `/buildinfo`
HTTP endpoint (using the HTTP mode of JSON/RPC).

Ref CGKIELE-463