### PR TITLE
Improve Mpt trie performance

### DIFF
--- a/src/benchmark/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeSpeedSpec.scala
+++ b/src/benchmark/scala/io/iohk/ethereum/mpt/MerklePatriciaTreeSpeedSpec.scala
@@ -35,8 +35,8 @@ class MerklePatriciaTreeSpeedSpec extends FunSuite
     }
     val rootHash = Hex.toHexString(trieResult.getRootHash)
 
-    log.debug("Time taken(ms): " + (System.currentTimeMillis - start))
-    log.debug("Root hash obtained: " + rootHash)
+    log.info("Time taken(ms): " + (System.currentTimeMillis - start))
+    log.info("Root hash obtained: " + rootHash)
 
     if (Symmetric) assert(rootHash.take(4) == "36f6" && rootHash.drop(rootHash.length - 4) == "93a3")
     else assert(rootHash.take(4) == "da8a" && rootHash.drop(rootHash.length - 4) == "0ca4")

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainActor.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainActor.scala
@@ -16,7 +16,7 @@ import io.iohk.ethereum.network.p2p.messages.PV63.MptNodeEncoders._
 import org.bouncycastle.util.encoders.Hex
 import ReceiptImplicits._
 import BlockHeaderImplicits._
-import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, LeafNode, MptNode}
+import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode, MptNode}
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
@@ -111,10 +111,10 @@ class DumpChainActor(peerManager: ActorRef, peerMessageBus: ActorRef, startBlock
       val nodes = NodeData(stateNodes).values.indices.map(i => NodeData(stateNodes).getMptNode(i))
 
       val children = nodes.flatMap {
-        case n: BranchNode => n.children.collect { case Some(Left(h)) => h }
-        case ExtensionNode(_, Left(h), _, _) => Seq(h)
+        case n: BranchNode => n.children.collect { case HashNode(h) => h }
+        case ExtensionNode(_, HashNode(h), _, _) => Seq(h)
         case _: LeafNode => Seq.empty
-       case _ => Seq.empty
+        case _ => Seq.empty
       }
 
       var contractChildren: Seq[ByteString] = Nil
@@ -142,8 +142,8 @@ class DumpChainActor(peerManager: ActorRef, peerMessageBus: ActorRef, startBlock
 
       val cNodes = NodeData(contractNodes).values.indices.map(i => NodeData(contractNodes).getMptNode(i))
       contractChildren = contractChildren ++ cNodes.flatMap {
-        case n: BranchNode => n.children.collect { case Some(Left(h)) => h }
-        case ExtensionNode(_, Left(h), _, _) => Seq(h)
+        case n: BranchNode => n.children.collect { case HashNode(h) => h }
+        case ExtensionNode(_, HashNode(h), _, _) => Seq(h)
         case _ => Seq.empty
       }
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -84,8 +84,8 @@ object FixtureProvider {
             }
           }
 
-        case None =>
         case _ =>
+
       }
 
       traverse(block.header.stateRoot)

--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/FixtureProvider.scala
@@ -14,7 +14,7 @@ import MptNodeEncoders._
 import ReceiptImplicits._
 import io.iohk.ethereum.db.cache.MapCaches
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
-import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, LeafNode, MptNode}
+import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode, MptNode}
 import org.bouncycastle.util.encoders.Hex
 
 import scala.io.Source
