### PR TITLE
Refactor/change index seq to array of byte in data storage

### DIFF
--- a/src/it/scala/io/iohk/ethereum/db/DataSourceIntegrationTestBehavior.scala
+++ b/src/it/scala/io/iohk/ethereum/db/DataSourceIntegrationTestBehavior.scala
@@ -3,7 +3,6 @@ package io.iohk.ethereum.db
 import java.io.File
 import java.nio.file.Files
 
-import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
 import io.iohk.ethereum.db.dataSource.DataSource
 import org.scalatest.FlatSpec
@@ -34,7 +33,7 @@ trait DataSourceIntegrationTestBehavior
     }
   }
 
-  def updateInSeparateCalls(dataSource: DataSource, toUpsert: Seq[(ByteString, ByteString)]): DataSource = {
+  def updateInSeparateCalls(dataSource: DataSource, toUpsert: Seq[(Array[Byte], Array[Byte])]): DataSource = {
     toUpsert.foldLeft(dataSource) { case (recDB, keyValuePair) =>
       recDB.update(OtherNamespace, Seq(), Seq(keyValuePair))
     }
@@ -43,7 +42,7 @@ trait DataSourceIntegrationTestBehavior
   // scalastyle:off
   def dataSource(createDataSource: => String => DataSource): Unit = {
     it should "be able to insert keys in separate updates" in {
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = updateInSeparateCalls(
@@ -58,7 +57,7 @@ trait DataSourceIntegrationTestBehavior
     }
 
     it should "be able to insert keys in a single update" in {
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path).update(OtherNamespace, Seq(), keyList.zip(keyList))
@@ -71,7 +70,7 @@ trait DataSourceIntegrationTestBehavior
     }
 
     it should "be able to update keys in separate updates" in {
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path).update(OtherNamespace, Seq(), keyList.zip(keyList))
@@ -89,7 +88,7 @@ trait DataSourceIntegrationTestBehavior
     }
 
     it should "be able to update keys in a single update" in {
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path).update(OtherNamespace, Seq(), keyList.zip(keyList))
@@ -107,7 +106,7 @@ trait DataSourceIntegrationTestBehavior
     }
 
     it should "be cleared" in {
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path).update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
@@ -121,7 +120,7 @@ trait DataSourceIntegrationTestBehavior
     }
 
     it should "be able to be closed and then continuing using it" in {
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path).update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
@@ -137,7 +136,7 @@ trait DataSourceIntegrationTestBehavior
 
     it should "be destroyed" in {
       withDir { path =>
-        forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+        forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path).update(namespace = OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
           db.destroy()
@@ -154,7 +153,7 @@ trait DataSourceIntegrationTestBehavior
 
     it should "be able to handle inserts to multiple namespaces with the same key" in {
       val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path)
@@ -180,7 +179,7 @@ trait DataSourceIntegrationTestBehavior
 
     it should "be able to handle removals from multiple namespaces with the same key" in {
       val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
-      forAll(seqByteStringOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList: Seq[ByteString] =>
+      forAll(seqByteArrayOfNItemsGen(KeySizeWithoutPrefix)) { unFilteredKeyList =>
         withDir { path =>
           val keyList = unFilteredKeyList.take(KeyNumberLimit)
           val db = createDataSource(path)

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -29,7 +29,7 @@ trait DataSource {
     * @param key the key retrieve the value.
     * @return the value associated with the passed key.
     */
-  def getOptimized(key: Array[Byte]): Option[Array[Byte]]
+  def getOptimized(key: Key): Option[Array[Byte]]
 
   /**
     * This function updates the DataSource by deleting, updating and inserting new (key-value) pairs.
@@ -52,7 +52,7 @@ trait DataSource {
     *                 If a key is already in the DataSource its value will be updated.
     * @return the new DataSource after the removals and insertions were done.
     */
-  def updateOptimized(toRemove: Seq[Array[Byte]], toUpsert: Seq[(Array[Byte], Array[Byte])]): DataSource
+  def updateOptimized(toRemove: Seq[Key], toUpsert: Seq[(Key, Array[Byte])]): DataSource
 
   /**
     * This function updates the DataSource by deleting all the (key-value) pairs in it.
@@ -73,7 +73,7 @@ trait DataSource {
 }
 
 object DataSource {
-  type Key = IndexedSeq[Byte]
+  type Key = Array[Byte]
   type Value = IndexedSeq[Byte]
   type Namespace = IndexedSeq[Byte]
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/DataSource.scala
@@ -29,7 +29,7 @@ trait DataSource {
     * @param key the key retrieve the value.
     * @return the value associated with the passed key.
     */
-  def getOptimized(key: Key): Option[Array[Byte]]
+  def getOptimized(key: Key): Option[Value]
 
   /**
     * This function updates the DataSource by deleting, updating and inserting new (key-value) pairs.
@@ -52,7 +52,7 @@ trait DataSource {
     *                 If a key is already in the DataSource its value will be updated.
     * @return the new DataSource after the removals and insertions were done.
     */
-  def updateOptimized(toRemove: Seq[Key], toUpsert: Seq[(Key, Array[Byte])]): DataSource
+  def updateOptimized(toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource
 
   /**
     * This function updates the DataSource by deleting all the (key-value) pairs in it.
@@ -74,6 +74,6 @@ trait DataSource {
 
 object DataSource {
   type Key = Array[Byte]
-  type Value = IndexedSeq[Byte]
+  type Value = Array[Byte]
   type Namespace = IndexedSeq[Byte]
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/IodbDataSource.scala
@@ -13,7 +13,7 @@ class IodbDataSource private (lSMStore: LSMStore, keySize: Int, path: String) ex
   override def get(namespace: Namespace, key: Key): Option[Value] = {
     require(namespace.length + key.length <= keySize, "Wrong key size in IODB get")
     val keyPadded = padToKeySize(namespace, key, keySize)
-    lSMStore.get(ByteArrayWrapper(keyPadded)).map(v => v.data.toIndexedSeq)
+    lSMStore.get(ByteArrayWrapper(keyPadded)).map(v => v.data)
   }
 
   override def update(namespace: Namespace, toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource = {
@@ -38,7 +38,7 @@ class IodbDataSource private (lSMStore: LSMStore, keySize: Int, path: String) ex
 
   override def close(): Unit = lSMStore.close()
 
-  override def updateOptimized(toRemove: Seq[Array[Byte]], toUpsert: Seq[(Array[Byte], Array[Byte])]): DataSource  = {
+  override def updateOptimized(toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource  = {
     lSMStore.update(
       ByteArrayWrapper(storageVersionGen()),
       toRemove.map(key => ByteArrayWrapper(key)),
@@ -46,7 +46,7 @@ class IodbDataSource private (lSMStore: LSMStore, keySize: Int, path: String) ex
     new IodbDataSource(lSMStore, keySize, path)
   }
 
-  override def getOptimized(key: Array[Byte]): Option[Array[Byte]] = {
+  override def getOptimized(key: Key): Option[Value] = {
     lSMStore.get(ByteArrayWrapper(key)).map(_.data)
   }
 
@@ -60,7 +60,7 @@ class IodbDataSource private (lSMStore: LSMStore, keySize: Int, path: String) ex
   }
 
   private def asStorables(keyValues: Seq[(Key, Value)]): Seq[(ByteArrayWrapper, ByteArrayWrapper)] =
-    keyValues.map{ case (key, value) => ByteArrayWrapper(key) -> ByteArrayWrapper(value.toArray) }
+    keyValues.map{ case (key, value) => ByteArrayWrapper(key) -> ByteArrayWrapper(value) }
 }
 
 

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSource.scala
@@ -39,7 +39,7 @@ class LevelDBDataSource(private var db: DB, private val levelDbConfig: LevelDbCo
     val batch = db.createWriteBatch()
 
     toRemove.foreach{ key => batch.delete((namespace ++ key).toArray) }
-    toUpsert.foreach{ case (k, v) => batch.put((namespace ++ k).toArray, v.toArray) }
+    toUpsert.foreach{ case (k, v) => batch.put((namespace ++ k).toArray, v) }
 
     db.write(batch)
     batch.close()
@@ -47,7 +47,7 @@ class LevelDBDataSource(private var db: DB, private val levelDbConfig: LevelDbCo
     this
   }
 
-  override def updateOptimized(toRemove: Seq[Key], toUpsert: Seq[(Key, Array[Byte])]): DataSource = {
+  override def updateOptimized(toRemove: Seq[Key], toUpsert: Seq[(Key, Value)]): DataSource = {
     val batch = db.createWriteBatch()
 
     toRemove.foreach{ key => batch.delete(key) }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/LevelDBDataSource.scala
@@ -24,7 +24,7 @@ class LevelDBDataSource(private var db: DB, private val levelDbConfig: LevelDbCo
     * @param key the key retrieve the value.
     * @return the value associated with the passed key.
     */
-  override def getOptimized(key: Array[Byte]): Option[Array[Byte]] = Option(db.get(key))
+  override def getOptimized(key: Key): Option[Array[Byte]] = Option(db.get(key))
 
   /**
     * This function updates the DataSource by deleting, updating and inserting new (key-value) pairs.
@@ -47,7 +47,7 @@ class LevelDBDataSource(private var db: DB, private val levelDbConfig: LevelDbCo
     this
   }
 
-  override def updateOptimized(toRemove: Seq[Array[Byte]], toUpsert: Seq[(Array[Byte], Array[Byte])]): DataSource = {
+  override def updateOptimized(toRemove: Seq[Key], toUpsert: Seq[(Key, Array[Byte])]): DataSource = {
     val batch = db.createWriteBatch()
 
     toRemove.foreach{ key => batch.delete(key) }

--- a/src/main/scala/io/iohk/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/AppStateStorage.scala
@@ -12,7 +12,7 @@ class AppStateStorage(val dataSource: DataSource) extends KeyValueStorage[Key, V
   type T = AppStateStorage
 
   val namespace: IndexedSeq[Byte] = Namespaces.AppStateNamespace
-  def keySerializer: Key => IndexedSeq[Byte] = _.name.getBytes
+  def keySerializer: Key => Array[Byte] = _.name.getBytes
   def valueSerializer: String => IndexedSeq[Byte] = _.getBytes
   def valueDeserializer: IndexedSeq[Byte] => String = (valueBytes: IndexedSeq[Byte]) => new String(valueBytes.toArray)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/AppStateStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/AppStateStorage.scala
@@ -13,8 +13,8 @@ class AppStateStorage(val dataSource: DataSource) extends KeyValueStorage[Key, V
 
   val namespace: IndexedSeq[Byte] = Namespaces.AppStateNamespace
   def keySerializer: Key => Array[Byte] = _.name.getBytes
-  def valueSerializer: String => IndexedSeq[Byte] = _.getBytes
-  def valueDeserializer: IndexedSeq[Byte] => String = (valueBytes: IndexedSeq[Byte]) => new String(valueBytes.toArray)
+  def valueSerializer: String => Array[Byte] = _.getBytes
+  def valueDeserializer: Array[Byte] => String = (valueBytes: Array[Byte]) => new String(valueBytes)
 
   protected def apply(dataSource: DataSource): AppStateStorage = new AppStateStorage(dataSource)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
@@ -17,7 +17,7 @@ class BlockBodiesStorage(val dataSource: DataSource) extends KeyValueStorage[Blo
 
   override val namespace: IndexedSeq[Byte] = Namespaces.BodyNamespace
 
-  override def keySerializer: (BlockBodyHash) => IndexedSeq[Byte] = identity
+  override def keySerializer: (BlockBodyHash) => Array[Byte] = _.toArray[Byte]
 
   override def valueSerializer: (BlockBody) => IndexedSeq[Byte] = BlockBodiesStorage.toBytes
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockBodiesStorage.scala
@@ -19,9 +19,9 @@ class BlockBodiesStorage(val dataSource: DataSource) extends KeyValueStorage[Blo
 
   override def keySerializer: (BlockBodyHash) => Array[Byte] = _.toArray[Byte]
 
-  override def valueSerializer: (BlockBody) => IndexedSeq[Byte] = BlockBodiesStorage.toBytes
+  override def valueSerializer: (BlockBody) => Array[Byte] = BlockBodiesStorage.toBytes
 
-  override def valueDeserializer: (IndexedSeq[Byte]) => BlockBody = b => BlockBodiesStorage.fromBytes(b.toArray[Byte])
+  override def valueDeserializer: (Array[Byte]) => BlockBody = BlockBodiesStorage.fromBytes
 
   override protected def apply(dataSource: DataSource): BlockBodiesStorage = new BlockBodiesStorage(dataSource)
 }
@@ -52,7 +52,7 @@ object BlockBodiesStorage {
   }
 
 
-  private[BlockBodiesStorage] def toBytes(blockBody: BlockBody): IndexedSeq[Byte] = {
+  private[BlockBodiesStorage] def toBytes(blockBody: BlockBody): Array[Byte] = {
     encode(BlockBody.blockBodyToRlpEncodable(
       blockBody,
       signedTransactionToBytes,

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockHeadersStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockHeadersStorage.scala
@@ -17,9 +17,9 @@ class BlockHeadersStorage(val dataSource: DataSource) extends KeyValueStorage[Bl
 
   override def keySerializer: (BlockHeaderHash) => Array[Byte] = _.toArray[Byte]
 
-  override def valueSerializer: (BlockHeader) => IndexedSeq[Byte] = _.toBytes
+  override def valueSerializer: (BlockHeader) => Array[Byte] = _.toBytes
 
-  override def valueDeserializer: (IndexedSeq[Byte]) => BlockHeader = b => b.toArray.toBlockHeader
+  override def valueDeserializer: (Array[Byte]) => BlockHeader = b => b.toBlockHeader
 
   override protected def apply(dataSource: DataSource): BlockHeadersStorage = new BlockHeadersStorage(dataSource)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockHeadersStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockHeadersStorage.scala
@@ -15,7 +15,7 @@ class BlockHeadersStorage(val dataSource: DataSource) extends KeyValueStorage[Bl
 
   override val namespace: IndexedSeq[Byte] = Namespaces.HeaderNamespace
 
-  override def keySerializer: (BlockHeaderHash) => IndexedSeq[Byte] = identity
+  override def keySerializer: (BlockHeaderHash) => Array[Byte] = _.toArray[Byte]
 
   override def valueSerializer: (BlockHeader) => IndexedSeq[Byte] = _.toBytes
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockNumberMappingStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockNumberMappingStorage.scala
@@ -9,9 +9,9 @@ class BlockNumberMappingStorage(val dataSource: DataSource) extends KeyValueStor
 
   override def keySerializer: (BigInt) => Array[Byte] = index => index.toByteArray
 
-  override def valueSerializer: (BlockHeaderHash) => IndexedSeq[Byte] = identity
+  override def valueSerializer: (BlockHeaderHash) => Array[Byte] = _.toArray[Byte]
 
-  override def valueDeserializer: (IndexedSeq[Byte]) => BlockHeaderHash = arr => ByteString(arr.toArray[Byte])
+  override def valueDeserializer: (Array[Byte]) => BlockHeaderHash = arr => ByteString(arr)
 
   override protected def apply(dataSource: DataSource): BlockNumberMappingStorage = new BlockNumberMappingStorage(dataSource)
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/BlockNumberMappingStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/BlockNumberMappingStorage.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.db.storage.BlockHeadersStorage.BlockHeaderHash
 class BlockNumberMappingStorage(val dataSource: DataSource) extends KeyValueStorage[BigInt, BlockHeaderHash, BlockNumberMappingStorage] {
   override val namespace: IndexedSeq[Byte] = Namespaces.HeightsNamespace
 
-  override def keySerializer: (BigInt) => IndexedSeq[Byte] = index => index.toByteArray
+  override def keySerializer: (BigInt) => Array[Byte] = index => index.toByteArray
 
   override def valueSerializer: (BlockHeaderHash) => IndexedSeq[Byte] = identity
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/EvmCodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/EvmCodeStorage.scala
@@ -12,8 +12,8 @@ import io.iohk.ethereum.db.storage.EvmCodeStorage._
 class EvmCodeStorage(val dataSource: DataSource) extends KeyValueStorage[CodeHash, Code, EvmCodeStorage] {
   val namespace: IndexedSeq[Byte] = Namespaces.CodeNamespace
   def keySerializer: CodeHash => Array[Byte] = _.toArray[Byte]
-  def valueSerializer: Code => IndexedSeq[Byte] = identity
-  def valueDeserializer: IndexedSeq[Byte] => Code = (code: IndexedSeq[Byte]) => ByteString(code.toArray)
+  def valueSerializer: Code => Array[Byte] = _.toArray[Byte]
+  def valueDeserializer: Array[Byte] => Code = (code: Array[Byte]) => ByteString(code)
 
   protected def apply(dataSource: DataSource): EvmCodeStorage = new EvmCodeStorage(dataSource)
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/EvmCodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/EvmCodeStorage.scala
@@ -11,7 +11,7 @@ import io.iohk.ethereum.db.storage.EvmCodeStorage._
   */
 class EvmCodeStorage(val dataSource: DataSource) extends KeyValueStorage[CodeHash, Code, EvmCodeStorage] {
   val namespace: IndexedSeq[Byte] = Namespaces.CodeNamespace
-  def keySerializer: CodeHash => IndexedSeq[Byte] = identity
+  def keySerializer: CodeHash => Array[Byte] = _.toArray[Byte]
   def valueSerializer: Code => IndexedSeq[Byte] = identity
   def valueDeserializer: IndexedSeq[Byte] => Code = (code: IndexedSeq[Byte]) => ByteString(code.toArray)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/FastSyncStateStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/FastSyncStateStorage.scala
@@ -33,10 +33,10 @@ class FastSyncStateStorage(val dataSource: DataSource) extends KeyValueStorage[S
 
   override def keySerializer: String => Array[Byte] = _.getBytes
 
-  override def valueSerializer: SyncState => IndexedSeq[Byte] = ss => compactPickledBytes(Pickle.intoBytes(ss))
+  override def valueSerializer: SyncState => Array[Byte] = ss => compactPickledBytes(Pickle.intoBytes(ss)).toArray[Byte]
 
-  override def valueDeserializer: IndexedSeq[Byte] => SyncState =
-    (bytes: IndexedSeq[Byte]) => Unpickle[SyncState].fromBytes(ByteBuffer.wrap(bytes.toArray[Byte]))
+  override def valueDeserializer: Array[Byte] => SyncState =
+    (bytes: Array[Byte]) => Unpickle[SyncState].fromBytes(ByteBuffer.wrap(bytes))
 
   protected def apply(dataSource: DataSource): FastSyncStateStorage = new FastSyncStateStorage(dataSource)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/FastSyncStateStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/FastSyncStateStorage.scala
@@ -31,7 +31,7 @@ class FastSyncStateStorage(val dataSource: DataSource) extends KeyValueStorage[S
       .addConcreteType[EvmCodeHash]
       .addConcreteType[StorageRootHash]
 
-  override def keySerializer: String => IndexedSeq[Byte] = _.getBytes
+  override def keySerializer: String => Array[Byte] = _.getBytes
 
   override def valueSerializer: SyncState => IndexedSeq[Byte] = ss => compactPickledBytes(Pickle.intoBytes(ss))
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/IodbBlockNumberMappingStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/IodbBlockNumberMappingStorage.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.db.dataSource.{DataSource, IodbDataSource}
   */
 class IodbBlockNumberMappingStorage(dataSource: DataSource) extends BlockNumberMappingStorage(dataSource) {
 
-  override def keySerializer: (BigInt) => IndexedSeq[Byte] = index => index.toByteArray.padTo(IodbDataSource.KeySizeWithoutNamespace, 0.toByte)
+  override def keySerializer: (BigInt) => Array[Byte] = index => index.toByteArray.padTo(IodbDataSource.KeySizeWithoutNamespace, 0.toByte)
 
   override protected def apply(dataSource: DataSource): IodbBlockNumberMappingStorage = new IodbBlockNumberMappingStorage(dataSource)
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
@@ -8,8 +8,8 @@ trait KeyValueStorage[K, V, T <: KeyValueStorage[K, V, T]] extends SimpleMap[K, 
   val dataSource: DataSource
   val namespace: IndexedSeq[Byte]
   def keySerializer: K => Array[Byte]
-  def valueSerializer: V => IndexedSeq[Byte]
-  def valueDeserializer: IndexedSeq[Byte] => V
+  def valueSerializer: V => Array[Byte]
+  def valueDeserializer: Array[Byte] => V
 
   protected def apply(dataSource: DataSource): T
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/KeyValueStorage.scala
@@ -7,7 +7,7 @@ trait KeyValueStorage[K, V, T <: KeyValueStorage[K, V, T]] extends SimpleMap[K, 
 
   val dataSource: DataSource
   val namespace: IndexedSeq[Byte]
-  def keySerializer: K => IndexedSeq[Byte]
+  def keySerializer: K => Array[Byte]
   def valueSerializer: V => IndexedSeq[Byte]
   def valueDeserializer: IndexedSeq[Byte] => V
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/KnownNodesStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/KnownNodesStorage.scala
@@ -14,7 +14,7 @@ class KnownNodesStorage(val dataSource: DataSource) extends KeyValueStorage[Stri
   val key = "KnownNodes"
 
   val namespace: IndexedSeq[Byte] = Namespaces.KnownNodesNamespace
-  def keySerializer: String => IndexedSeq[Byte] = _.getBytes
+  def keySerializer: String => Array[Byte] = _.getBytes
   def valueSerializer: Set[String] => IndexedSeq[Byte] = _.mkString(" ").getBytes
   def valueDeserializer: IndexedSeq[Byte] => Set[String] = (valueBytes: IndexedSeq[Byte]) => new String(valueBytes.toArray).split(' ').toSet
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/KnownNodesStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/KnownNodesStorage.scala
@@ -15,8 +15,8 @@ class KnownNodesStorage(val dataSource: DataSource) extends KeyValueStorage[Stri
 
   val namespace: IndexedSeq[Byte] = Namespaces.KnownNodesNamespace
   def keySerializer: String => Array[Byte] = _.getBytes
-  def valueSerializer: Set[String] => IndexedSeq[Byte] = _.mkString(" ").getBytes
-  def valueDeserializer: IndexedSeq[Byte] => Set[String] = (valueBytes: IndexedSeq[Byte]) => new String(valueBytes.toArray).split(' ').toSet
+  def valueSerializer: Set[String] => Array[Byte] = _.mkString(" ").getBytes
+  def valueDeserializer: Array[Byte] => Set[String] = (valueBytes: Array[Byte]) => new String(valueBytes).split(' ').toSet
 
   protected def apply(dataSource: DataSource): KnownNodesStorage = new KnownNodesStorage(dataSource)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
@@ -22,8 +22,8 @@ class NodeStorage(val dataSource: DataSource) extends KeyValueStorage[NodeHash, 
   val namespace: IndexedSeq[Byte] = Namespaces.NodeNamespace
   private val specialNameSpace = namespace.head
   def keySerializer: NodeHash => Array[Byte] = _.toArray[Byte]
-  def valueSerializer: NodeEncoded => IndexedSeq[Byte] = _.toIndexedSeq
-  def valueDeserializer: IndexedSeq[Byte] => NodeEncoded = _.toArray
+  def valueSerializer: NodeEncoded => Array[Byte] = identity
+  def valueDeserializer: Array[Byte] => NodeEncoded = identity
 
   def specialSerializer(nodeHash: NodeHash): Array[Byte] = {
     (specialNameSpace +: nodeHash).toArray

--- a/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/NodeStorage.scala
@@ -21,7 +21,7 @@ class NodeStorage(val dataSource: DataSource) extends KeyValueStorage[NodeHash, 
 
   val namespace: IndexedSeq[Byte] = Namespaces.NodeNamespace
   private val specialNameSpace = namespace.head
-  def keySerializer: NodeHash => IndexedSeq[Byte] = _.toIndexedSeq
+  def keySerializer: NodeHash => Array[Byte] = _.toArray[Byte]
   def valueSerializer: NodeEncoded => IndexedSeq[Byte] = _.toIndexedSeq
   def valueDeserializer: IndexedSeq[Byte] => NodeEncoded = _.toArray
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReceiptStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReceiptStorage.scala
@@ -15,9 +15,9 @@ class ReceiptStorage(val dataSource: DataSource) extends KeyValueStorage[BlockHa
 
   val namespace: IndexedSeq[Byte] = Namespaces.ReceiptsNamespace
   def keySerializer: BlockHash => Array[Byte] = _.toArray[Byte]
-  def valueSerializer: Seq[Receipt] => IndexedSeq[Byte] = (receipts: Seq[Receipt]) => receipts.toBytes
-  def valueDeserializer: IndexedSeq[Byte] => Seq[Receipt] =
-    (encodedReceipts: IndexedSeq[Byte]) => encodedReceipts.toArray[Byte].toReceipts
+  def valueSerializer: Seq[Receipt] => Array[Byte] = (receipts: Seq[Receipt]) => receipts.toBytes
+  def valueDeserializer: Array[Byte] => Seq[Receipt] =
+    (encodedReceipts: Array[Byte]) => encodedReceipts.toReceipts
 
   protected def apply(dataSource: DataSource): ReceiptStorage = new ReceiptStorage(dataSource)
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/ReceiptStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/ReceiptStorage.scala
@@ -14,7 +14,7 @@ class ReceiptStorage(val dataSource: DataSource) extends KeyValueStorage[BlockHa
   import io.iohk.ethereum.network.p2p.messages.PV63.ReceiptImplicits._
 
   val namespace: IndexedSeq[Byte] = Namespaces.ReceiptsNamespace
-  def keySerializer: BlockHash => IndexedSeq[Byte] = identity
+  def keySerializer: BlockHash => Array[Byte] = _.toArray[Byte]
   def valueSerializer: Seq[Receipt] => IndexedSeq[Byte] = (receipts: Seq[Receipt]) => receipts.toBytes
   def valueDeserializer: IndexedSeq[Byte] => Seq[Receipt] =
     (encodedReceipts: IndexedSeq[Byte]) => encodedReceipts.toArray[Byte].toReceipts

--- a/src/main/scala/io/iohk/ethereum/db/storage/TotalDifficultyStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/TotalDifficultyStorage.scala
@@ -12,8 +12,8 @@ import io.iohk.ethereum.db.storage.TotalDifficultyStorage._
 class TotalDifficultyStorage(val dataSource: DataSource) extends KeyValueStorage[BlockHash, TotalDifficulty, TotalDifficultyStorage]{
   val namespace: IndexedSeq[Byte] = Namespaces.TotalDifficultyNamespace
   def keySerializer: BlockHash => Array[Byte] = _.toArray[Byte]
-  def valueSerializer: TotalDifficulty => IndexedSeq[Byte] = _.toByteArray.toIndexedSeq
-  def valueDeserializer: IndexedSeq[Byte] => BigInt = (valueBytes: IndexedSeq[Byte]) => BigInt(1, valueBytes.toArray)
+  def valueSerializer: TotalDifficulty => Array[Byte] = _.toByteArray
+  def valueDeserializer: Array[Byte] => BigInt = (valueBytes: Array[Byte]) => BigInt(1, valueBytes)
 
   protected def apply(dataSource: DataSource): TotalDifficultyStorage = new TotalDifficultyStorage(dataSource)
 }

--- a/src/main/scala/io/iohk/ethereum/db/storage/TotalDifficultyStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/TotalDifficultyStorage.scala
@@ -11,7 +11,7 @@ import io.iohk.ethereum.db.storage.TotalDifficultyStorage._
   */
 class TotalDifficultyStorage(val dataSource: DataSource) extends KeyValueStorage[BlockHash, TotalDifficulty, TotalDifficultyStorage]{
   val namespace: IndexedSeq[Byte] = Namespaces.TotalDifficultyNamespace
-  def keySerializer: BlockHash => IndexedSeq[Byte] = _.toIndexedSeq
+  def keySerializer: BlockHash => Array[Byte] = _.toArray[Byte]
   def valueSerializer: TotalDifficulty => IndexedSeq[Byte] = _.toByteArray.toIndexedSeq
   def valueDeserializer: IndexedSeq[Byte] => BigInt = (valueBytes: IndexedSeq[Byte]) => BigInt(1, valueBytes.toArray)
 

--- a/src/main/scala/io/iohk/ethereum/db/storage/TransactionMappingStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/TransactionMappingStorage.scala
@@ -11,7 +11,7 @@ import boopickle.Default._
 class TransactionMappingStorage(val dataSource: DataSource) extends KeyValueStorage[TxHash, TransactionLocation, TransactionMappingStorage] {
 
   val namespace: IndexedSeq[Byte] = Namespaces.TransactionMappingNamespace
-  def keySerializer: TxHash => IndexedSeq[Byte] = identity
+  def keySerializer: TxHash => Array[Byte] = _.toArray[Byte]
   def valueSerializer: TransactionLocation => IndexedSeq[Byte] = tl => compactPickledBytes(Pickle.intoBytes(tl))
   def valueDeserializer: IndexedSeq[Byte] => TransactionLocation =
     bytes => Unpickle[TransactionLocation].fromBytes(ByteBuffer.wrap(bytes.toArray[Byte]))

--- a/src/main/scala/io/iohk/ethereum/db/storage/TransactionMappingStorage.scala
+++ b/src/main/scala/io/iohk/ethereum/db/storage/TransactionMappingStorage.scala
@@ -12,9 +12,9 @@ class TransactionMappingStorage(val dataSource: DataSource) extends KeyValueStor
 
   val namespace: IndexedSeq[Byte] = Namespaces.TransactionMappingNamespace
   def keySerializer: TxHash => Array[Byte] = _.toArray[Byte]
-  def valueSerializer: TransactionLocation => IndexedSeq[Byte] = tl => compactPickledBytes(Pickle.intoBytes(tl))
-  def valueDeserializer: IndexedSeq[Byte] => TransactionLocation =
-    bytes => Unpickle[TransactionLocation].fromBytes(ByteBuffer.wrap(bytes.toArray[Byte]))
+  def valueSerializer: TransactionLocation => Array[Byte] = tl => compactPickledBytes(Pickle.intoBytes(tl)).toArray[Byte]
+  def valueDeserializer: Array[Byte] => TransactionLocation =
+    bytes => Unpickle[TransactionLocation].fromBytes(ByteBuffer.wrap(bytes))
 
   implicit val byteStringPickler: Pickler[ByteString] = transformPickler[ByteString, Array[Byte]](ByteString(_))(_.toArray[Byte])
 

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -38,6 +38,8 @@ trait ObjectGenerators {
 
   def seqByteStringOfNItemsGen(n: Int): Gen[Seq[ByteString]] = Gen.listOf(byteStringOfLengthNGen(n))
 
+  def seqByteArrayOfNItemsGen(n: Int): Gen[Seq[Array[Byte]]] = Gen.listOf(byteArrayOfNItemsGen(n))
+
   def hexPrefixDecodeParametersGen(): Gen[(Array[Byte], Boolean)] = {
     for {
       aByteList <- Gen.nonEmptyListOf(Arbitrary.arbitrary[Byte])

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
@@ -93,13 +93,13 @@ trait DataSourceTestBehavior
         dataSource.update(OtherNamespace, Seq(), Seq(someByteArray -> someValue1))
         dataSource.update(OtherNamespace2, Seq(), Seq(someByteArray -> someValue2))
 
-        assert(dataSource.get(OtherNamespace, someByteArray).contains(someValue1))
-        assert(dataSource.get(OtherNamespace2, someByteArray).contains(someValue2))
+        assert(dataSource.get(OtherNamespace, someByteArray).forall(_ sameElements someValue1))
+        assert(dataSource.get(OtherNamespace2, someByteArray).forall(_ sameElements someValue2))
 
         //Removal
         dataSource.update(OtherNamespace2, Seq(someByteArray), Nil)
 
-        assert(dataSource.get(OtherNamespace, someByteArray).contains(someValue1))
+        assert(dataSource.get(OtherNamespace, someByteArray).forall(_ sameElements someValue1))
         assert(dataSource.get(OtherNamespace2, someByteArray).isEmpty)
 
         dataSource.destroy()

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/DataSourceTestBehavior.scala
@@ -29,14 +29,13 @@ trait DataSourceTestBehavior
   // scalastyle:off
   def dataSource(createDataSource: => String => DataSource): Unit = {
     it should "be able to insert and retrieve stored keys" in {
-      val key = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
-      val value = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
+      val array = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
       withDir { path =>
         val dataSource = createDataSource(path)
-        dataSource.update(OtherNamespace, Seq(), Seq(key -> value))
+        dataSource.update(OtherNamespace, Seq(), Seq(array -> array))
 
-        dataSource.get(OtherNamespace, key) match {
-          case Some(b) if b == value => succeed
+        dataSource.get(OtherNamespace, array) match {
+          case Some(b) if b sameElements array => succeed
           case _ => fail
         }
 
@@ -45,35 +44,32 @@ trait DataSourceTestBehavior
     }
 
     it should "allow to remove keys" in {
-      val key1 = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
-      val key2 = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
-      val value1 = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
-      val value2 = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
+      val array1 = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
+      val array2 = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
       withDir { path =>
         val dataSource = createDataSource(path)
 
-        dataSource.update(OtherNamespace, Seq(), Seq(key1 -> value1, key2 -> value2))
+        dataSource.update(OtherNamespace, Seq(), Seq(array1 -> array1, array2 -> array2))
 
-        assert(dataSource.get(OtherNamespace, key1).isDefined)
-        assert(dataSource.get(OtherNamespace, key2).isDefined)
+        assert(dataSource.get(OtherNamespace, array1).isDefined)
+        assert(dataSource.get(OtherNamespace, array2).isDefined)
 
-        dataSource.update(OtherNamespace, Seq(key1), Seq())
+        dataSource.update(OtherNamespace, Seq(array1), Seq())
 
-        assert(dataSource.get(OtherNamespace, key1).isEmpty)
-        assert(dataSource.get(OtherNamespace, key2).isDefined)
+        assert(dataSource.get(OtherNamespace, array1).isEmpty)
+        assert(dataSource.get(OtherNamespace, array2).isDefined)
 
         dataSource.destroy()
       }
     }
 
     it should "remove all keys after clear" in {
-      val someByteString = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
       val someByteArray = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
 
       withDir { path =>
         val dataSource = createDataSource(path)
 
-        dataSource.update(OtherNamespace, Seq(), Seq(someByteArray -> someByteString))
+        dataSource.update(OtherNamespace, Seq(), Seq(someByteArray -> someByteArray))
 
         assert(dataSource.get(OtherNamespace, someByteArray).isDefined)
 
@@ -88,9 +84,8 @@ trait DataSourceTestBehavior
     it should "allow using multiple namespaces with the same key" in {
       val OtherNamespace2: IndexedSeq[Byte] = IndexedSeq[Byte]('h'.toByte)
       val someByteArray = byteArrayOfNItemsGen(KeySizeWithoutPrefix).sample.get
-      val someByteString = byteStringOfLengthNGen(KeySizeWithoutPrefix).sample.get
-      val someValue1 = 1.toByte +: someByteString
-      val someValue2 = 2.toByte +: someByteString
+      val someValue1 = 1.toByte +: someByteArray
+      val someValue2 = 2.toByte +: someByteArray
       withDir { path =>
         val dataSource = createDataSource(path)
 
@@ -112,6 +107,5 @@ trait DataSourceTestBehavior
     }
   }
   // scalastyle:on
-
 
 }

--- a/src/test/scala/io/iohk/ethereum/db/dataSource/EphemDataSourceSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/db/dataSource/EphemDataSourceSuite.scala
@@ -1,6 +1,5 @@
 package io.iohk.ethereum.db.dataSource
 
-import akka.util.ByteString
 import io.iohk.ethereum.ObjectGenerators
 import org.scalacheck.Gen
 import org.scalatest.FunSuite
@@ -13,56 +12,52 @@ class EphemDataSourceSuite extends FunSuite
   val KeySize: Int = 32
   val KeyNumberLimit: Int = 40
   val OtherNamespace: IndexedSeq[Byte] = IndexedSeq[Byte]('e'.toByte)
-  def putMultiple(dataSource: DataSource, toInsert: Seq[(ByteString, ByteString)]): DataSource = {
+  def putMultiple(dataSource: DataSource, toInsert: Seq[(Array[Byte], Array[Byte])]): DataSource = {
     toInsert.foldLeft(dataSource){ case (recDB, (key, value)) =>
-      val actualKey = key.toArray[Byte]
-      recDB.update(OtherNamespace, Seq(), Seq((actualKey, value)))
+      recDB.update(OtherNamespace, Seq(), Seq((key, value)))
     }
   }
 
-  def removeMultiple(dataSource: DataSource, toDelete: Seq[ByteString]): DataSource = {
+  def removeMultiple(dataSource: DataSource, toDelete: Seq[Array[Byte]]): DataSource = {
     toDelete.foldLeft(dataSource){ case (recDB, key) =>
-      recDB.update(OtherNamespace, Seq(key.toArray[Byte]), Seq())
+      recDB.update(OtherNamespace, Seq(key), Seq())
     }
   }
 
   test("EphemDataSource insert"){
-    forAll(seqByteStringOfNItemsGen(KeySize)) { unFilteredKeyList: Seq[ByteString] =>
+    forAll(seqByteArrayOfNItemsGen(KeySize)) { unFilteredKeyList =>
       val keyList = unFilteredKeyList.filter(_.length == KeySize)
       val db = putMultiple(dataSource = EphemDataSource(), toInsert = keyList.zip(keyList))
       keyList.foreach { key =>
-        val actualKey = key.toArray[Byte]
-        val obtained = db.get(OtherNamespace, actualKey)
+        val obtained = db.get(OtherNamespace, key)
         assert(obtained.isDefined)
-        assert(obtained.get == key)
+        assert(obtained.get sameElements key)
       }
     }
   }
 
   test("EphemDataSource delete"){
-    forAll(seqByteStringOfNItemsGen(KeySize)) { keyList: Seq[ByteString] =>
+    forAll(seqByteArrayOfNItemsGen(KeySize)) { keyList =>
       val (keysToDelete, keyValueLeft) = keyList.splitAt(Gen.choose(0, keyList.size).sample.get)
 
       val dbAfterInsert = putMultiple(dataSource = EphemDataSource(), toInsert = keyList.zip(keyList))
       val db = removeMultiple(dataSource = dbAfterInsert, toDelete = keysToDelete)
       keyValueLeft.foreach { key =>
-        val actualKey = key.toArray[Byte]
-        val obtained = db.get(OtherNamespace, actualKey)
+        val obtained = db.get(OtherNamespace, key)
         assert(obtained.isDefined)
-        assert(obtained.get == key)
+        assert(obtained.get sameElements key)
       }
-      keysToDelete.foreach { key => assert(db.get(OtherNamespace, key.toArray[Byte]).isEmpty) }
+      keysToDelete.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
     }
   }
 
   test("EphemDataSource clear") {
-    forAll(seqByteStringOfNItemsGen(KeySize)) { keyList: Seq[ByteString] =>
-      val keys = keyList.map(k => k.toArray[Byte])
+    forAll(seqByteArrayOfNItemsGen(KeySize)) { keyList =>
       val db = EphemDataSource()
-        .update(OtherNamespace, toRemove = Seq(), toUpsert = keys.zip(keyList))
+        .update(OtherNamespace, toRemove = Seq(), toUpsert = keyList.zip(keyList))
         .clear
 
-      keys.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
+      keyList.foreach { key => assert(db.get(OtherNamespace, key).isEmpty) }
     }
   }
 }

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -21,9 +21,10 @@ class MerklePatriciaTrieSuite extends FunSuite
 
   val EmptyEphemNodeStorage: NodesKeyValueStorage = new ArchiveNodeStorage(new NodeStorage(EphemDataSource()))
 
-  val EmptyTrie = MerklePatriciaTrie[Array[Byte], Array[Byte]](EmptyEphemNodeStorage)
+  val EmptyTrie: MerklePatriciaTrie[Array[Byte], Array[Byte]] =
+    MerklePatriciaTrie[Array[Byte], Array[Byte]](EmptyEphemNodeStorage)
 
-  implicit val intByteArraySerializable = new ByteArraySerializable[Int] {
+  implicit val intByteArraySerializable: ByteArraySerializable[Int] = new ByteArraySerializable[Int] {
     override def toBytes(input: Int): Array[Byte] = {
       val b: ByteBuffer = ByteBuffer.allocate(4)
       b.putInt(input)
@@ -97,7 +98,7 @@ class MerklePatriciaTrieSuite extends FunSuite
       }
       val (keyValueToDelete, keyValueLeft) = keyValueList.splitAt(Gen.choose(0, keyValueList.size).sample.get)
       val trieAfterDelete = keyValueToDelete.foldLeft(trieAfterInsert) {
-        case (recTrie, (key, value)) => recTrie.remove(key)
+        case (recTrie, (key, _)) => recTrie.remove(key)
       }
 
       keyValueLeft.foreach { case (key, value) =>
@@ -105,7 +106,7 @@ class MerklePatriciaTrieSuite extends FunSuite
         assert(obtained.isDefined)
         assert(obtained.get == value)
       }
-      keyValueToDelete.foreach { case (key, value) =>
+      keyValueToDelete.foreach { case (key, _) =>
         val obtained = trieAfterDelete.get(key)
         assert(obtained.isEmpty)
       }
@@ -340,7 +341,7 @@ class MerklePatriciaTrieSuite extends FunSuite
     val wrongSource = EphemDataSource().update(
       IndexedSeq[Byte]('e'.toByte),
       toRemove = Seq(),
-      toUpsert = Seq(trie.getRootHash -> ByteString(trie.nodeStorage.get(ByteString(trie.getRootHash)).get))
+      toUpsert = Seq(trie.getRootHash -> trie.nodeStorage.get(ByteString(trie.getRootHash)).get)
     )
     val trieAfterDelete = Try {
       val trieWithWrongSource = MerklePatriciaTrie[Array[Byte], Array[Byte]](trie.getRootHash, new ArchiveNodeStorage(new NodeStorage(wrongSource)))

--- a/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
+++ b/src/test/scala/io/iohk/ethereum/mpt/MerklePatriciaTrieSuite.scala
@@ -340,7 +340,7 @@ class MerklePatriciaTrieSuite extends FunSuite
     val wrongSource = EphemDataSource().update(
       IndexedSeq[Byte]('e'.toByte),
       toRemove = Seq(),
-      toUpsert = Seq(ByteString(trie.getRootHash) -> ByteString(trie.nodeStorage.get(ByteString(trie.getRootHash)).get))
+      toUpsert = Seq(trie.getRootHash -> ByteString(trie.nodeStorage.get(ByteString(trie.getRootHash)).get))
     )
     val trieAfterDelete = Try {
       val trieWithWrongSource = MerklePatriciaTrie[Array[Byte], Array[Byte]](trie.getRootHash, new ArchiveNodeStorage(new NodeStorage(wrongSource)))


### PR DESCRIPTION
I've done performance tests:
10 times per 10 mins and I've got average for such conditions:

baseline: 127221.1 blocks/10mins
this branch: 128925.7 blocks/10mins
which gives ~1% speed up