### PR TITLE
Parallel header validation

### DIFF
--- a/src/main/scala/io/iohk/ethereum/testmode/TestLedgerBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestLedgerBuilder.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.testmode
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.{Consensus, ConsensusBuilder}
 import io.iohk.ethereum.domain._
+import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger._
 import io.iohk.ethereum.nodebuilder.{BlockchainBuilder, BlockchainConfigBuilder, LedgerBuilder, SyncConfigBuilder}
 
@@ -27,6 +28,9 @@ trait TestLedgerBuilder extends LedgerBuilder {
       testLedger.binarySearchGasEstimation(stx, blockHeader, world)
     override def simulateTransaction(stx: SignedTransactionWithSender, blockHeader: BlockHeader, world: Option[InMemoryWorldStateProxy]): Ledger.TxResult =
       testLedger.simulateTransaction(stx, blockHeader, world)
+    override def validateBlockBeforeExecution(block: Block): Either[ValidationBeforeExecError, BlockExecutionSuccess] =
+      testLedger.validateBlockBeforeExecution(block)
+
   }
 
   override lazy val ledger: Ledger = new TestLedgerProxy


### PR DESCRIPTION
Validate headers conccurently with block import. This is approach taken for example by geth , as it can give a lot in terms of performance.
In test 3h regular sync from master node:
`baseline - 766976 blocks synced`
`concurrentValidation - 898369 blocks synced` 
~15 % improvements over baseline
