### PR TITLE
Fix touched account handling

### DIFF
--- a/src/main/scala/io/iohk/ethereum/extvm/World.scala
+++ b/src/main/scala/io/iohk/ethereum/extvm/World.scala
@@ -49,9 +49,12 @@ case class World(
 
   protected def noEmptyAccounts: Boolean = noEmptyAccountsCond
 
-  def combineTouchedAccounts(world: World): World =
-    copy(touchedAccounts = touchedAccounts ++ world.touchedAccounts)
-
+  override def keepPrecompileTouched(world: World): World = {
+    if (world.touchedAccounts.contains(ripmdContractAddress))
+      copy(touchedAccounts = touchedAccounts + ripmdContractAddress)
+    else
+      this
+  }
   def getCode(address: Address): ByteString =
     codeRepo.getOrElse(address, codeCache.getCode(address))
 

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockPreparator.scala
@@ -97,27 +97,6 @@ class BlockPreparator(
     worldStateProxy.saveAccount(senderAddress, account.increaseBalance(-calculateUpfrontGas(stx.tx)).increaseNonce())
   }
 
-  private[ledger] def saveNewContract(address: Address, result: PR, config: EvmConfig): PR = {
-    val contractCode = result.returnData
-    val codeDepositCost = config.calcCodeDepositCost(contractCode)
-
-    val maxCodeSizeExceeded = blockchainConfig.maxCodeSize.exists(codeSizeLimit => contractCode.size > codeSizeLimit)
-    val codeStoreOutOfGas = result.gasRemaining < codeDepositCost
-
-    if (maxCodeSizeExceeded || (codeStoreOutOfGas && config.exceptionalFailedCodeDeposit)) {
-      // Code size too big or code storage causes out-of-gas with exceptionalFailedCodeDeposit enabled
-      result.copy(error = Some(OutOfGas))
-    } else if (codeStoreOutOfGas && !config.exceptionalFailedCodeDeposit) {
-      // Code storage causes out-of-gas with exceptionalFailedCodeDeposit disabled
-      result
-    } else {
-      // Code storage succeeded
-      result.copy(
-        gasRemaining = result.gasRemaining - codeDepositCost,
-        world = result.world.saveCode(address, result.returnData))
-    }
-  }
-
   private[ledger] def runVM(stx: SignedTransaction, senderAddress: Address, blockHeader: BlockHeader, world: InMemoryWorldStateProxy): PR = {
     val evmConfig = EvmConfig.forBlock(blockHeader.number, blockchainConfig)
     val context: PC = ProgramContext(stx, blockHeader, senderAddress, world, evmConfig)
@@ -137,12 +116,14 @@ class BlockPreparator(
     }
   }
 
-  private[ledger] def pay(address: Address, value: UInt256)(world: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
+  private[ledger] def pay(address: Address, value: UInt256, withTouch: Boolean)(world: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
     if (world.isZeroValueTransferToNonExistentAccount(address, value)) {
       world
     } else {
       val account = world.getAccount(address).getOrElse(Account.empty(blockchainConfig.accountStartNonce)).increaseBalance(value)
-      world.saveAccount(address, account).touchAccounts(address)
+      val savedWorld = world.saveAccount(address, account)
+
+      if (withTouch) savedWorld.touchAccounts(address) else savedWorld
     }
   }
 
@@ -209,8 +190,8 @@ class BlockPreparator(
     val totalGasToRefund = calcTotalGasToRefund(stx, resultWithErrorHandling)
     val executionGasToPayToMiner = gasLimit - totalGasToRefund
 
-    val refundGasFn = pay(senderAddress, (totalGasToRefund * gasPrice).toUInt256) _
-    val payMinerForGasFn = pay(Address(blockHeader.beneficiary), (executionGasToPayToMiner * gasPrice).toUInt256) _
+    val refundGasFn = pay(senderAddress, (totalGasToRefund * gasPrice).toUInt256, withTouch = false) _
+    val payMinerForGasFn = pay(Address(blockHeader.beneficiary), (executionGasToPayToMiner * gasPrice).toUInt256, withTouch = true) _
 
     val worldAfterPayments = (refundGasFn andThen payMinerForGasFn)(resultWithErrorHandling.world)
 

--- a/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxy.scala
@@ -180,8 +180,11 @@ class InMemoryWorldStateProxy private[ledger](
 
   override def noEmptyAccounts: Boolean = noEmptyAccountsCond
 
-  override def combineTouchedAccounts(world: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
-    copyWith(touchedAccounts = touchedAccounts ++ world.touchedAccounts)
+  override def keepPrecompileTouched(world: InMemoryWorldStateProxy): InMemoryWorldStateProxy = {
+    if (world.touchedAccounts.contains(ripmdContractAddress))
+      copyWith(touchedAccounts = touchedAccounts + ripmdContractAddress)
+    else
+      this
   }
 
   /**

--- a/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/OpCode.scala
@@ -821,7 +821,7 @@ abstract class CallOp(code: Int, delta: Int, alpha: Int) extends OpCode(code, de
     result.error match {
       case Some(error) =>
         val stack2 = stack1.push(UInt256.Zero)
-        val world1 = state.world.combineTouchedAccounts(result.world)
+        val world1 = state.world.keepPrecompileTouched(result.world)
         val gasAdjustment = if (error == InvalidCall) -startGas else if (error == RevertOccurs) -result.gasRemaining else BigInt(0)
         val memoryAdjustment = if (error == RevertOccurs) mem2 else mem1.expand(outOffset, outSize)
 

--- a/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/WorldStateProxy.scala
@@ -25,8 +25,20 @@ trait WorldStateProxy[WS <: WorldStateProxy[WS, S], S <: Storage[S]] { self: WS 
   protected def noEmptyAccounts: Boolean
   protected def accountStartNonce: UInt256 = UInt256.Zero
 
-  def combineTouchedAccounts(world: WS): WS
 
+  /*
+  *  During tx: 0xcf416c536ec1a19ed1fb89e4ec7ffb3cf73aa413b3aa9b77d60e4fd81a4296ba
+  *  precompiled account 0000000000000000000000000000000000000003 was deleted in block 2675119,
+  *  even though the deletion should have been reverted due to an out of gas error.
+  *  It was due to erroneous implementations of eip161 in parity and geth.
+  *  To avoid rewinding the chain, this special case is covered in parity and geth.
+  *  more details:
+  *  https://github.com/ethereum/EIPs/issues/716
+  *  https://github.com/ethereum/go-ethereum/pull/3341/files#r89548312
+  * */
+  def keepPrecompileTouched(world: WS): WS
+
+  protected val ripmdContractAddress = Address(3)
   /**
     * In certain situation an account is guaranteed to exist, e.g. the account that executes the code, the account that
     * transfer value to another. There could be no input to our application that would cause this fail, so we shouldn't

--- a/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/DeleteTouchedAccountsSpec.scala
@@ -64,7 +64,7 @@ class DeleteTouchedAccountsSpec extends FlatSpec with Matchers with MockFactory 
     val worldAfterTransfer = worldStatePreEIP161.transfer(validAccountAddress, validEmptyAccountAddress, zeroTransferBalance)
     worldAfterTransfer.touchedAccounts.size shouldEqual 0
 
-    val worldAfterPayingToMiner = consensus.blockPreparator.pay(validEmptyAccountAddress1, zeroTransferBalance)(worldAfterTransfer)
+    val worldAfterPayingToMiner = consensus.blockPreparator.pay(validEmptyAccountAddress1, zeroTransferBalance, withTouch = true)(worldAfterTransfer)
 
     worldAfterPayingToMiner.touchedAccounts.size shouldEqual 0
 
@@ -79,7 +79,7 @@ class DeleteTouchedAccountsSpec extends FlatSpec with Matchers with MockFactory 
     val worldAfterTransfer = worldStatePostEIP161.transfer(validAccountAddress, validEmptyAccountAddress, zeroTransferBalance)
     worldAfterTransfer.touchedAccounts.size shouldEqual 2
 
-    val worldAfterPayingToMiner = consensus.blockPreparator.pay(validEmptyAccountAddress1, zeroTransferBalance)(worldAfterTransfer)
+    val worldAfterPayingToMiner = consensus.blockPreparator.pay(validEmptyAccountAddress1, zeroTransferBalance, withTouch = true)(worldAfterTransfer)
 
     worldAfterPayingToMiner.touchedAccounts.size shouldEqual 3
 

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -180,7 +180,7 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     worldStateAfterSecondTransfer.touchedAccounts should contain theSameElementsAs Set(address1, address3)
   }
 
-  it should "update touched accounts using keepPrecompieContrac method" in new TestSetup {
+  it should "update touched accounts using keepPrecompieContract method" in new TestSetup {
     val account = Account(0, 100)
     val zeroTransfer = UInt256.Zero
     val nonZeroTransfer = account.balance - 80

--- a/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/InMemoryWorldStateProxySpec.scala
@@ -180,14 +180,16 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     worldStateAfterSecondTransfer.touchedAccounts should contain theSameElementsAs Set(address1, address3)
   }
 
-  it should "update touched accounts using combineTouchedAccounts method" in new TestSetup {
+  it should "update touched accounts using keepPrecompieContrac method" in new TestSetup {
     val account = Account(0, 100)
     val zeroTransfer = UInt256.Zero
     val nonZeroTransfer = account.balance - 80
 
+    val precompiledAddress =  Address(3)
+
     val worldAfterSelfTransfer = postEIP161WorldState
-      .saveAccount(address1, account)
-      .transfer(address1, address1, nonZeroTransfer)
+      .saveAccount(precompiledAddress, account)
+      .transfer(precompiledAddress, precompiledAddress, nonZeroTransfer)
 
     val worldStateAfterFirstTransfer = worldAfterSelfTransfer
       .saveAccount(address1, account)
@@ -196,9 +198,9 @@ class InMemoryWorldStateProxySpec extends FlatSpec with Matchers {
     val worldStateAfterSecondTransfer = worldStateAfterFirstTransfer
       .transfer(address1, address3, nonZeroTransfer)
 
-    val postEip161UpdatedWorld = postEIP161WorldState.combineTouchedAccounts(worldStateAfterSecondTransfer)
+    val postEip161UpdatedWorld = postEIP161WorldState.keepPrecompileTouched(worldStateAfterSecondTransfer)
 
-    postEip161UpdatedWorld.touchedAccounts should contain theSameElementsAs Set(address1, address3)
+    postEip161UpdatedWorld.touchedAccounts should contain theSameElementsAs Set(precompiledAddress)
   }
 
   it should "correctly determine if account is dead" in new TestSetup {

--- a/src/test/scala/io/iohk/ethereum/vm/CallOpcodesSpecPostEip161.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/CallOpcodesSpecPostEip161.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.vm
 
-import io.iohk.ethereum.domain.UInt256
+import io.iohk.ethereum.domain.{Address, UInt256}
 import io.iohk.ethereum.vm.MockWorldState._
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, WordSpec}
@@ -36,12 +36,13 @@ class CallOpcodesSpecPostEip161 extends WordSpec with Matchers with PropertyChec
     }
 
     "external contract terminates abnormally" should {
+      val touchedPrecompile = Address(3)
 
-      val context: PC = fxt.context.copy(world = fxt.worldWithInvalidProgram)
+      val context: PC = fxt.context.copy(world = fxt.worldWithInvalidProgram.copy(touchedAccounts = Set(touchedPrecompile)))
       val call = fxt.CallResult(op = CALL, context)
 
-      "modify only touched accounts in world state" in {
-        call.world shouldEqual fxt.worldWithInvalidProgram.touchAccounts(fxt.ownerAddr, fxt.extAddr)
+      "modify only touched accounts by precompiled ripmd contract in world state" in {
+        call.world shouldEqual fxt.worldWithInvalidProgram.touchAccounts(touchedPrecompile)
       }
     }
 

--- a/src/test/scala/io/iohk/ethereum/vm/MockWorldState.scala
+++ b/src/test/scala/io/iohk/ethereum/vm/MockWorldState.scala
@@ -69,7 +69,10 @@ case class MockWorldState(
 
   def noEmptyAccounts: Boolean = noEmptyAccountsCond
 
-  def combineTouchedAccounts(world: MockWorldState): MockWorldState = {
-    copy(touchedAccounts = touchedAccounts ++ world.touchedAccounts)
+  override def keepPrecompileTouched(world: MockWorldState): MockWorldState = {
+    if (world.touchedAccounts.contains(ripmdContractAddress))
+      copy(touchedAccounts = touchedAccounts + ripmdContractAddress)
+    else
+      this
   }
 }


### PR DESCRIPTION
Touched account handling updtaed to clarified spec: 
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md - `The specification was amended to clarify that empty account deletions are reverted when the state is reverted.`
Also taking into account bug in parity and geth.
