### PR TITLE
Replace some logging with Riemann events

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,28 @@ After installing the `sbt-verify` library to your local repository checkout this
 
 This creates a distribution zip.
 
+### Logs
+
+Mantis uses [Riemann](http://riemann.io) as well as normal logs, by default Riemann events are sent to stdout however this can make things quite noisy. It is recommended that you run Riemann locally, this can be done using docker:
+
+`docker run -p 5555:5555 -p 5556:5556 riemannio/riemann`
+
+and uncommenting the `riemann` section of [application.conf](./src/main/resources/application.conf).
+
+You can then view Riemann events by using tools such as:
+
+[rcl](https://gitlab.com/shmish111/rcl)
+
+`rcl 'service =~ "mantis %"'`
+
+A useful query with `jq` filtering is:
+
+`rcl 'service =~ "mantis %" and not service =~ "mantis health %" and not service =~ "mantis riemann %"' | jq -c 'del(.[] | nulls) | del(.host) | del(.ttl) | del(.time)''`
+
+[riemann dash](https://hub.docker.com/r/include/docker-riemann-dash/)
+
+`docker run -p 4567:4567 include/docker-riemann-dash`
+
 ### Feedback
 
 Feedback gratefully received through the Ethereum Classic Forum (http://forum.ethereumclassic.org/)

--- a/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/data/GenesisDataLoader.scala
@@ -5,7 +5,7 @@ import java.io.FileNotFoundException
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader.JsonSerializers.ByteStringJsonSerializer
 import io.iohk.ethereum.rlp.RLPList
-import io.iohk.ethereum.utils.{BlockchainConfig, Logger, NumericUtils}
+import io.iohk.ethereum.utils._
 import io.iohk.ethereum.{crypto, rlp}
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.db.storage._
@@ -14,7 +14,7 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 import io.iohk.ethereum.rlp.RLPImplicits._
-import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.events._
 import org.json4s.{CustomSerializer, DefaultFormats, Formats, JString, JValue}
 import org.spongycastle.util.encoders.Hex
 
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success, Try}
 class GenesisDataLoader(
     blockchain: Blockchain,
     blockchainConfig: BlockchainConfig)
-  extends Logger{
+  extends Logger with EventSupport {
 
   private val bloomLength = 512
   private val hashLength = 64
@@ -35,32 +35,35 @@ class GenesisDataLoader(
   private val emptyTrieRootHash = ByteString(crypto.kec256(rlp.encode(Array.emptyByteArray)))
   private val emptyEvmHash: ByteString = crypto.kec256(ByteString.empty)
 
+  protected def mainService: String = "genesis load"
+
   def loadGenesisData(): Unit = {
-    Riemann.ok("genesis load").send
+    Event.okStart().send()
 
     val genesisJson = blockchainConfig.customGenesisFileOpt match {
       case Some(customGenesisFile) =>
-        Riemann.ok("genesis load").attribute("file", customGenesisFile).send
+        Event.ok().attribute(EventAttr.File, customGenesisFile).send()
 
         Try(Source.fromFile(customGenesisFile)).recoverWith { case _: FileNotFoundException =>
-          Riemann.warning("genesis load file").attribute("file", customGenesisFile).send
+          Event.warning("file").attribute(EventAttr.File, customGenesisFile).send()
           Try(Source.fromResource(customGenesisFile))
         } match {
           case Success(customGenesis) =>
-            Riemann.ok("genesis loaded file").attribute("file", customGenesisFile).send
+            Event.ok("file").attribute(EventAttr.File, customGenesisFile).send()
             try {
               customGenesis.getLines().mkString
             } finally {
               customGenesis.close()
             }
           case Failure(ex) =>
-            Riemann.exception("genesis load", ex).attribute("file", customGenesisFile).send
+            Event.exception(ex).attribute(EventAttr.File, customGenesisFile).send()
             throw ex
         }
       case None =>
-        Riemann.ok("genesis load resource").send
-        val src = Source.fromResource("blockchain/default-genesis.json")
+        val resource = "blockchain/default-genesis.json"
+        val src = Source.fromResource(resource)
         try {
+          Event.ok("resource").attribute(EventAttr.Resource, resource).send()
           src.getLines().mkString
         } finally {
           src.close()
@@ -69,9 +72,9 @@ class GenesisDataLoader(
 
     loadGenesisData(genesisJson) match {
       case Success(_) =>
-        Riemann.ok("genesis loaded").send
+        Event.okFinish().send()
       case Failure(ex) =>
-        Riemann.exception("genesis loaded", ex).send
+        Event.exceptionFinish(ex).send()
         throw ex
     }
   }
@@ -103,15 +106,16 @@ class GenesisDataLoader(
 
     val header: BlockHeader = prepareHeader(genesisData, stateMptRootHash)
 
-    header.toRiemann.send
+    Event(header.toRiemann).send()
 
     blockchain.getBlockHeaderByNumber(0) match {
       case Some(existingGenesisHeader) if existingGenesisHeader.hash == header.hash =>
-        Riemann.ok("genesis already exists").send
         Success(())
       case Some(_) =>
-        Failure(new RuntimeException("Genesis data present in the database does not match genesis block from file." +
-          " Use different directory for running private blockchains."))
+        val exception = new RuntimeException("Genesis data present in the database does not match genesis block from file." +
+          " Use different directory for running private blockchains.")
+        Event.exception(exception).send()
+        Failure(exception)
       case None =>
         ephemDataSource.getAll(nodeStorage.namespace)
           .foreach { case (key, value) => blockchain.saveNode(ByteString(key.toArray[Byte]), value.toArray[Byte], 0) }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -16,8 +16,8 @@ import io.iohk.ethereum.network.p2p.messages.PV63.MptNodeEncoders._
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.PV63._
 import io.iohk.ethereum.network.Peer
-import io.iohk.ethereum.utils.Riemann
 import io.iohk.ethereum.utils.Config.SyncConfig
+import io.iohk.ethereum.utils.events._
 import org.spongycastle.util.encoders.Hex
 
 import scala.annotation.tailrec
@@ -37,12 +37,15 @@ class FastSync(
     implicit val scheduler: Scheduler)
   extends Actor with ActorLogging
     with PeerListSupport with BlacklistSupport
-    with FastSyncReceiptsValidator with SyncBlocksValidator {
+    with FastSyncReceiptsValidator with SyncBlocksValidator
+    with EventSupport {
 
   import FastSync._
   import syncConfig._
 
   val syncController: ActorRef = context.parent
+
+  protected def mainService: String = "fast sync"
 
   override def receive: Receive = idle
 
@@ -53,7 +56,8 @@ class FastSync(
   }
 
   def start(): Unit = {
-    Riemann.ok("block sync start").attribute("mode", "fast").send
+    Event.okStart().send()
+
     fastSyncStateStorage.getSyncState() match {
       case Some(syncState) => startWithState(syncState)
       case None => startFromScratch()
@@ -61,10 +65,11 @@ class FastSync(
   }
 
   def startWithState(syncState: SyncState): Unit = {
-    Riemann.ok("block sync start")
-      .attribute("mode", "fast")
-      .attribute("targetBlock", s"${syncState.targetBlock.number}")
-      .metric(syncState.targetBlock.number.longValue).send
+    Event.okStart()
+      .block("target", syncState.targetBlock)
+      .metric(syncState.targetBlock.number.longValue)
+      .send()
+
     val syncingHandler = new SyncingHandler(syncState)
     context become syncingHandler.receive
     syncingHandler.processSyncing()
@@ -79,8 +84,10 @@ class FastSync(
   def waitingForTargetBlock: Receive = handleCommonMessages orElse {
     case FastSyncTargetBlockSelector.Result(targetBlockHeader) =>
       if (targetBlockHeader.number < 1) {
-        Riemann.warning("block sync start")
-          .description("Unable to start block synchronization in fast mode: target block is less than 1").send
+        Event.warningStart()
+          .description("Unable to start block synchronization in fast mode: target block is less than 1")
+          .send()
+
         appStateStorage.fastSyncDone()
         context become idle
         syncController ! Done
@@ -115,44 +122,53 @@ class FastSync(
     private val reportStatusCancellable = scheduler.schedule(reportStatusInterval, reportStatusInterval, self, PrintStatus)
     private val heartBeat = scheduler.schedule(syncRetryInterval, syncRetryInterval * 2, self, ProcessSyncing)
 
+    //scalastyle:off method.length
     def receive: Receive = handleCommonMessages orElse {
       case ProcessSyncing => processSyncing()
       case PrintStatus => reportStatus()
       case PersistSyncState => persistSyncState()
 
       case ResponseReceived(peer, BlockHeaders(blockHeaders), timeTaken) =>
-        Riemann.ok("block headers received").metric(timeTaken)
-          .attribute("timeTaken", s"${timeTaken} ms")
-          .attribute("blockHeaders", s"${blockHeaders.size}")
-          .send
+        Event.ok("headers received")
+          .metric(timeTaken)
+          .timeTakenMs(timeTaken)
+          .count(blockHeaders.size)
+          .send()
+
         removeRequestHandler(sender())
         handleBlockHeaders(peer, blockHeaders)
 
       case ResponseReceived(peer, BlockBodies(blockBodies), timeTaken) =>
-        Riemann.ok("block bodies received").metric(timeTaken)
-          .attribute("timeTaken", s"${timeTaken} ms")
-          .attribute("blockBodies", s"${blockBodies.size}")
-          .send
+        Event.ok("bodies received")
+          .metric(timeTaken)
+          .timeTakenMs(timeTaken)
+          .count(blockBodies.size)
+          .send()
+
         val requestedBodies = requestedBlockBodies.getOrElse(sender(), Nil)
         requestedBlockBodies -= sender()
         removeRequestHandler(sender())
         handleBlockBodies(peer, requestedBodies, blockBodies)
 
       case ResponseReceived(peer, Receipts(receipts), timeTaken) =>
-        Riemann.ok("block receipts received").metric(timeTaken)
-          .attribute("timeTaken", s"${timeTaken} ms")
-          .attribute("receipts", s"${receipts.size}")
-          .send
+        Event.ok("receipts received")
+          .metric(timeTaken)
+          .timeTakenMs(timeTaken)
+          .count(receipts.size)
+          .send()
+
         val requestedHashes = requestedReceipts.getOrElse(sender(), Nil)
         requestedReceipts -= sender()
         removeRequestHandler(sender())
         handleReceipts(peer, requestedHashes, receipts)
 
       case ResponseReceived(peer, nodeData: NodeData, timeTaken) =>
-        Riemann.ok("block state nodes received").metric(timeTaken)
-          .attribute("timeTaken", s"${timeTaken} ms")
-          .attribute("nodes", s"${nodeData.values.size}")
-          .send
+        Event.ok("state nodes received")
+          .metric(timeTaken)
+          .timeTakenMs(timeTaken)
+          .count(nodeData.values.size)
+          .send()
+
         val requestedHashes = requestedMptNodes.getOrElse(sender(), Nil) ++ requestedNonMptNodes.getOrElse(sender(), Nil)
         requestedMptNodes -= sender()
         requestedNonMptNodes -= sender()
@@ -218,17 +234,20 @@ class FastSync(
               else true
 
             case Left(error) =>
-              Riemann.warning("block header validation failed")
-                .attribute("header", s"${header.number}")
-                .attribute("error", error.toString)
-                .send
+              Event.warning("header validation failed")
+                .header(header)
+                .attribute(EventAttr.Error, error.toString)
+                .send()
 
               if (header.number == syncState.targetBlock.number) {
                 // target validation failed, declare a failure and stop syncing
                 log.error(s"Sync failure! Block header validation failed at fast sync target block. Blockchain state may be invalid.")
-                Riemann.warning("block header sync failed")
+                Event.warning("block header sync failed")
+                  .header(header)
+                  .block("target", syncState.targetBlock)
                   .description("Block header validation failed at fast sync target block. Blockchain state may be invalid.")
-                  .send
+                  .send()
+
                 sys.exit(1)
                 false
               } else {
@@ -315,9 +334,10 @@ class FastSync(
 
     private def handleNodeData(peer: Peer, requestedHashes: Seq[HashType], nodeData: NodeData) = {
       if (nodeData.values.isEmpty) {
-        Riemann.ok("peer blockchain only")
+        Event.ok("peer blockchain only")
           .attribute("hashes", s"${requestedHashes.map(h => Hex.toHexString(h.v.toArray[Byte]))}")
-          .send
+          .send()
+
         markPeerBlockchainOnly(peer)
       }
 
@@ -361,7 +381,7 @@ class FastSync(
         val account = Try(n.value.toArray[Byte].toAccount) match {
           case Success(acc) => Some(acc)
           case Failure(e) =>
-            Riemann.error("node without account").description(e.getMessage).send
+            Event.error("node without account").description(e.getMessage).send()
             None
         }
 
@@ -440,7 +460,7 @@ class FastSync(
           //todo adjust the formula to minimize redownloaded block headers
           bestBlockHeaderNumber = (syncState.bestBlockHeaderNumber - 2 * blockHeadersPerRequest).max(0)
       )
-      Riemann.warning("block header missing").send
+      Event.warning("header missing").send()
     }
 
     private def persistSyncState(): Unit = {
@@ -458,15 +478,16 @@ class FastSync(
     }
 
     private def reportStatus() = {
-      Riemann.ok("block number").metric(appStateStorage.getBestBlockNumber().longValue).send
-      Riemann.ok("block target").metric(initialSyncState.targetBlock.number.longValue).send
-      Riemann.ok("peers waiting").metric(assignedHandlers.size).send
-      Riemann.ok("peers connected").metric(handshakedPeers.size).send
-      Riemann.ok("nodes downloaded").metric(syncState.downloadedNodesCount).send
-      Riemann.ok("nodes total").metric(syncState.totalNodesCount).send
-      assignedHandlers.values.map { peer => peer.toRiemann.service("peer connected").send }
-      handshakedPeers.keys.map { peer => peer.toRiemann.service("peer handshaked").send }
-      blacklistedPeers.map { case (id, _) => Riemann.ok("peer blacklisted").attribute("id", id.value).send }
+      Event.ok("block number").metric(appStateStorage.getBestBlockNumber().longValue).send()
+      Event.ok("block target").metric(initialSyncState.targetBlock.number.longValue).send()
+      Event.ok("peers waiting").metric(assignedHandlers.size).send()
+      Event.ok("peers connected").metric(handshakedPeers.size).send()
+      Event.ok("nodes downloaded").metric(syncState.downloadedNodesCount).send()
+      Event.ok("nodes total").metric(syncState.totalNodesCount).send()
+
+      assignedHandlers.values.map { peer => Event(peer.toRiemann).service("peer connected").send() }
+      handshakedPeers.keys.map { peer => Event(peer.toRiemann).service("peer handshaked").send() }
+      blacklistedPeers.map { case (id, _) => Event.ok("peer blacklisted").attribute(EventAttr.Id, id.value).send() }
     }
 
     private def insertBlocks(requestedHashes: Seq[ByteString], blockBodies: Seq[BlockBody]): Unit = {
@@ -487,12 +508,15 @@ class FastSync(
         finish()
       } else {
         if (anythingToDownload) processDownloads()
-        else Riemann.ok("block sync download wait").metric(assignedHandlers.size).send
+        else Event.ok("download wait").metric(assignedHandlers.size).send()
       }
     }
 
     def finish(): Unit = {
-      Riemann.ok("block sync finished").description("Block synchronization in fast mode finished, switching to regular mode").send
+      Event.okFinish()
+        .description("Block synchronization in fast mode finished, switching to regular mode")
+        .send()
+
       cleanup()
       appStateStorage.fastSyncDone()
       context become idle
@@ -512,9 +536,12 @@ class FastSync(
     def processDownloads(): Unit = {
       if (unassignedPeers.isEmpty) {
         if (assignedHandlers.nonEmpty) {
-          Riemann.warning("no available peers").send
+          Event.warning("no available peers").send()
         } else {
-          Riemann.warning("no peers").attribute("retry-interval", syncRetryInterval.toString).send
+          Event.warning("no peers")
+            .attribute("retryInterval", syncRetryInterval.toString)
+            .send()
+
           scheduler.scheduleOnce(syncRetryInterval, self, ProcessSyncing)
         }
       } else {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/RegularSync.scala
@@ -21,7 +21,7 @@ import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{AddTransactions, RemoveTransactions}
 import io.iohk.ethereum.utils.Config.SyncConfig
 import org.spongycastle.util.encoders.Hex
-import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.events._
 
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -40,11 +40,12 @@ class RegularSync(
     val blockchain: Blockchain,
     val syncConfig: SyncConfig,
     implicit val scheduler: Scheduler)
-  extends Actor with ActorLogging with PeerListSupport with BlacklistSupport {
+  extends Actor with ActorLogging with PeerListSupport with BlacklistSupport with EventSupport {
 
   import RegularSync._
   import syncConfig._
 
+  protected def mainService: String = "regular sync"
 
   private var headersQueue: Seq[BlockHeader] = Nil
   private var waitingForActor: Option[ActorRef] = None
@@ -122,7 +123,10 @@ class RegularSync(
     case MessageFromPeer(NewBlock(newBlock, _), peerId) =>
       //we allow inclusion of new block only if we are not syncing
       if (notDownloading() && topOfTheChain) {
-        Riemann.ok("block new message").attribute("id", newBlock.idTag)
+        Event.ok("block new message")
+          .block(newBlock)
+          .send()
+
         val importResult = Try(ledger.importBlock(newBlock))
 
         importResult match {
@@ -130,63 +134,65 @@ class RegularSync(
             case BlockImportedToTop(newBlocks, newTds) =>
               broadcastBlocks(newBlocks, newTds)
               updateTxAndOmmerPools(newBlocks, Nil)
-              Riemann.ok("block new imported to top")
+
+              Event.ok("block new imported to top")
                 .metric(newBlock.header.number.longValue)
-                .attribute("number", newBlock.header.number.toString)
-                .attribute("peerId", peerId.toString)
-                .send
+                .block(newBlock)
+                .peerId(peerId)
+                .send()
 
             case BlockEnqueued =>
               ommersPool ! AddOmmers(newBlock.header)
-              Riemann.ok("block new enqueued")
+
+              Event.ok("block new enqueued")
                 .metric(newBlock.header.number.longValue)
-                .attribute("block", Hex.toHexString(newBlock.header.hash.toArray).toString)
-                .attribute("peerId", peerId.toString)
-                .send
+                .block(newBlock)
+                .peerId(peerId)
+                .send()
 
             case DuplicateBlock =>
-              Riemann.ok("block new duplicate")
+              Event.ok("block new duplicate")
                 .metric(newBlock.header.number.longValue)
-                .attribute("block", Hex.toHexString(newBlock.header.hash.toArray).toString)
-                .attribute("peerId", peerId.toString)
-                .send
+                .block(newBlock)
+                .peerId(peerId)
+                .send()
 
             case UnknownParent =>
               // This is normal when receiving broadcasted blocks
-              Riemann.ok("block new unknown parent")
+              Event.ok("block new unknown parent")
                 .metric(newBlock.header.number.longValue)
-                .attribute("block", Hex.toHexString(newBlock.header.hash.toArray).toString)
-                .attribute("peerId", peerId.toString)
-                .send
+                .block(newBlock)
+                .peerId(peerId)
+                .send()
 
             case ChainReorganised(oldBranch, newBranch, totalDifficulties) =>
               updateTxAndOmmerPools(newBranch, oldBranch)
               broadcastBlocks(newBranch, totalDifficulties)
-              Riemann.ok("block new chain reorganised")
+
+              Event.ok("block new chain reorganised")
                 .metric(newBlock.header.number.longValue)
-                .attribute("block", Hex.toHexString(newBlock.header.hash.toArray).toString)
-                .attribute("peerId", peerId.toString)
+                .block(newBlock)
+                .peerId(peerId)
                 .attribute("branchLength", newBranch.size.toString)
-                .attribute("previousNumber", newBranch.last.header.number.toString)
-                .attribute("previousBlock", Hex.toHexString(newBranch.last.header.hash.toArray).toString)
-                .send
+                .send()
 
             case BlockImportFailed(error) =>
               blacklist(peerId, blacklistDuration, error)
-              Riemann.warning("block new import failed")
+
+              Event.warning("block new import failed")
                 .metric(newBlock.header.number.longValue)
-                .attribute("peerId", peerId.toString)
+                .peerId(peerId)
                 .attribute("blacklistDuration", blacklistDuration.toString)
-                .attribute("peerId", error)
-                .send
+                .attribute(EventAttr.Error, error)
+                .send()
           }
 
           case Failure(missingNodeEx: MissingNodeException) if syncConfig.redownloadMissingStateNodes =>
             // state node redownload will be handled when downloading headers
-            Riemann.exception("block new missing node", missingNodeEx).send
+            Event.exception("block new missing node", missingNodeEx).send()
 
           case Failure(ex) =>
-            Riemann.exception("block new", ex).send
+            Event.exception("block new", ex).send()
             throw ex
         }
       }
@@ -245,37 +251,41 @@ class RegularSync(
 
   def handleResponseToRequest: Receive = {
     case ResponseReceived(peer: Peer, BlockHeaders(headers), timeTaken) =>
-      Riemann.ok("block headers received")
+      Event.ok("block headers received")
         .metric(headers.size)
-        .attribute("timeTaken", timeTaken.toString)
+        .timeTakenMs(timeTaken)
         .attribute("peer", peer.toString)
         .attribute("resolvingBranches", resolvingBranches.toString)
-        .send
+        .send()
+
       waitingForActor = None
       if (resolvingBranches) handleBlockBranchResolution(peer, headers.reverse)
       else handleBlockHeaders(peer, headers)
 
     case ResponseReceived(peer, BlockBodies(blockBodies), timeTaken) =>
-      Riemann.ok("block bodies received")
+      Event.ok("block bodies received")
         .metric(blockBodies.size)
-        .attribute("timeTaken", timeTaken.toString)
-        .send
+        .timeTakenMs(timeTaken)
+        .send()
+
       waitingForActor = None
       handleBlockBodies(peer, blockBodies)
 
     case ResponseReceived(peer, NodeData(nodes), timeTaken) if missingStateNodeRetry.isDefined =>
-      Riemann.ok("received missing state nodes")
+      Event.ok("received missing state nodes")
         .metric(nodes.size)
-        .attribute("timeTaken", timeTaken.toString)
-        .send
+        .timeTakenMs(timeTaken)
+        .send()
+
       waitingForActor = None
       handleRedownloadedStateNodes(peer, nodes)
 
     case PeerRequestHandler.RequestFailed(peer, reason) if waitingForActor.contains(sender()) =>
-      Riemann.warning("peer request failed")
+      Event.warning("peer request failed")
         .attribute("peer", peer.toString)
         .attribute("reason", reason.toString)
-        .send
+        .send()
+
       waitingForActor = None
       if (handshakedPeers.contains(peer)) {
         blacklist(peer.id, blacklistDuration, reason)
@@ -294,34 +304,54 @@ class RegularSync(
         importResult match {
           case Success(result) => result match {
             case BlockImportedToTop(blocks, totalDifficulties) =>
-              Riemann.ok("block mined imported to top").metric(block.header.number.longValue).send
+              Event.ok("block mined imported to top")
+                .metric(block.header.number.longValue)
+                .send()
+
               broadcastBlocks(blocks, totalDifficulties)
               updateTxAndOmmerPools(blocks, Nil)
 
             case ChainReorganised(oldBranch, newBranch, totalDifficulties) =>
-              Riemann.ok("mined block chain reorganised").metric(block.header.number.longValue).send
+              Event.ok("mined block chain reorganised")
+                .metric(block.header.number.longValue)
+                .send()
+
               broadcastBlocks(newBranch, totalDifficulties)
               updateTxAndOmmerPools(newBranch, oldBranch)
 
             case DuplicateBlock =>
-              Riemann.warning("mined block chain duplicate").metric(block.header.number.longValue).send
+              Event.warning("mined block chain duplicate")
+                .metric(block.header.number.longValue)
+                .send()
 
             case BlockEnqueued =>
-              Riemann.ok("mined block enqueued").metric(block.header.number.longValue).send
+              Event.ok("mined block enqueued")
+                .metric(block.header.number.longValue)
+                .send()
+
               ommersPool ! AddOmmers(block.header)
 
             case UnknownParent =>
-              Riemann.warning("mined block unknown parent").metric(block.header.number.longValue).send
+              Event.warning("mined block unknown parent")
+                .metric(block.header.number.longValue)
+                .send()
 
             case BlockImportFailed(err) =>
-              Riemann.warning("mined block import failed").metric(block.header.number.longValue).attribute("error", err).send
+              Event.warning("mined block import failed")
+                .metric(block.header.number.longValue)
+                .attribute("error", err)
+                .send()
           }
 
           case Failure(missingNodeEx: MissingNodeException) if syncConfig.redownloadMissingStateNodes =>
-            Riemann.exception("mined block missing node", missingNodeEx).metric(block.header.number.longValue).send
+            Event.exception("mined block missing node", missingNodeEx)
+              .metric(block.header.number.longValue)
+              .send()
 
           case Failure(ex) =>
-            Riemann.exception("mined block", ex).metric(block.header.number.longValue).send
+            Event.exception("mined block", ex)
+              .metric(block.header.number.longValue)
+              .send()
             throw ex
         }
 

--- a/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/atomixraft/AtomixRaftConsensus.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.consensus
 package atomixraft
 
-import java.time.{Duration => JDuration}
+import java.time.{Duration ⇒ JDuration}
 
 import io.atomix.cluster._
 import io.atomix.cluster.impl.{DefaultClusterMetadataService, DefaultClusterService}
@@ -25,7 +25,8 @@ import io.iohk.ethereum.ledger.BlockPreparator
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.metrics.Metrics
 import io.iohk.ethereum.nodebuilder.Node
-import io.iohk.ethereum.utils.{BlockchainConfig, Logger, VmConfig, Riemann}
+import io.iohk.ethereum.utils._
+import io.iohk.ethereum.utils.events._
 
 class AtomixRaftConsensus private(
   val vm: VMImpl,
@@ -34,7 +35,12 @@ class AtomixRaftConsensus private(
   val config: FullConsensusConfig[AtomixRaftConfig],
   val validators: Validators,
   val blockGenerator: AtomixRaftBlockGenerator
-) extends TestConsensus with Logger {
+) extends TestConsensus with Logger with EventSupport {
+
+  protected def mainService: String = "raft"
+
+  override protected def postProcessEvent(event: EventDSL): EventDSL =
+    event.tag("consensus")
 
   type Config = AtomixRaftConfig
 
@@ -64,7 +70,7 @@ class AtomixRaftConsensus private(
   private[this] def stopForger(): Unit = forgerRef.kill()
 
   private[this] def onRaftServerStarted(messagingService: ManagedMessagingService): Unit = {
-    Riemann.ok("raft server started").attribute("endpoint", messagingService.endpoint.toString).send
+    Event.ok("server started").attribute("endpoint", messagingService.endpoint.toString).send()
   }
 
   private[this] def onLeaderWithMiningEnabled(): Unit = {
@@ -75,7 +81,7 @@ class AtomixRaftConsensus private(
   }
 
   private[this] def onLeaderWithMiningDisabled(): Unit = {
-    Riemann.warning("raft server elected").attribute(ConsensusConfig.Keys.MiningEnabled, config.miningEnabled.toString).send
+    Event.warning("leader elected").attribute(ConsensusConfig.Keys.MiningEnabled, config.miningEnabled.toString).send()
 
     raftServer.run { server ⇒
       val cluster = server.cluster()
@@ -83,22 +89,22 @@ class AtomixRaftConsensus private(
 
       // We have just become the leader but what is the probability of having a re-election and a new leader,
       // thus kicking out a different leader?
-      Riemann.ok("raft server demoting").attribute("leader", leader.toString).send
+      Event.ok("server demoting").attribute("leader", leader.toString).send()
       try leader.demote().join()
       catch {
         case t: Throwable ⇒
-          Riemann.exception("raft server demoting", t).attribute("leader", leader.toString).send
+          Event.exception("server demoting", t).attribute("leader", leader.toString).send()
           throw t
       }
     }
   }
 
   private[this] def onClusterEvent(event: ClusterEvent): Unit = {
-    Riemann.ok("atomix server cluster event").attribute("event", event.toString).send
+    Event.ok("cluster event").attribute("event", event.toString).send()
   }
 
   private[this] def onRoleChange(role: RaftServer.Role): Unit = {
-    Riemann.ok("raft server role changed").attribute("role", role.toString).attribute(ConsensusConfig.Keys.MiningEnabled, config.miningEnabled.toString).send
+    Event.ok("role changed").attribute("role", role.toString).attribute(ConsensusConfig.Keys.MiningEnabled, config.miningEnabled.toString).send()
 
     if(role == RaftServer.Role.LEADER) {
       if(config.miningEnabled) {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -17,7 +17,7 @@ import io.iohk.ethereum.jsonrpc.TestService._
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer.JsonRpcHttpServerConfig
 import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer.JsonRpcIpcServerConfig
 import io.iohk.ethereum.metrics.Metrics
-import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.events._
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -90,7 +90,7 @@ class JsonRpcController(
   ethService: EthService,
   personalService: PersonalService,
   testServiceOpt: Option[TestService],
-  config: JsonRpcConfig) extends Logger {
+  config: JsonRpcConfig) extends Logger with EventSupport {
 
   import JsonRpcController._
   import EthJsonMethodsImplicits._
@@ -100,6 +100,8 @@ class JsonRpcController(
   import JsonRpcErrors._
 
   private[this] val metrics = new JsonRpcControllerMetrics(Metrics.get())
+
+  protected def mainService: String = "jsonrpc"
 
   lazy val apisHandleFns: Map[String, PartialFunction[JsonRpcRequest, Future[JsonRpcResponse]]] = Map(
     Apis.Eth -> handleEthRequest,
@@ -310,24 +312,37 @@ class JsonRpcController(
     responseF.andThen {
       case Success(response) ⇒ {
         if (response.isOK) {
-          Riemann.ok("health jsonrpc").send()
-        }else {
-          Riemann.error("health jsonrpc").send()
+          Event.ok("health").send()
+        }
+        else {
           metrics.HealhcheckErrorCounter.increment()
-          response.checks.map { result => result.status match {
-                                 case HealthcheckStatus.OK => Riemann.ok(s"health jsonrpc ${result.description}").send()
-                                 case _ => Riemann
-                                     .error(s"health jsonrpc ${result.description}")
-                                     .attribute("error", result.error.getOrElse("unknown"))
-                                     .send()
-                               }
+
+          Event.error("health").send()
+          response.checks.foreach { result =>
+            (result.status, result.error) match {
+              case (HealthcheckStatus.OK, None) =>
+                Event.ok(s"health ${result.description}").send()
+
+              case (HealthcheckStatus.ERROR, Some(error)) =>
+                Event
+                  .error(s"health ${result.description}")
+                  .attribute(EventAttr.Error, error)
+                  .send()
+              case _ =>
+                // See assertion in [[io.iohk.ethereum.healthcheck.HealthcheckResult]]
+                Event.error("health result internal error")
+                  .attribute(EventAttr.Status, result.status)
+                  .attribute(EventAttr.Error, result.error.toString)
+                  .send()
+            }
           }
         }
       }
 
       case Failure(t) ⇒ {
         metrics.HealhcheckErrorCounter.increment()
-        Riemann.exception("health jsonrpc", t).send()
+
+        Event.exception("health", t).send()
       }
     }
   }

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -10,6 +10,7 @@ import io.iohk.ethereum.ledger.Ledger._
 import io.iohk.ethereum.metrics.Metrics
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils._
+import io.iohk.ethereum.utils.events._
 import io.iohk.ethereum.vm._
 import org.spongycastle.util.encoders.Hex
 
@@ -77,7 +78,7 @@ class LedgerImpl(
   blockQueue: BlockQueue,
   blockchainConfig: BlockchainConfig,
   theConsensus: Consensus
-) extends Ledger with Logger {
+) extends Ledger with Logger with EventSupport {
 
   def this(
     blockchain: BlockchainImpl,
@@ -92,6 +93,8 @@ class LedgerImpl(
   private[ledger] val blockRewardCalculator = _blockPreparator.blockRewardCalculator
 
   private[this] final val metrics = new LedgerMetrics(Metrics.get(), () ⇒ blockchain.getBestBlockNumber().doubleValue)
+
+  protected def mainService: String = "ledger"
 
   def consensus: Consensus = theConsensus
 
@@ -160,17 +163,25 @@ class LedgerImpl(
 
     importedBlocks.foreach { b =>
       log.debug(s"Imported new block (${b.header.number}: ${Hex.toHexString(b.header.hash.toArray)}) to the top of chain")
-      Riemann.ok("ledger block imported").metric(b.header.number.longValue).attribute("header", Hex.toHexString(b.header.hash.toArray)).send()
+      Event.ok("block imported")
+        .metric(b.header.number.longValue)
+        .block(b)
+        .tag(EventTag.BlockImport)
+        .send()
     }
 
     if(importedBlocks.nonEmpty) {
       val blocksCount = importedBlocks.size
       metrics.ImportedBlocksCounter.increment(blocksCount.toDouble)
-      Riemann.ok("ledger blocks imported").metric(blocksCount.toDouble).send()
+      Event.ok("blocks imported")
+        .metric(blocksCount.toDouble)
+        .send()
 
       val transactionsCount = importedBlocks.map(_.body.transactionList.length).sum
       metrics.ImportedTransactionsCounter.increment(transactionsCount.toDouble)
-      Riemann.ok("ledger transactions imported").metric(transactionsCount).send()
+      Event.ok("transactions imported")
+        .metric(transactionsCount)
+        .send()
     }
 
     result

--- a/src/main/scala/io/iohk/ethereum/network/KnownNodesManager.scala
+++ b/src/main/scala/io/iohk/ethereum/network/KnownNodesManager.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import akka.actor.{Actor, Props, Scheduler}
 import io.iohk.ethereum.db.storage.KnownNodesStorage
 import io.iohk.ethereum.network.KnownNodesManager.KnownNodesManagerConfig
-import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.events._
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -14,7 +14,7 @@ class KnownNodesManager(
     config: KnownNodesManagerConfig,
     knownNodesStorage: KnownNodesStorage,
     externalSchedulerOpt: Option[Scheduler] = None)
-  extends Actor {
+  extends Actor with EventSupport {
 
   import KnownNodesManager._
 
@@ -27,6 +27,8 @@ class KnownNodesManager(
   var toRemove: Set[URI] = Set.empty
 
   scheduler.schedule(config.persistInterval, config.persistInterval, self, PersistChanges)
+
+  protected def mainService: String = "known nodes manager"
 
   override def receive: Receive = {
     case AddKnownNode(uri) =>
@@ -51,7 +53,7 @@ class KnownNodesManager(
   }
 
   private def persistChanges(): Unit = {
-    Riemann.ok("persisting known nodes").metric(knownNodes.size).send
+    Event.ok("persist").metric(knownNodes.size).send()
     if (knownNodes.size > config.maxPersistedNodes) {
       val toAbandon = knownNodes.take(knownNodes.size - config.maxPersistedNodes)
       toRemove ++= toAbandon

--- a/src/main/scala/io/iohk/ethereum/network/KnownNodesManager.scala
+++ b/src/main/scala/io/iohk/ethereum/network/KnownNodesManager.scala
@@ -2,9 +2,10 @@ package io.iohk.ethereum.network
 
 import java.net.URI
 
-import akka.actor.{Actor, ActorLogging, Props, Scheduler}
+import akka.actor.{Actor, Props, Scheduler}
 import io.iohk.ethereum.db.storage.KnownNodesStorage
 import io.iohk.ethereum.network.KnownNodesManager.KnownNodesManagerConfig
+import io.iohk.ethereum.utils.Riemann
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -13,7 +14,7 @@ class KnownNodesManager(
     config: KnownNodesManagerConfig,
     knownNodesStorage: KnownNodesStorage,
     externalSchedulerOpt: Option[Scheduler] = None)
-  extends Actor with ActorLogging {
+  extends Actor {
 
   import KnownNodesManager._
 
@@ -50,7 +51,7 @@ class KnownNodesManager(
   }
 
   private def persistChanges(): Unit = {
-    log.debug(s"Persisting ${knownNodes.size} known nodes.")
+    Riemann.ok("persisting known nodes").metric(knownNodes.size).send
     if (knownNodes.size > config.maxPersistedNodes) {
       val toAbandon = knownNodes.take(knownNodes.size - config.maxPersistedNodes)
       toRemove ++= toAbandon

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -22,6 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
+import io.iohk.ethereum.utils.Riemann
 
 //TODO Refactor to mutate state only via context.become [EC-316]
 class PeerManagerActor(
@@ -31,7 +32,7 @@ class PeerManagerActor(
     knownNodesManager: ActorRef,
     peerFactory: (ActorContext, InetSocketAddress, Boolean) => ActorRef,
     externalSchedulerOpt: Option[Scheduler] = None)
-  extends Actor with ActorLogging with Stash {
+  extends Actor with Stash {
 
   import PeerManagerActor._
   import akka.pattern.{ask, pipe}
@@ -69,7 +70,7 @@ class PeerManagerActor(
       val nodesToConnect = nodes.take(peerConfiguration.maxOutgoingPeers)
 
       if (nodesToConnect.nonEmpty) {
-        log.debug("Trying to connect to {} known nodes", nodesToConnect.size)
+        Riemann.ok("peer nodes discovered").metric(nodesToConnect.size).send
         nodesToConnect.foreach(n => self ! ConnectToPeer(n))
       }
 
@@ -88,14 +89,14 @@ class PeerManagerActor(
         .sortBy(-_.addTimestamp)
         .take(peerConfiguration.maxOutgoingPeers - peerAddresses.size)
 
-      log.debug(
-        s"Discovered ${nodesInfo.size} nodes, " +
-        s"connected to ${managerState.peers.size}/${peerConfiguration.maxOutgoingPeers + peerConfiguration.maxIncomingPeers}. " +
-        s"Trying to connect to ${nodesToConnect.size} more nodes."
-      )
+      Riemann.ok("peer nodes connected")
+        .metric(nodesToConnect.size)
+        .attribute("configuredPeers", (peerConfiguration.maxOutgoingPeers + peerConfiguration.maxIncomingPeers).toString)
+        .attribute("retryPeers", nodesToConnect.size.toString)
+        .send
 
       if (nodesToConnect.nonEmpty) {
-        log.debug("Trying to connect to {} nodes", nodesToConnect.size)
+        Riemann.ok("peer nodes discovered").metric(nodesInfo.size).send
         nodesToConnect.foreach(n => self ! ConnectToPeer(n.node.toUri))
       }
   }
@@ -190,18 +191,18 @@ class PeerManagerActor(
 
   private def handleConnectionErrors(error: ConnectionError): Unit = error match {
     case MaxIncomingPendingConnections(connection)  =>
-      log.debug("Maximum number of pending incoming peers reached.")
+      Riemann.warning("peer pending connection limit reached").send
       connection ! PoisonPill
 
     case IncomingConnectionAlreadyHandled(remoteAddress, connection) =>
-      log.debug("Another connection with {} is already opened. Disconnecting.", remoteAddress)
+      Riemann.warning("peer pending connection already open").attribute("remoteAddress", remoteAddress.toString).send
       connection ! PoisonPill
 
     case MaxOutgoingConnections =>
-      log.debug("Maximum number of connected peers reached.")
+      Riemann.warning("peer connection limit reached").send
 
     case OutgoingConnectionAlreadyHandled(uri) =>
-      log.debug("Another connection with {} is already opened", uri)
+      Riemann.warning("peer connection already open").attribute("uri", uri.toString).send
   }
 }
 

--- a/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/PeerManagerActor.scala
@@ -22,7 +22,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.events._
 
 //TODO Refactor to mutate state only via context.become [EC-316]
 class PeerManagerActor(
@@ -32,7 +32,7 @@ class PeerManagerActor(
     knownNodesManager: ActorRef,
     peerFactory: (ActorContext, InetSocketAddress, Boolean) => ActorRef,
     externalSchedulerOpt: Option[Scheduler] = None)
-  extends Actor with Stash {
+  extends Actor with Stash with EventSupport {
 
   import PeerManagerActor._
   import akka.pattern.{ask, pipe}
@@ -45,6 +45,8 @@ class PeerManagerActor(
     OneForOneStrategy() {
       case _ => Stop
     }
+
+  protected def mainService: String = "peer manager"
 
   override def receive: Receive = {
 
@@ -70,7 +72,7 @@ class PeerManagerActor(
       val nodesToConnect = nodes.take(peerConfiguration.maxOutgoingPeers)
 
       if (nodesToConnect.nonEmpty) {
-        Riemann.ok("peer nodes discovered").metric(nodesToConnect.size).send
+        Event.ok("peer nodes discovered").metric(nodesToConnect.size).send()
         nodesToConnect.foreach(n => self ! ConnectToPeer(n))
       }
 
@@ -89,14 +91,14 @@ class PeerManagerActor(
         .sortBy(-_.addTimestamp)
         .take(peerConfiguration.maxOutgoingPeers - peerAddresses.size)
 
-      Riemann.ok("peer nodes connected")
+      Event.ok("peer nodes connected")
         .metric(nodesToConnect.size)
         .attribute("configuredPeers", (peerConfiguration.maxOutgoingPeers + peerConfiguration.maxIncomingPeers).toString)
         .attribute("retryPeers", nodesToConnect.size.toString)
-        .send
+        .send()
 
       if (nodesToConnect.nonEmpty) {
-        Riemann.ok("peer nodes discovered").metric(nodesInfo.size).send
+        Event.ok("peer nodes discovered").metric(nodesInfo.size).send()
         nodesToConnect.foreach(n => self ! ConnectToPeer(n.node.toUri))
       }
   }
@@ -191,18 +193,27 @@ class PeerManagerActor(
 
   private def handleConnectionErrors(error: ConnectionError): Unit = error match {
     case MaxIncomingPendingConnections(connection)  =>
-      Riemann.warning("peer pending connection limit reached").send
+      Event.warning("pending connection limit reached")
+        .attribute("connection", connection.toString)
+        .send()
+
       connection ! PoisonPill
 
     case IncomingConnectionAlreadyHandled(remoteAddress, connection) =>
-      Riemann.warning("peer pending connection already open").attribute("remoteAddress", remoteAddress.toString).send
+      Event.warning("pending connection already open")
+        .attribute("remoteAddress", remoteAddress.toString)
+        .attribute("connection", connection.toString)
+        .send()
+
       connection ! PoisonPill
 
     case MaxOutgoingConnections =>
-      Riemann.warning("peer connection limit reached").send
+      Event.warning("outgoing connection limit reached").send()
 
     case OutgoingConnectionAlreadyHandled(uri) =>
-      Riemann.warning("peer connection already open").attribute("uri", uri.toString).send
+      Event.warning("connection already open")
+        .attribute("uri", uri.toString)
+        .send()
   }
 }
 

--- a/src/main/scala/io/iohk/ethereum/network/ServerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/ServerActor.scala
@@ -2,14 +2,14 @@ package io.iohk.ethereum.network
 
 import java.net.InetSocketAddress
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.agent.Agent
 import akka.io.Tcp.{Bind, Bound, CommandFailed, Connected}
 import akka.io.{IO, Tcp}
-import io.iohk.ethereum.utils.{NodeStatus, ServerStatus}
+import io.iohk.ethereum.utils.{NodeStatus, ServerStatus, Riemann}
 import org.spongycastle.util.encoders.Hex
 
-class ServerActor(nodeStatusHolder: Agent[NodeStatus], peerManager: ActorRef) extends Actor with ActorLogging {
+class ServerActor(nodeStatusHolder: Agent[NodeStatus], peerManager: ActorRef) extends Actor {
 
   import ServerActor._
   import context.system
@@ -23,16 +23,17 @@ class ServerActor(nodeStatusHolder: Agent[NodeStatus], peerManager: ActorRef) ex
   def waitingForBindingResult: Receive = {
     case Bound(localAddress) =>
       val nodeStatus = nodeStatusHolder()
-      log.info("Listening on {}", localAddress)
-      log.info("Node address: enode://{}@{}:{}",
-        Hex.toHexString(nodeStatus.nodeId),
-        getHostName(localAddress.getAddress),
-        localAddress.getPort)
+      Riemann.ok("server actor listening")
+        .attribute("localAddress", localAddress.toString)
+        .attribute("nodeAddress", s"enode://${Hex.toHexString(nodeStatus.nodeId)}@${getHostName(localAddress.getAddress)}:${localAddress.getPort}")
+        .send
       nodeStatusHolder.send(_.copy(serverStatus = ServerStatus.Listening(localAddress)))
       context become listening
 
     case CommandFailed(b: Bind) =>
-      log.warning("Binding to {} failed", b.localAddress)
+      Riemann.error("server actor listening")
+        .attribute("localAddress", b.localAddress.toString)
+        .send
       context stop self
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/ServerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/network/ServerActor.scala
@@ -6,13 +6,16 @@ import akka.actor.{Actor, ActorRef, Props}
 import akka.agent.Agent
 import akka.io.Tcp.{Bind, Bound, CommandFailed, Connected}
 import akka.io.{IO, Tcp}
-import io.iohk.ethereum.utils.{NodeStatus, ServerStatus, Riemann}
+import io.iohk.ethereum.utils.{NodeStatus, ServerStatus}
+import io.iohk.ethereum.utils.events._
 import org.spongycastle.util.encoders.Hex
 
-class ServerActor(nodeStatusHolder: Agent[NodeStatus], peerManager: ActorRef) extends Actor {
+class ServerActor(nodeStatusHolder: Agent[NodeStatus], peerManager: ActorRef) extends Actor with EventSupport {
 
   import ServerActor._
   import context.system
+
+  protected def mainService: String = "server actor"
 
   override def receive: Receive = {
     case StartServer(address) =>
@@ -23,17 +26,19 @@ class ServerActor(nodeStatusHolder: Agent[NodeStatus], peerManager: ActorRef) ex
   def waitingForBindingResult: Receive = {
     case Bound(localAddress) =>
       val nodeStatus = nodeStatusHolder()
-      Riemann.ok("server actor listening")
+      Event.ok("listening")
         .attribute("localAddress", localAddress.toString)
         .attribute("nodeAddress", s"enode://${Hex.toHexString(nodeStatus.nodeId)}@${getHostName(localAddress.getAddress)}:${localAddress.getPort}")
-        .send
+        .send()
+
       nodeStatusHolder.send(_.copy(serverStatus = ServerStatus.Listening(localAddress)))
       context become listening
 
     case CommandFailed(b: Bind) =>
-      Riemann.error("server actor listening")
+      Event.error("listening")
         .attribute("localAddress", b.localAddress.toString)
-        .send
+        .send()
+
       context stop self
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcForkBlockExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcForkBlockExchangeState.scala
@@ -7,12 +7,16 @@ import io.iohk.ethereum.network.p2p.{Message, MessageSerializable}
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
 import io.iohk.ethereum.network.p2p.messages.PV62.{BlockHeaders, GetBlockHeaders}
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
-import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.events._
 
-case class EtcForkBlockExchangeState(handshakerConfiguration: EtcHandshakerConfiguration,
-                                     forkResolver: ForkResolver, remoteStatus: Status) extends InProgressState[PeerInfo] {
+case class EtcForkBlockExchangeState(
+  handshakerConfiguration: EtcHandshakerConfiguration,
+  forkResolver: ForkResolver, remoteStatus: Status
+) extends InProgressState[PeerInfo] with EventSupport {
 
   import handshakerConfiguration._
+
+  protected def mainService: String = "fork block state"
 
   def nextMessage: NextMessage =
     NextMessage(
@@ -30,19 +34,29 @@ case class EtcForkBlockExchangeState(handshakerConfiguration: EtcHandshakerConfi
         case Some(forkBlockHeader) =>
           val fork = forkResolver.recognizeFork(forkBlockHeader)
 
-          Riemann.ok("peer fork").attribute("fork", fork.toString).send
-
           if (forkResolver.isAccepted(fork)) {
-            Riemann.ok("peer fork accepted").send
+            Event.ok("peer fork accepted")
+              .attribute("fork", fork.toString)
+              .attribute("forkBlockNumber", forkResolver.forkBlockNumber.toString)
+              .send()
+
             val peerInfo: PeerInfo = PeerInfo(remoteStatus, remoteStatus.totalDifficulty, true, forkBlockHeader.number)
             ConnectedState(peerInfo)
           } else {
-            Riemann.warning("peer fork denied").send
+            Event.warning("peer fork denied")
+              .attribute("fork", fork.toString)
+              .attribute("forkBlockNumber", forkResolver.forkBlockNumber.toString)
+              .send()
+
             DisconnectedState[PeerInfo](Disconnect.Reasons.UselessPeer)
           }
 
         case None =>
-          Riemann.warning("peer fork no header").description("Peer did not respond with fork block header").send
+          Event.warning("peer fork no header")
+            .attribute("forkBlockNumber", forkResolver.forkBlockNumber.toString)
+            .description("Peer did not respond with fork block header")
+            .send()
+
           ConnectedState(PeerInfo(remoteStatus, remoteStatus.totalDifficulty, false, 0))
       }
 
@@ -51,7 +65,10 @@ case class EtcForkBlockExchangeState(handshakerConfiguration: EtcHandshakerConfi
   override def respondToRequest(receivedMessage: Message): Option[MessageSerializable] = receivedMessage match {
 
     case GetBlockHeaders(Left(number), numHeaders, _, _) if number == forkResolver.forkBlockNumber && numHeaders == 1 =>
-      Riemann.ok("peer fork block requested").send
+      Event.ok("peer fork block requested")
+        .attribute("forkBlockNumber", forkResolver.forkBlockNumber.toString)
+        .send()
+
       blockchain.getBlockHeaderByNumber(number) match {
         case Some(header) => Some(BlockHeaders(Seq(header)))
         case None => Some(BlockHeaders(Nil))

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcHelloExchangeState.scala
@@ -6,15 +6,22 @@ import io.iohk.ethereum.network.handshaker.Handshaker.NextMessage
 import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.Versions
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.{Capability, Disconnect, Hello}
-import io.iohk.ethereum.utils.{Config, ServerStatus, Riemann}
+import io.iohk.ethereum.utils.{Config, ServerStatus}
+import io.iohk.ethereum.utils.events._
 
 
-case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfiguration) extends InProgressState[PeerInfo] {
+case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfiguration)
+  extends InProgressState[PeerInfo] with EventSupport {
 
   import handshakerConfiguration._
 
+  protected def mainService: String = "hello state"
+
   override def nextMessage: NextMessage = {
-    Riemann.ok("peer send hello").description("RLPx connection established, sending Hello").send
+    Event.ok("peer send hello")
+      .description("RLPx connection established, sending Hello")
+      .send()
+
     NextMessage(
       messageToSend = createHelloMsg(),
       timeout = peerConfiguration.waitForHelloTimeout
@@ -24,21 +31,24 @@ case class EtcHelloExchangeState(handshakerConfiguration: EtcHandshakerConfigura
   override def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = {
 
     case hello: Hello =>
-      hello.toRiemann.description("Protocol handshake finished").send
+      hello.toRiemann.description("Protocol handshake finished").send()
+
       if (hello.capabilities.contains(Capability("eth", Versions.PV63.toByte)))
         EtcNodeStatusExchangeState(handshakerConfiguration)
       else {
-        Riemann.warning("peer disconnecting")
+        Event.warning("peer disconnecting")
           .description("Connected peer does not support eth protocol. Disconnecting.")
           .attribute("protocol", Versions.PV63.toByte.toString)
-          .send
+          .send()
+
         DisconnectedState(Disconnect.Reasons.IncompatibleP2pProtocolVersion)
       }
 
   }
 
   override def processTimeout: HandshakerState[PeerInfo] = {
-    Riemann.warning("peer handshake timeout").attribute("type", "hello").send
+    Event.warning("peer handshake timeout").attribute("type", "hello").send()
+
     DisconnectedState(Disconnect.Reasons.TimeoutOnReceivingAMessage)
   }
 

--- a/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
+++ b/src/main/scala/io/iohk/ethereum/network/handshaker/EtcNodeStatusExchangeState.scala
@@ -4,15 +4,17 @@ import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.handshaker.Handshaker.NextMessage
 import io.iohk.ethereum.network.p2p.Message
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
-import io.iohk.ethereum.network.p2p.messages.CommonMessages._
 import io.iohk.ethereum.network.p2p.messages.Versions
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect
 import io.iohk.ethereum.network.p2p.messages.WireProtocol.Disconnect.Reasons
-import io.iohk.ethereum.utils.Riemann
+import io.iohk.ethereum.utils.events._
 
-case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConfiguration) extends InProgressState[PeerInfo] {
+case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConfiguration)
+  extends InProgressState[PeerInfo] with EventSupport  {
 
   import handshakerConfiguration._
+
+  protected def mainService: String = "node state"
 
   def nextMessage: NextMessage =
     NextMessage(
@@ -23,7 +25,9 @@ case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConf
   def applyResponseMessage: PartialFunction[Message, HandshakerState[PeerInfo]] = {
 
     case remoteStatus: Status =>
-      Riemann.ok("peer handshake").attribute("type", "status").attribute("status", remoteStatus.toString).send
+      Event.ok("peer handshake")
+        .attribute("status", remoteStatus.toString)
+        .send()
 
       val validNetworkID = remoteStatus.networkId == handshakerConfiguration.peerConfiguration.networkId
       val validGenesisHash = remoteStatus.genesisHash == blockchain.genesisHeader.hash
@@ -41,7 +45,8 @@ case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConf
   }
 
   def processTimeout: HandshakerState[PeerInfo] = {
-    Riemann.warning("peer handshake timeout").attribute("type", "status").send
+    Event.warning("peer handshake timeout").send()
+
     DisconnectedState(Disconnect.Reasons.TimeoutOnReceivingAMessage)
   }
 
@@ -53,13 +58,16 @@ case class EtcNodeStatusExchangeState(handshakerConfiguration: EtcHandshakerConf
   private def createStatusMsg(): Status = {
     val bestBlockHeader = getBestBlockHeader()
     val totalDifficulty = blockchain.getTotalDifficultyByHash(bestBlockHeader.hash).get
+
     val status = Status(
       protocolVersion = Versions.PV63,
       networkId = peerConfiguration.networkId,
       totalDifficulty = totalDifficulty,
       bestHash = bestBlockHeader.hash,
       genesisHash = blockchain.genesisHeader.hash)
-    status.toRiemann.send
+
+    status.toRiemann.send()
+
     status
   }
 

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -48,16 +48,15 @@ object Config {
 
   val healthIntervalMilliseconds: Long = config.getDuration("health-interval").toMillis()
 
-  val riemann = getOptionalConfig(config, "riemann") match {
-    case None => None
-    case Some(riemannConfig) => Some(new RiemannConfiguration(
-                                       riemannConfig.getString("host"),
-                                       riemannConfig.getInt("port"),
-                                       riemannConfig.getInt("batch-size"),
-                                       riemannConfig.getInt("buffer-size"),
-                                       riemannConfig.getInt("auto-flush-ms"),
-                                       getOptionalString(riemannConfig, "host-name").getOrElse(InetAddress.getLocalHost().getHostName())
-                                     ))
+  val riemann = getOptionalConfig(config, "riemann") map { riemannConfig ⇒
+    RiemannConfiguration(
+      riemannConfig.getString("host"),
+      riemannConfig.getInt("port"),
+      riemannConfig.getInt("batch-size"),
+      riemannConfig.getInt("buffer-size"),
+      riemannConfig.getInt("auto-flush-ms"),
+      getOptionalString(riemannConfig, "host-name").getOrElse(InetAddress.getLocalHost().getHostName())
+    )
   }
 
   object Network {

--- a/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Riemann.scala
@@ -1,122 +1,124 @@
 package io.iohk.ethereum.utils
 
-import io.riemann.riemann.client.RiemannClient
-import io.riemann.riemann.client.Transport
-import io.riemann.riemann.client.EventDSL
-import io.riemann.riemann.client.IRiemannClient
-import io.riemann.riemann.client.IPromise
-import io.riemann.riemann.client.Promise
-import io.riemann.riemann.client.ChainPromise
-import io.riemann.riemann.Proto.Event
-import io.riemann.riemann.Proto.Msg
+import java.io.{IOException, PrintWriter}
 import java.net.InetAddress
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.ArrayBlockingQueue
-import java.util.concurrent.BlockingQueue
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit
 import java.util.LinkedList
-import java.io.IOException
-import scala.collection.JavaConverters._
+import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue, ScheduledExecutorService, TimeUnit}
+
 import com.googlecode.protobuf.format.FormatFactory
+import io.iohk.ethereum.utils.events.{EventState, EventTag}
+import io.riemann.riemann.Proto.{Event, Msg}
+import io.riemann.riemann.client._
+import org.apache.commons.io.output.StringBuilderWriter
+
+import scala.collection.JavaConverters._
 
 trait Riemann extends Logger {
 
   private val hostName = Config.riemann
-    .map { c =>
-      c.hostName
-    }
+    .map(_.hostName)
     .getOrElse(InetAddress.getLocalHost().getHostName())
 
   private val riemannClient = {
     log.debug("create new RiemannClient")
+
+    def stdoutClient(): RiemannStdoutClient = {
+      log.info("create new stdout riemann client")
+      val client = new RiemannStdoutClient()
+      client.connect()
+      client
+    }
+
     val c = {
       Config.riemann match {
         case Some(config) => {
-          log.debug(
-            s"create new riemann batch client connecting to ${config.host}:${config.port}")
-          val client = new RiemannBatchClient(config)
+          log.info(s"create new riemann batch client connecting to ${config.host}:${config.port}")
+
           try {
+            val client = new RiemannBatchClient(config)
             client.connect()
             client
           } catch {
             case e: IOException =>
-              log.error(e.toString)
-              log.error(
-                "failed to create riemann batch client, falling back to stdout client")
-              new RiemannStdoutClient()
+              log.error("failed to create riemann batch client, falling back to stdout client", e)
+              stdoutClient()
           }
         }
         case None => {
-          log.debug("create new stdout riemann client")
-          val client = new RiemannStdoutClient()
-          client.connect()
-          client
+          stdoutClient()
         }
       }
     }
+
     log.debug("riemann client connected")
+
     c
   }
 
-  def close: Unit = riemannClient.close()
+  def close(): Unit = riemannClient.close()
 
   def defaultEvent: EventDSL = {
     val event = new EventDSL(riemannClient)
-    val seconds =
-      TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    val seconds = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())
     event.time(seconds).host(hostName)
   }
 
-  def ok(service: String): EventDSL = defaultEvent.state("ok").service(s"mantis ${service}")
+  def ok(service: String): EventDSL =
+    defaultEvent
+      .state(EventState.OK)
+      .service(s"mantis ${service}")
+
   def warning(service: String): EventDSL =
-    defaultEvent.state("warning").service(s"mantis ${service}")
+    defaultEvent
+      .state(EventState.Warning)
+      .service(s"mantis ${service}")
+
   def error(service: String): EventDSL =
-    defaultEvent.state("err").service(s"mantis ${service}")
+    defaultEvent
+      .state(EventState.Error)
+      .service(s"mantis ${service}")
+
   def exception(service: String, t: Throwable): EventDSL = {
     // Format message and stacktrace
-    val desc = new StringBuilder();
-    desc.append(t.toString())
-    desc.append("\n\n");
-    t.getStackTrace.map { e =>
-      desc.append(e)
-      desc.append("\n")
-    }
+    val sw = new StringBuilderWriter()
+    val pw = new PrintWriter(sw, true)
+
     defaultEvent
       .service(s"mantis ${service}")
-      .state("error")
-      .tag("exception")
+      .state(EventState.Error)
+      .tag(EventTag.Exception)
       .tag(t.getClass().getSimpleName())
-      .description(desc.toString())
+      .description(sw.toString())
   }
+
   def critical(service: String): EventDSL =
-    defaultEvent.state("critical").service(service)
+    defaultEvent
+      .state(EventState.Critical)
+      .service(s"mantis ${service}")
 
 }
 
-object Riemann extends Riemann {}
+object Riemann extends Riemann
 
-class RiemannBatchClient(config: RiemannConfiguration)
-    extends IRiemannClient
-    with Logger {
+class RiemannBatchClient(config: RiemannConfiguration) extends IRiemannClient with Logger {
   private def promise[A](v: A): Promise[A] = {
     val p: Promise[A] = new Promise()
     p.deliver(v)
     p
   }
+
   private def simpleMsg(event: Event) = {
     val msg = Msg.newBuilder().addEvents(event).build()
     promise(msg)
   }
-  private val jsonFormatter =
-    (new FormatFactory()).createFormatter(FormatFactory.Formatter.JSON)
 
-  protected val queue: BlockingQueue[Event] = new ArrayBlockingQueue(
-    config.bufferSize)
+  private val jsonFormatter = new FormatFactory().createFormatter(FormatFactory.Formatter.JSON)
+
+  protected val queue: BlockingQueue[Event] = new ArrayBlockingQueue(config.bufferSize)
 
   private val client = RiemannClient.tcp(config.host, config.port)
 
-  protected def sendBatch: Unit = {
+  protected def sendBatch(): Unit = {
     val batch: LinkedList[Event] = new LinkedList()
     queue.drainTo(batch, config.batchSize)
     batch.add(Riemann.ok("riemann batch").metric(batch.size()).build())
@@ -131,10 +133,10 @@ class RiemannBatchClient(config: RiemannConfiguration)
       case e: IOException =>
         log.error(e.toString)
         batch.asScala
-          .map { event =>
+          .foreach { event =>
             {
               // scalastyle:off
-              System.err.println(s"${jsonFormatter.printToString(event)}")
+              System.err.println(jsonFormatter.printToString(event))
             }
           }
     }
@@ -144,7 +146,7 @@ class RiemannBatchClient(config: RiemannConfiguration)
     log.trace("run sender")
     while (queue.size() > 0) {
       log.trace("sending batch of Riemann events")
-      sendBatch
+      sendBatch()
       log.trace("sent batch of Riemann events")
     }
   }
@@ -158,31 +160,37 @@ class RiemannBatchClient(config: RiemannConfiguration)
     }
     simpleMsg(event)
   }
+
   override def sendMessage(msg: Msg): IPromise[Msg] = client.sendMessage(msg)
 
   override def event(): EventDSL = {
     new EventDSL(this)
   }
+
   override def query(q: String): IPromise[java.util.List[Event]] =
     client.query(q)
+
   override def sendEvents(events: java.util.List[Event]): IPromise[Msg] = {
     val p = new ChainPromise[Msg]
-    events.asScala.map { e =>
+    events.asScala.foreach { e =>
       val clientPromise = sendEvent(e)
       p.attach(clientPromise)
     }
     p
   }
+
   override def sendEvents(events: Event*): IPromise[Msg] = {
     val p = new ChainPromise[Msg]
-    events.map { e =>
+    events.foreach { e =>
       val clientPromise = sendEvent(e)
       p.attach(clientPromise)
     }
     p
   }
+
   override def sendException(service: String, t: Throwable): IPromise[Msg] =
     client.sendException(service, t)
+
   private var sendExecutor: ScheduledExecutorService = null
 
   private def tryConnect(times: Int): Unit = {
@@ -209,64 +217,78 @@ class RiemannBatchClient(config: RiemannConfiguration)
     client.close()
     sendExecutor.shutdown()
   }
+
   override def flush(): Unit = client.flush()
+
   override def isConnected(): Boolean = client.isConnected
+
   override def reconnect(): Unit = {
     client.reconnect()
     sendExecutor.shutdown()
     sendExecutor = Scheduler.startRunner(config.autoFlushMilliseconds, TimeUnit.MILLISECONDS, sender)
   }
+
   override def transport(): Transport = this
 }
 
 class RiemannStdoutClient extends IRiemannClient {
   private var connected = false
+
   private def promise[A](v: A): Promise[A] = {
     val p: Promise[A] = new Promise()
     p.deliver(v)
     p
   }
+
   private def simpleMsg(event: Event) = {
     val msg = Msg.newBuilder().addEvents(event).build()
     promise(msg)
   }
-  private val jsonFormatter =
-    (new FormatFactory()).createFormatter(FormatFactory.Formatter.JSON)
+
+  private val jsonFormatter = (new FormatFactory()).createFormatter(FormatFactory.Formatter.JSON)
+
   override def connect() = {
     connected = true
   }
+
   override def sendEvent(event: Event) = {
     // scalastyle:off
-    println(s"${jsonFormatter.printToString(event)}")
+    println(jsonFormatter.printToString(event))
     simpleMsg(event)
   }
+
   override def sendMessage(msg: Msg): IPromise[Msg] = {
     // scalastyle:off
-    println(s"${jsonFormatter.printToString(msg)}")
+    println(jsonFormatter.printToString(msg))
     promise(msg)
   }
+
   override def event(): EventDSL = {
     new EventDSL(this)
   }
+
   override def query(q: String): IPromise[java.util.List[Event]] = {
     promise(new java.util.LinkedList())
   }
+
   override def sendEvents(events: java.util.List[Event]): IPromise[Msg] = {
-    events.asScala.map { e =>
+    events.asScala.foreach { e =>
       // scalastyle:off
-      println(s"${jsonFormatter.printToString(e)}")
+      println(jsonFormatter.printToString(e))
     }
     val msg = Msg.newBuilder().build()
     promise(msg)
   }
+
   override def sendEvents(events: Event*): IPromise[Msg] = {
-    events.map { e =>
+    events.foreach { e =>
       // scalastyle:off
-      println(s"${jsonFormatter.printToString(e)}")
+      println(jsonFormatter.printToString(e))
     }
     val msg = Msg.newBuilder().build()
     promise(msg)
   }
+
   override def sendException(service: String, t: Throwable): IPromise[Msg] = {
     // scalastyle:off
     System.err.println(s"service: ${service}\n${t}")
@@ -276,11 +298,15 @@ class RiemannStdoutClient extends IRiemannClient {
   override def close(): Unit = {
     connected = false
   }
+
   override def flush(): Unit = {}
+
   override def isConnected(): Boolean = connected
+
   override def reconnect(): Unit = {
     connected = true
   }
+
   override def transport(): Transport = this
 
 }

--- a/src/main/scala/io/iohk/ethereum/utils/Scheduler.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Scheduler.scala
@@ -5,17 +5,19 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit
 
 class Runner(executor: ScheduledExecutorService, interval: Long, unit: TimeUnit, f: () => Unit) extends Runnable {
-  def run {
+  def run(): Unit = {
     f()
-    executor.schedule(new Runner(executor, interval, unit, f),
-                      interval,
-                      unit)
+    executor.schedule(
+      new Runner(executor, interval, unit, f),
+      interval,
+      unit
+    )
   }
 }
 
 object Scheduler {
   def startRunner(interval: Long, unit: TimeUnit, f: () => Unit): ScheduledExecutorService = {
-    val sendExecutor = Executors.newScheduledThreadPool(1);
+    val sendExecutor = Executors.newScheduledThreadPool(1)
     val sender = new Runner(sendExecutor, interval, unit, f)
     sender.run()
     sendExecutor

--- a/src/main/scala/io/iohk/ethereum/utils/events/EventSupport.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/events/EventSupport.scala
@@ -1,0 +1,61 @@
+package io.iohk.ethereum.utils.events
+
+import io.iohk.ethereum.utils.Riemann
+
+trait EventSupport {
+  // The main service is always a prefix of the event service.
+  // Use something short.
+  protected def mainService: String
+
+  // An implementor decides what else is added in the event.
+  protected def postProcessEvent(event: EventDSL): EventDSL = event
+
+  private[this] def mkService(moreService: String): String =
+    if(moreService.isEmpty) mainService else s"${mainService} ${moreService}"
+
+  private[this] def postProcessAndTagMainService(event: EventDSL): EventDSL =
+    postProcessEvent(event).tag(mainService)
+
+  // DSL convenience for the eye.
+  @inline final protected def Event: this.type = this
+
+  // DSL convenience for the eye.
+  // Use like this:
+  //    Event(event).send()
+  // when `event` comes from elsewhere (e.g. a `ToRiemann.toRiemann` call)
+  @inline final protected def apply(event: EventDSL): event.type = event
+
+  protected def ok(moreService: String): EventDSL = {
+    val service = mkService(moreService)
+    val event = Riemann.ok(service)
+    postProcessAndTagMainService(event)
+  }
+
+  protected def ok(): EventDSL = ok("")
+
+  protected def okStart(): EventDSL = ok(EventTag.Start).tag(EventTag.Start)
+  protected def okFinish(): EventDSL = ok(EventTag.Finish).tag(EventTag.Finish)
+
+  protected def warning(moreService: String): EventDSL = {
+    val service = mkService(moreService)
+    val event = Riemann.warning(service)
+    postProcessAndTagMainService(event)
+  }
+
+  protected def warningStart(): EventDSL = warning(EventTag.Start).tag(EventTag.Start)
+
+  protected def error(moreService: String): EventDSL = {
+    val service = mkService(moreService)
+    val event = Riemann.warning(service)
+    postProcessAndTagMainService(event)
+  }
+
+  protected def exception(moreService: String, t: Throwable): EventDSL = {
+    val service = mkService(moreService)
+    val event = Riemann.exception(service, t)
+    postProcessAndTagMainService(event)
+  }
+
+  protected def exception(t: Throwable): EventDSL = exception("", t)
+  protected def exceptionFinish(t: Throwable): EventDSL = exception(EventTag.Finish, t).tag(EventTag.Finish)
+}

--- a/src/main/scala/io/iohk/ethereum/utils/events/package.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/events/package.scala
@@ -1,0 +1,69 @@
+package io.iohk.ethereum.utils
+
+import io.iohk.ethereum.domain.{Block, BlockHeader}
+import io.iohk.ethereum.network.PeerId
+
+// Gathers together event-related stuff, so that you can easily import them all at once
+package object events {
+  final type EventDSL = io.riemann.riemann.client.EventDSL
+
+  implicit class RichEventDSL(val event: EventDSL) extends AnyVal {
+    def attribute(name: String, value: BigInt): EventDSL = event.attribute(name, value.toString())
+
+    def attribute(name: String, value: Int): EventDSL = event.attribute(name, value.toString)
+
+    def attribute(name: String, value: Long): EventDSL = event.attribute(name, value.toString)
+
+    def timeTakenMs(ms: Long): EventDSL = attribute(EventAttr.TimeTakenMs, ms)
+
+    def count(count: Int): EventDSL = attribute(EventAttr.Count, count)
+
+    def peerId(peerId: PeerId): EventDSL = event.attribute(EventAttr.PeerId, peerId.value)
+
+    def header(header: BlockHeader): EventDSL =
+      event
+        .attribute("header", header.number)
+        .attribute("headerHex", "0x" + header.number.toString(16))
+        .attribute("headerHash", "0x" + header.hashAsHexString)
+
+    def block(block: Block): EventDSL =
+      event
+        .attribute("block", block.header.number)
+        .attribute("blockHex", "0x" + block.header.number.toString(16))
+        .attribute("blockHash", "0x" + block.header.hashAsHexString)
+
+    def block(prefix: String, header: BlockHeader): EventDSL =
+      event
+        .attribute(s"${prefix}Block", header.number)
+        .attribute(s"${prefix}BlockHex", "0x" + header.number.toString(16))
+        .attribute(s"${prefix}BlockHash", "0x" + header.hashAsHexString)
+
+    def block(prefix: String, block: Block): EventDSL = this.block(prefix, block.header)
+  }
+
+  object EventState {
+    final val Critical = "critical"
+    final val Error = "err"
+    final val OK = "ok"
+    final val Warning = "warning"
+  }
+
+  object EventTag {
+    final val BlockForge = "blockForge"
+    final val BlockImport = "blockImport"
+    final val Exception = "exception"
+    final val Finish = "finish"
+    final val Start = "start"
+  }
+
+  object EventAttr {
+    final val Count = "count"
+    final val Error = "error"
+    final val File = "file"
+    final val Id = "id"
+    final val PeerId = "peerId"
+    final val Resource = "resource"
+    final val Status = "status"
+    final val TimeTakenMs = "timeTakenMs"
+  }
+}


### PR DESCRIPTION
There are now quite a few Riemann events in place of logging, this means after this PR you really would be better off running a simple Riemann server (`docker run --rm -p 5555:5555 -p 5556:5556 riemannio/riemann`) and using `rcl` with `jq`. 

Installing `rcl` requires either nix (it's built in our Hydra) or stack at the moment as I don't have any need to distribute it anywhere else.

This is basically structured logging from a developer point of view and my intention would be to remove all `log.*` calls except for a few odd `log.debug` calls perhaps and ofc the logs that other libraries produce such as akka and netty.