### PR TITLE
jsonrpc: Make request body strict

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -197,6 +197,9 @@ mantis {
         # Domains allowed to query RPC endpoint. Use "*" to enable requests from
         # any domain.
         cors-allowed-origins = []
+
+        # max size in bytes of the request body
+        max-content-length = 50k
       }
 
       ipc {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/BasicJsonRpcHttpServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/BasicJsonRpcHttpServer.scala
@@ -27,4 +27,6 @@ class BasicJsonRpcHttpServer(val jsonRpcController: JsonRpcController, config: J
   }
 
   override def corsAllowedOrigins: HttpOriginRange = config.corsAllowedOrigins
+
+  def maxContentLength: Long = config.maxContentLength
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
@@ -97,7 +97,10 @@ trait JsonRpcHttpServer extends Json4sSupport {
     cors(corsSettings) {
       handleRejections(myRejectionHandler) {
         handleExceptions(myExceptionHandler) {
-          limitsRoute
+          if(maxContentLength > 0)
+            limitsRoute
+          else
+            mainRoute
         }
       }
     }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServer.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.jsonrpc.server.http
 
 import java.security.SecureRandom
+import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
@@ -13,12 +14,14 @@ import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import io.iohk.ethereum.buildinfo.MantisBuildInfo
 import io.iohk.ethereum.jsonrpc._
+import io.iohk.ethereum.metrics.Metrics
 import io.iohk.ethereum.utils.{ConfigUtils, JsonUtils, Logger}
-import org.json4s.JsonAST.JInt
+import org.json4s.JsonAST.{JInt, JString}
 import org.json4s.{DefaultFormats, native}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 trait JsonRpcHttpServer extends Json4sSupport {
@@ -29,11 +32,14 @@ trait JsonRpcHttpServer extends Json4sSupport {
   implicit val formats = DefaultFormats
 
   def corsAllowedOrigins: HttpOriginRange
+  def maxContentLength: Long
 
   val corsSettings = CorsSettings.defaultSettings.copy(
     allowGenericHttpRequests = true,
     allowedOrigins = corsAllowedOrigins
   )
+
+  protected lazy val metrics = new JsonRpcHttpServerMetrics(Metrics.get())
 
   implicit def myRejectionHandler: RejectionHandler =
     RejectionHandler.newBuilder()
@@ -45,23 +51,56 @@ trait JsonRpcHttpServer extends Json4sSupport {
       }
       .result()
 
-  val route: Route = cors(corsSettings) {
-    handleRejections(myRejectionHandler) {
-      (path("healthcheck") & pathEndOrSingleSlash & get) {
-        handleHealthcheck()
-      } ~
-        (path("buildinfo") & pathEndOrSingleSlash & get) {
-          handleBuildInfo()
-        } ~
-        (pathEndOrSingleSlash & post) {
-          entity(as[JsonRpcRequest]) { request =>
-            handleRequest(request)
-          } ~ entity(as[Seq[JsonRpcRequest]]) { request =>
-            handleBatchRequest(request)
-          }
-        }
+  val myExceptionHandler: ExceptionHandler =
+    ExceptionHandler {
+      case EntityStreamSizeException(limit, actualSize) =>
+        val msg = s"Entity size ${actualSize.getOrElse("(?)")} exceeds limit of ${limit}"
+        val error = JsonRpcErrors.InvalidRequest.copy(data = Some(JString(msg)))
+        complete((StatusCodes.BadRequest, JsonRpcResponse("2.0", None, Some(error), JInt(0))))
     }
+
+  val mainRoute: Route = {
+    (path("healthcheck") & pathEndOrSingleSlash & get) {
+      handleHealthcheck()
+    } ~
+      (path("buildinfo") & pathEndOrSingleSlash & get) {
+        handleBuildInfo()
+      } ~
+      (pathEndOrSingleSlash & post) {
+        entity(as[JsonRpcRequest]) { request =>
+          handleRequest(request)
+        } ~ entity(as[Seq[JsonRpcRequest]]) { request =>
+          handleBatchRequest(request)
+        }
+      }
   }
+
+  val stricEntityDuration = FiniteDuration(2 * 150, TimeUnit.MILLISECONDS)
+
+  val limitsRoute: Route =
+    withSizeLimit(maxContentLength) {
+      toStrictEntity(stricEntityDuration) {
+        extractRequestEntity {
+          case HttpEntity.Strict(_, data) ⇒
+            metrics.RequestSizeDistribution.record(data.size)
+
+            mainRoute
+
+          case _ ⇒
+            assert(false)
+            mainRoute
+        }
+      }
+    }
+
+  val route: Route =
+    cors(corsSettings) {
+      handleRejections(myRejectionHandler) {
+        handleExceptions(myExceptionHandler) {
+          limitsRoute
+        }
+      }
+    }
 
   /**
     * Try to start JSON RPC server
@@ -120,16 +159,17 @@ object JsonRpcHttpServer extends Logger {
     case _ => Left(s"Cannot start JSON RPC server: Invalid mode ${config.mode} selected")
   }
 
-  trait JsonRpcHttpServerConfig {
-    val mode: String
-    val enabled: Boolean
-    val interface: String
-    val port: Int
-    val certificateKeyStorePath: Option[String]
-    val certificateKeyStoreType: Option[String]
-    val certificatePasswordFile: Option[String]
-    val corsAllowedOrigins: HttpOriginRange
-  }
+  final case class JsonRpcHttpServerConfig(
+    mode: String,
+    enabled: Boolean,
+    interface: String,
+    port: Int,
+    certificateKeyStorePath: Option[String],
+    certificateKeyStoreType: Option[String],
+    certificatePasswordFile: Option[String],
+    corsAllowedOrigins: HttpOriginRange,
+    maxContentLength: Long
+  )
 
   object JsonRpcHttpServerConfig {
     import com.typesafe.config.{Config ⇒ TypesafeConfig}
@@ -137,18 +177,20 @@ object JsonRpcHttpServer extends Logger {
     def apply(mantisConfig: TypesafeConfig): JsonRpcHttpServerConfig = {
       val rpcHttpConfig = mantisConfig.getConfig("network.rpc.http")
 
-      new JsonRpcHttpServerConfig {
-        override val mode: String = rpcHttpConfig.getString("mode")
-        override val enabled: Boolean = rpcHttpConfig.getBoolean("enabled")
-        override val interface: String = rpcHttpConfig.getString("interface")
-        override val port: Int = rpcHttpConfig.getInt("port")
+      JsonRpcHttpServerConfig(
+        mode = rpcHttpConfig.getString("mode"),
+        enabled = rpcHttpConfig.getBoolean("enabled"),
+        interface = rpcHttpConfig.getString("interface"),
+        port = rpcHttpConfig.getInt("port"),
 
-        override val corsAllowedOrigins = ConfigUtils.parseCorsAllowedOrigins(rpcHttpConfig, "cors-allowed-origins")
+        corsAllowedOrigins = ConfigUtils.parseCorsAllowedOrigins(rpcHttpConfig, "cors-allowed-origins"),
 
-        override val certificateKeyStorePath: Option[String] = Try(rpcHttpConfig.getString("certificate-keystore-path")).toOption
-        override val certificateKeyStoreType: Option[String] = Try(rpcHttpConfig.getString("certificate-keystore-type")).toOption
-        override val certificatePasswordFile: Option[String] = Try(rpcHttpConfig.getString("certificate-password-file")).toOption
-      }
+        maxContentLength = rpcHttpConfig.getBytes("max-content-length"),
+
+        certificateKeyStorePath = Try(rpcHttpConfig.getString("certificate-keystore-path")).toOption,
+        certificateKeyStoreType = Try(rpcHttpConfig.getString("certificate-keystore-type")).toOption,
+        certificatePasswordFile = Try(rpcHttpConfig.getString("certificate-password-file")).toOption
+      )
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServerMetrics.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServerMetrics.scala
@@ -1,0 +1,7 @@
+package io.iohk.ethereum.jsonrpc.server.http
+
+import io.iohk.ethereum.metrics.{Metrics, MetricsContainer}
+
+class JsonRpcHttpServerMetrics(metrics: Metrics) extends MetricsContainer {
+  final val RequestSizeDistribution = metrics.distribution("json.rpc.request.size.distribution")
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpsServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpsServer.scala
@@ -114,6 +114,8 @@ class JsonRpcHttpsServer(val jsonRpcController: JsonRpcController, config: JsonR
     }
 
   override def corsAllowedOrigins: HttpOriginRange = config.corsAllowedOrigins
+
+  def maxContentLength: Long = config.maxContentLength
 }
 
 object JsonRpcHttpsServer {

--- a/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
@@ -21,7 +21,7 @@ case class Metrics(prefix: String, registry: MeterRegistry) {
   def close(): Unit = registry.close()
 
   def deltaSpike(name: String): DeltaSpikeGauge =
-    new DeltaSpikeGauge(name, this)
+    new DeltaSpikeGauge(mkName(name), this)
 
   /**
    * Returns a [[io.micrometer.core.instrument.Gauge Gauge]].
@@ -56,6 +56,16 @@ case class Metrics(prefix: String, registry: MeterRegistry) {
    */
   def timer(name: String): Timer =
     Timer
+      .builder(mkName(name))
+      .register(registry)
+
+  /**
+   * Returns a [[io.micrometer.core.instrument.DistributionSummary DistributionSummary]].
+   * Its actual name is the concatenation of three items:
+   *  [[io.iohk.ethereum.metrics.Metrics.prefix prefix]], `.`, and the value of the `name` parameter.
+   */
+  def distribution(name: String): DistributionSummary =
+    DistributionSummary
       .builder(mkName(name))
       .register(registry)
 }


### PR DESCRIPTION
This avoids observed non-deterministic behavior that bubbles up as
request parsing errors (probably caused by consuming a stream
more than once).

Ref CGKIELE-570