@@ -63,12 +63,12 @@ object FixtureProvider {
       def traverse(nodeHash: ByteString): Unit = fixtures.stateMpt.get(nodeHash).orElse(fixtures.contractMpts.get(nodeHash)) match {
         case Some(m: BranchNode) =>
           blockchain.nodesKeyValueStorageFor(Some(block.header.number), storages.nodeStorage).update(Nil, Seq(ByteString(m.hash) -> m.toBytes))
-          m.children.collect { case Some(Left(hash)) => hash}.foreach(e => traverse(e))
+          m.children.collect { case HashNode(hash) => hash}.foreach(e => traverse(e))
 
         case Some(m: ExtensionNode) =>
           blockchain.nodesKeyValueStorageFor(Some(block.header.number), storages.nodeStorage).update(Nil, Seq(ByteString(m.hash) -> m.toBytes))
           m.next match {
-            case Left(hash) if hash.nonEmpty => traverse(hash)
+            case HashNode(hash) if hash.nonEmpty => traverse(hash)
             case _ =>
           }
 
@@ -85,6 +85,7 @@ object FixtureProvider {
           }
 
         case None =>
+        case _ =>
       }
 
       traverse(block.header.stateRoot)

--- a/src/main/scala/io/iohk/ethereum/mpt/HexPrefix.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/HexPrefix.scala
@@ -48,8 +48,16 @@ object HexPrefix {
     *
     */
   def bytesToNibbles(bytes: Array[Byte]): Array[Byte] = {
-    bytes.foldRight[List[Byte]](List()){(elem, rec) =>
-      ((elem >> 4) & 0xF).toByte :: (elem & 0xF).toByte :: rec}.toArray
+    val newArray = new Array[Byte](bytes.length * 2)
+    var i = 0
+    var n = 0
+    while (i < bytes.length) {
+      newArray(n) = ((bytes(i) >> 4) & 0xF).toByte
+      newArray(n + 1) = (bytes(i) & 0xF).toByte
+      n = n + 2
+      i = i + 1
+    }
+    newArray
   }
 
   /**
@@ -61,6 +69,17 @@ object HexPrefix {
     */
   def nibblesToBytes(nibbles: Array[Byte]): Array[Byte] = {
     require(nibbles.length % 2 == 0)
-    nibbles.grouped(2).map{case Array(n1,n2) => (16*n1 + n2).toByte}.toArray
+    val newArray = new Array[Byte](nibbles.length / 2)
+    var i = 0
+    var n = 0
+
+    while (i < nibbles.length) {
+      val newValue = (16 * nibbles(i) + nibbles(i + 1)).toByte
+      newArray(n) = newValue
+      n = n + 1
+      i = i + 2
+    }
+
+    newArray
   }
 }

--- a/src/main/scala/io/iohk/ethereum/mpt/HexPrefix.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/HexPrefix.scala
@@ -42,7 +42,7 @@ object HexPrefix {
 
   /**
     * Transforms an array of 8bit values to the corresponding array of 4bit values (hexadecimal format)
-    *
+    * Needs to be as fast possible, which requires usage of var's and mutable arrays.
     * @param bytes byte[]
     * @return array with each individual nibble
     *
@@ -62,7 +62,7 @@ object HexPrefix {
 
   /**
     * Transforms an array of 4bit values (hexadecimal format) to the corresponding array of 8bit values
-    *
+    * Needs to be as fast possible, which requires usage of var's and mutable arrays.
     * @param nibbles byte[]
     * @return array with bytes combining pairs of nibbles
     *

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -75,7 +75,7 @@ object MerklePatriciaTrie {
         }
         ExtensionNode(ByteString(key), next)
       }
-    case _ => throw new RuntimeException("Invalid Node")
+    case _ => throw new MPTException("Invalid Node")
   }
 
   private def getNode(nodeId: Array[Byte], source: NodesKeyValueStorage)(implicit nodeDec: RLPDecoder[MptNode]): Option[MptNode] = {
@@ -279,14 +279,14 @@ class MerklePatriciaTrie[K, V] private (private val rootHash: Option[Array[Byte]
         case NullNode => None
       }
     case _ =>
-      throw new MPTException("Cannot get from HashNode or NullNode")
+      throw new MPTException("Cannot get node from HashNode or NullNode")
   }
 
   private def put(node: MptNode, searchKey: Array[Byte], value: Array[Byte]): NodeInsertResult = node match {
     case leafNode: LeafNode => putInLeafNode(leafNode, searchKey, value)
     case extensionNode: ExtensionNode => putInExtensionNode(extensionNode, searchKey, value)
     case branchNode: BranchNode => putInBranchNode(branchNode, searchKey, value)
-    case _ => throw new MPTException("Cannot put in HashNode or NullNode")
+    case _ => throw new MPTException("Cannot put node in HashNode or NullNode")
   }
 
   private def putInLeafNode(node: LeafNode, searchKey: Array[Byte], value: Array[Byte]): NodeInsertResult = {
@@ -421,7 +421,7 @@ class MerklePatriciaTrie[K, V] private (private val rootHash: Option[Array[Byte]
     case leafNode: LeafNode => removeFromLeafNode(leafNode, searchKey)
     case extensionNode: ExtensionNode => removeFromExtensionNode(extensionNode, searchKey)
     case branchNode: BranchNode => removeFromBranchNode(branchNode, searchKey)
-    case _ => throw new MPTException("Cannot delete from HashNode or NullNode")
+    case _ => throw new MPTException("Cannot delete node from HashNode or NullNode")
   }
 
   private def removeFromBranchNode(node: BranchNode, searchKey: Array[Byte]): NodeRemoveResult = (node, searchKey.isEmpty) match {

--- a/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/MerklePatriciaTrie.scala
@@ -126,7 +126,7 @@ object MerklePatriciaTrie {
     case branch: BranchNode =>
       val encoded = new Array[RLPEncodeable](MerklePatriciaTrie.ListSize)
       var i = 0
-      while (i <= 15) {
+      while (i < BranchNode.numberOfChildren) {
         val nodeEncoded = this.nodeEnc.encode(branch.children(i))
         encoded(i) = nodeEncoded
         i = i + 1
@@ -266,7 +266,8 @@ class MerklePatriciaTrie[K, V] private (private val rootHash: Option[Array[Byte]
         case child@(_:BranchNode | _:ExtensionNode | _:LeafNode | _:HashNode) => get(child, searchKey.slice(1, searchKey.length))
         case NullNode => None
       }
-    case _ => None
+    case _ =>
+      throw new MPTException("Cannot get from HashNode or NullNode")
   }
 
   private def put(node: MptNode, searchKey: Array[Byte], value: Array[Byte]): NodeInsertResult = node match {

--- a/src/main/scala/io/iohk/ethereum/mpt/Node.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/Node.scala
@@ -25,6 +25,8 @@ sealed abstract class MptNode {
     val encoded = encode
     if (encoded.length < 32) ByteString(encoded) else ByteString(hash)
   }
+
+  def isNull: Boolean
 }
 
 object Node {
@@ -36,20 +38,26 @@ case class LeafNode(key: ByteString, value: ByteString,
   def withCachedHash(cachedHash: Array[Byte]): MptNode = copy(cachedHash = Some(cachedHash))
 
   def withCachedRlpEncoded(cachedEncode: Array[Byte]): MptNode = copy(cachedRlpEncoded = Some(cachedEncode))
+
+  override def isNull: Boolean = false
 }
 
-case class ExtensionNode(sharedKey: ByteString, next: Either[ByteString, MptNode],
+case class ExtensionNode(sharedKey: ByteString, next: MptNode,
                          cachedHash: Option[Array[Byte]] = None, cachedRlpEncoded: Option[Array[Byte]] = None) extends MptNode {
   def withCachedHash(cachedHash: Array[Byte]): MptNode = copy(cachedHash = Some(cachedHash))
 
   def withCachedRlpEncoded(cachedEncode: Array[Byte]): MptNode = copy(cachedRlpEncoded = Some(cachedEncode))
+
+  override def isNull: Boolean = false
 }
 
-case class BranchNode(children: Seq[Option[Either[ByteString, MptNode]]], terminator: Option[ByteString],
+case class BranchNode(children: Seq[MptNode], terminator: Option[ByteString],
                       cachedHash: Option[Array[Byte]] = None, cachedRlpEncoded: Option[Array[Byte]] = None) extends MptNode {
   def withCachedHash(cachedHash: Array[Byte]): MptNode = copy(cachedHash = Some(cachedHash))
 
   def withCachedRlpEncoded(cachedEncode: Array[Byte]): MptNode = copy(cachedRlpEncoded = Some(cachedEncode))
+
+  override def isNull: Boolean = false
 
   require(children.length == 16, "MptBranch childHashes length have to be 16")
 
@@ -62,9 +70,31 @@ case class BranchNode(children: Seq[Option[Either[ByteString, MptNode]]], termin
     */
   def updateChild(childIndex: Int, childNode: MptNode): BranchNode = {
     val childCapped = childNode.capped
-    BranchNode(children.updated(childIndex, Some(if (childCapped.length == 32) Left(childCapped) else Right(childNode))), terminator)
+    BranchNode(children.updated(childIndex, if (childCapped.length == 32) HashNode(childCapped) else childNode), terminator)
   }
 }
+
+case class HashNode(hashNode: ByteString) extends MptNode {
+  val cachedHash: Option[Array[Byte]] = Some(hashNode.toArray[Byte])
+  val cachedRlpEncoded: Option[Array[Byte]] = None
+  def withCachedHash(cachedHash: Array[Byte]): MptNode = copy()
+
+  def withCachedRlpEncoded(cachedEncode: Array[Byte]): MptNode = copy()
+
+  override def isNull: Boolean = false
+}
+
+case object NullNode extends MptNode {
+  import MerklePatriciaTrie._
+  val cachedHash: Option[Array[Byte]] = Some(EmptyRootHash)
+  val cachedRlpEncoded: Option[Array[Byte]] = Some(EmptyEncoded)
+  def withCachedHash(cachedHash: Array[Byte]): MptNode = this
+
+  def withCachedRlpEncoded(cachedEncode: Array[Byte]): MptNode = this
+
+  override def isNull: Boolean = true
+}
+
 
 object ExtensionNode {
   /**
@@ -76,12 +106,13 @@ object ExtensionNode {
     */
   def apply(sharedKey: ByteString, next: MptNode): ExtensionNode = {
     val nextCapped = next.capped
-    ExtensionNode(sharedKey, if (nextCapped.length == 32) Left(nextCapped) else Right(next))
+    val nextNode = if (nextCapped.length == 32) HashNode(nextCapped) else next
+    new ExtensionNode(sharedKey, nextNode)
   }
 }
 
 object BranchNode {
-  private val emptyChildren: Seq[Option[Either[ByteString, MptNode]]] = Array.fill(MerklePatriciaTrie.ListSize - 1)(None)
+  private val emptyChildren: Seq[MptNode] = Array.fill(MerklePatriciaTrie.ListSize - 1)(NullNode)
 
   /**
     * This function creates a new terminator BranchNode having only a value associated with it.
@@ -104,18 +135,6 @@ object BranchNode {
     */
   def withSingleChild(position: Byte, child: MptNode, terminator: Option[Array[Byte]]): BranchNode = {
     val childCapped = child.capped
-    BranchNode(emptyChildren.updated(position, Some(if (childCapped.length == 32) Left(childCapped) else Right(child))), terminator.map(e => ByteString(e)))
+    BranchNode(emptyChildren.updated(position, if (childCapped.length == 32) HashNode(childCapped) else child), terminator.map(e => ByteString(e)))
   }
-
-  /**
-    * This function creates a new BranchNode having only one child associated with it (and optionaly a value).
-    * This new BranchNode will be temporarily in an invalid state.
-    *
-    * @param position   of the BranchNode children where the child should be inserted.
-    * @param child      to be inserted as a child of the new BranchNode (already hashed if necessary).
-    * @param terminator to be associated with the new BranchNode.
-    * @return a new BranchNode.
-    */
-  def withSingleChild(position: Byte, child: Either[ByteString, MptNode], terminator: Option[Array[Byte]]): BranchNode =
-  BranchNode(emptyChildren.updated(position, Some(child)), terminator.map(e => ByteString(e)))
 }

--- a/src/main/scala/io/iohk/ethereum/mpt/Node.scala
+++ b/src/main/scala/io/iohk/ethereum/mpt/Node.scala
@@ -132,7 +132,7 @@ object ExtensionNode {
 }
 
 object BranchNode {
-  private val numberOfChildren = 16
+  val numberOfChildren = 16
   private val emptyChildren: Array[MptNode] = Array.fill(numberOfChildren)(NullNode)
 
   /**

--- a/src/rpcTest/scala/io/iohk/ethereum/rpcTest/RpcApiTests.scala
+++ b/src/rpcTest/scala/io/iohk/ethereum/rpcTest/RpcApiTests.scala
@@ -1126,6 +1126,6 @@ abstract class ScenarioSetup {
     val transaction = req.toTransaction(0)
 
     val stx = fromWallet.signTx(transaction, None)
-    Hex.toHexString(rlp.encode(stx.toRLPEncodable))
+    Hex.toHexString(rlp.encode(stx.tx.toRLPEncodable))
   }
 }

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -90,7 +90,7 @@ trait ObjectGenerators {
   def branchNodeGen: Gen[BranchNode] = for {
     children <- Gen.listOfN(16, byteStringOfLengthNGen(32)).map(childrenList => childrenList.map(child => HashNode(child)))
     terminator <- byteStringOfLengthNGen(32)
-  } yield BranchNode(children, Some(terminator))
+  } yield BranchNode(children.toArray, Some(terminator))
 
   def extensionNodeGen: Gen[ExtensionNode] = for {
     keyNibbles <- byteArrayOfNItemsGen(32)

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -6,7 +6,7 @@ import java.security.SecureRandom
 import akka.util.ByteString
 import io.iohk.ethereum.mpt.HexPrefix.bytesToNibbles
 import org.scalacheck.{Arbitrary, Gen, Shrink}
-import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, LeafNode, MptNode}
+import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode, MptNode}
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
@@ -88,14 +88,14 @@ trait ObjectGenerators {
   def receiptsGen(n: Int): Gen[Seq[Seq[Receipt]]] = Gen.listOfN(n, Gen.listOf(receiptGen()))
 
   def branchNodeGen: Gen[BranchNode] = for {
-    children <- Gen.listOfN(16, byteStringOfLengthNGen(32)).map(childrenList => childrenList.map(child => Some(Left(child))))
+    children <- Gen.listOfN(16, byteStringOfLengthNGen(32)).map(childrenList => childrenList.map(child => HashNode(child)))
     terminator <- byteStringOfLengthNGen(32)
   } yield BranchNode(children, Some(terminator))
 
   def extensionNodeGen: Gen[ExtensionNode] = for {
     keyNibbles <- byteArrayOfNItemsGen(32)
     value <- byteStringOfLengthNGen(32)
-  } yield ExtensionNode(ByteString(bytesToNibbles(keyNibbles)), Left(value))
+  } yield ExtensionNode(ByteString(bytesToNibbles(keyNibbles)), HashNode(value))
 
   def leafNodeGen: Gen[LeafNode] = for {
     keyNibbles <- byteArrayOfNItemsGen(32)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockchainHostActorSpec.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorSystem, Props}
 import akka.testkit.{TestActorRef, TestProbe}
 import akka.util.ByteString
 import io.iohk.ethereum.domain.{BlockHeader, Receipt}
-import io.iohk.ethereum.mpt.{ExtensionNode, HexPrefix, MptNode}
+import io.iohk.ethereum.mpt.{ExtensionNode, HashNode, HexPrefix, MptNode}
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
 import io.iohk.ethereum.network.PeerEventBusActor.SubscriptionClassifier.MessageClassifier
 import io.iohk.ethereum.network.PeerEventBusActor.{PeerSelector, Subscribe}
@@ -210,7 +210,7 @@ class BlockchainHostActorSpec extends FlatSpec with Matchers {
     //given
     val exampleNibbles = ByteString(HexPrefix.bytesToNibbles(Hex.decode("ffddaa")))
     val exampleHash = ByteString(Hex.decode("ab"*32))
-    val extensionNode: MptNode = ExtensionNode(exampleNibbles, Left(exampleHash))
+    val extensionNode: MptNode = ExtensionNode(exampleNibbles, HashNode(exampleHash))
 
     blockchain.nodesKeyValueStorageFor(Some(0), storagesInstance.storages.nodeStorage)
       .update(Nil, Seq(ByteString(extensionNode.hash) -> (extensionNode.toBytes: Array[Byte])))

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/NodeDataSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/NodeDataSpec.scala
@@ -36,14 +36,14 @@ class NodeDataSpec extends FlatSpec with Matchers {
   val encodedLeafNode = RLPList(hpEncode(exampleNibbles.toArray[Byte], isLeaf = true), encode(encodedAccount))
 
   val branchNode = new BranchNode(
-    (Seq.fill[MptNode](3)(NullNode) :+ HashNode(exampleHash)) ++
-      (Seq.fill[MptNode](6)(NullNode) :+ HashNode(exampleHash)) ++
-      Seq.fill[MptNode](5)(NullNode), None)
+    (Array.fill[MptNode](3)(NullNode) :+ HashNode(exampleHash)) ++
+      (Array.fill[MptNode](6)(NullNode) :+ HashNode(exampleHash)) ++
+      Array.fill[MptNode](5)(NullNode), None)
 
   val encodedBranchNode = RLPList(
-    (Seq.fill[RLPValue](3)(RLPValue(Array.emptyByteArray)) :+ (exampleHash: RLPEncodeable)) ++
-      (Seq.fill[RLPValue](6)(RLPValue(Array.emptyByteArray)) :+ (exampleHash: RLPEncodeable)) ++
-      (Seq.fill[RLPValue](5)(RLPValue(Array.emptyByteArray)) :+ (Array.emptyByteArray: RLPEncodeable)): _*)
+    (Array.fill[RLPValue](3)(RLPValue(Array.emptyByteArray)) :+ (exampleHash: RLPEncodeable)) ++
+      (Array.fill[RLPValue](6)(RLPValue(Array.emptyByteArray)) :+ (exampleHash: RLPEncodeable)) ++
+      (Array.fill[RLPValue](5)(RLPValue(Array.emptyByteArray)) :+ (Array.emptyByteArray: RLPEncodeable)): _*)
 
   val extensionNode = ExtensionNode(exampleNibbles, HashNode(exampleHash))
   val encodedExtensionNode = RLPList(hpEncode(exampleNibbles.toArray[Byte], isLeaf = false), RLPValue(exampleHash.toArray[Byte]))
@@ -90,7 +90,7 @@ class NodeDataSpec extends FlatSpec with Matchers {
       Hex.decode("f84d8080808080de9c32ea07b198667c460bb7d8bc9652f6ffbde7b195d81c17eb614e2b8901808080808080de9c3ffe8cb7f9cebdcb4eca6e682b56ab66f4f45827cf27c11b7f0a91620180808080")
 
     val decodedMptBranch =
-      new BranchNode(Seq(
+      new BranchNode(Array(
         NullNode,
         NullNode,
         NullNode,

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/NodeDataSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/NodeDataSpec.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.network.p2p.messages
 import akka.util.ByteString
 import io.iohk.ethereum.crypto._
 import io.iohk.ethereum.domain.Account
-import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, LeafNode, MptNode}
+import io.iohk.ethereum.mpt.{BranchNode, ExtensionNode, HashNode, LeafNode, MptNode, NullNode}
 import io.iohk.ethereum.mpt.HexPrefix.{bytesToNibbles, encode => hpEncode}
 import io.iohk.ethereum.network.p2p.messages.PV63._
 import io.iohk.ethereum.network.p2p.messages.PV63.MptNodeEncoders._
@@ -36,16 +36,16 @@ class NodeDataSpec extends FlatSpec with Matchers {
   val encodedLeafNode = RLPList(hpEncode(exampleNibbles.toArray[Byte], isLeaf = true), encode(encodedAccount))
 
   val branchNode = new BranchNode(
-    (Seq.fill[Option[Either[ByteString, MptNode]]](3)(None) :+ Some(Left(exampleHash))) ++
-      (Seq.fill[Option[Either[ByteString, MptNode]]](6)(None) :+ Some(Left(exampleHash))) ++
-      Seq.fill[Option[Either[ByteString, MptNode]]](5)(None), None)
+    (Seq.fill[MptNode](3)(NullNode) :+ HashNode(exampleHash)) ++
+      (Seq.fill[MptNode](6)(NullNode) :+ HashNode(exampleHash)) ++
+      Seq.fill[MptNode](5)(NullNode), None)
 
   val encodedBranchNode = RLPList(
     (Seq.fill[RLPValue](3)(RLPValue(Array.emptyByteArray)) :+ (exampleHash: RLPEncodeable)) ++
       (Seq.fill[RLPValue](6)(RLPValue(Array.emptyByteArray)) :+ (exampleHash: RLPEncodeable)) ++
       (Seq.fill[RLPValue](5)(RLPValue(Array.emptyByteArray)) :+ (Array.emptyByteArray: RLPEncodeable)): _*)
 
-  val extensionNode = ExtensionNode(exampleNibbles, Left(exampleHash))
+  val extensionNode = ExtensionNode(exampleNibbles, HashNode(exampleHash))
   val encodedExtensionNode = RLPList(hpEncode(exampleNibbles.toArray[Byte], isLeaf = false), RLPValue(exampleHash.toArray[Byte]))
 
   val nodeData = NodeData(Seq(
@@ -91,26 +91,26 @@ class NodeDataSpec extends FlatSpec with Matchers {
 
     val decodedMptBranch =
       new BranchNode(Seq(
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(Right(LeafNode(
+        NullNode,
+        NullNode,
+        NullNode,
+        NullNode,
+        NullNode,
+        LeafNode(
           key = ByteString(Hex.decode("020e0a00070b0109080606070c0406000b0b070d080b0c090605020f060f0f0b0d0e070b0109050d08010c01070e0b0601040e020b0809")),
-          value = ByteString(1)))),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(Right(LeafNode(
+          value = ByteString(1)),
+        NullNode,
+        NullNode,
+        NullNode,
+        NullNode,
+        NullNode,
+        NullNode,
+        LeafNode(
           key = ByteString(Hex.decode("0f0f0e080c0b070f090c0e0b0d0c0b040e0c0a060e0608020b05060a0b06060f040f04050802070c0f02070c01010b070f000a09010602")),
-          value = ByteString(1)))),
-        None,
-        None,
-        None
+          value = ByteString(1)),
+        NullNode,
+        NullNode,
+        NullNode
       ), None)
 
     //when


### PR DESCRIPTION
1st batch of improvements to mpt trie, changes:
Reduce unnecessery allocations of wrappers (`Option`, `Either`).
Use Arrays and while loops where possible.

changes to `MptNode` encoding enables further refactorings and possible performance gains but i did not want to make this pr to big. (extending `MptNode` required some additional exception throws in pattern matching clauses to satisfy compiler)

Performance gains (30min sync ):
Baseline - 288577blocks
Improved - 301057blocks
~5%
