### PR TITLE
Add new field sealEngine in BlockchainScenario to handle small change…

### DIFF
--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainSuite.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainSuite.scala
@@ -83,6 +83,7 @@ class BlockchainSuite extends FreeSpec with Matchers with BeforeAndAfterAll with
 
     val invalidBlocks = getBlocks(getInvalid)
 
+    // scalastyle:off regex
     blocksToProcess.foreach { b =>
       try {
         val r = ledger.importBlock(b)
@@ -90,19 +91,19 @@ class BlockchainSuite extends FreeSpec with Matchers with BeforeAndAfterAll with
       } catch {
         case ex: Throwable =>
           ex.printStackTrace()
-          println(s"WHAT A TERRIBLE FAILURE")
+          println("WHAT A TERRIBLE FAILURE")
           sys.exit(1)
       }
     }
 
-    val lastBlock = getBestBlock()
+    val lastBlock = getBestBlock
 
     val expectedWorldStateHash = finalWorld.stateRootHash
 
     lastBlock shouldBe defined
 
-    val expectedState = getExpectedState()
-    val resultState = getResultState()
+    val expectedState = getExpectedState
+    val resultState = getResultState
 
     lastBlock.get.header.hash shouldEqual scenario.lastblockhash
     resultState should contain theSameElementsAs expectedState

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
@@ -236,14 +236,14 @@ object Eip158ToByzantiumAt5Config extends BlockchainTestConfig {
 }
 
 object Validators {
-  val frontierValidators = EthashValidators(FrontierConfig)
-  val homesteadValidators = EthashValidators(HomesteadConfig)
-  val eip150Validators = EthashValidators(Eip150Config)
-  val frontierToHomesteadValidators = EthashValidators(FrontierToHomesteadAt5)
-  val homesteadToEipValidators = EthashValidators(HomesteadToEIP150At5)
-  val homesteadToDaoValidators = EthashValidators(HomesteadToDaoAt5)
-  val eip158Validators = EthashValidators(Eip158Config)
-  val byzantiumValidators = EthashValidators(ByzantiumConfig)
-  val constantinopleValidators = EthashValidators(ConstantinopleConfig)
-  val eip158ToByzantiumValidators = EthashValidators(Eip158ToByzantiumAt5Config)
+  def frontierValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(FrontierConfig, shouldSkipPoW)
+  def homesteadValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(HomesteadConfig, shouldSkipPoW)
+  def eip150Validators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(Eip150Config, shouldSkipPoW)
+  def frontierToHomesteadValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(FrontierToHomesteadAt5, shouldSkipPoW)
+  def homesteadToEipValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(HomesteadToEIP150At5, shouldSkipPoW)
+  def homesteadToDaoValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(HomesteadToDaoAt5, shouldSkipPoW)
+  def eip158Validators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(Eip158Config, shouldSkipPoW)
+  def byzantiumValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(ByzantiumConfig, shouldSkipPoW)
+  def constantinopleValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(ConstantinopleConfig, shouldSkipPoW)
+  def eip158ToByzantiumValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(Eip158ToByzantiumAt5Config, shouldSkipPoW)
 }

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
@@ -235,15 +235,32 @@ object Eip158ToByzantiumAt5Config extends BlockchainTestConfig {
     MonetaryPolicyConfig(5000000, 0.2, BigInt("5000000000000000000"), BigInt("3000000000000000000"))
 }
 
-case class Validators(shouldSkipPoW: Boolean) {
-  val frontierValidators = EthashValidators(FrontierConfig, shouldSkipPoW)
-  val homesteadValidators = EthashValidators(HomesteadConfig, shouldSkipPoW)
-  val eip150Validators = EthashValidators(Eip150Config, shouldSkipPoW)
-  val frontierToHomesteadValidators = EthashValidators(FrontierToHomesteadAt5, shouldSkipPoW)
-  val homesteadToEipValidators = EthashValidators(HomesteadToEIP150At5, shouldSkipPoW)
-  val homesteadToDaoValidators = EthashValidators(HomesteadToDaoAt5, shouldSkipPoW)
-  val eip158Validators = EthashValidators(Eip158Config, shouldSkipPoW)
-  val byzantiumValidators = EthashValidators(ByzantiumConfig, shouldSkipPoW)
-  val constantinopleValidators = EthashValidators(ConstantinopleConfig, shouldSkipPoW)
-  val eip158ToByzantiumValidators = EthashValidators(Eip158ToByzantiumAt5Config, shouldSkipPoW)
+object Validators {
+
+  val frontierValidators = EthashValidators(FrontierConfig)
+  val homesteadValidators = EthashValidators(HomesteadConfig)
+  val eip150Validators = EthashValidators(Eip150Config)
+  val frontierToHomesteadValidators = EthashValidators(FrontierToHomesteadAt5)
+  val homesteadToEipValidators = EthashValidators(HomesteadToEIP150At5)
+  val homesteadToDaoValidators= EthashValidators(HomesteadToDaoAt5)
+  val eip158Validators = EthashValidators(Eip158Config)
+  val byzantiumValidators = EthashValidators(ByzantiumConfig)
+  val constantinopleValidators = EthashValidators(ConstantinopleConfig)
+  val eip158ToByzantiumValidators = EthashValidators(Eip158ToByzantiumAt5Config)
+}
+
+// Connected with: https://github.com/ethereum/tests/issues/480
+object ValidatorsWithSkippedPoW {
+
+  val frontierValidators =  EthashValidators(FrontierConfig, new EthashTestBlockHeaderValidator(FrontierConfig))
+  val homesteadValidators = EthashValidators(HomesteadConfig, new EthashTestBlockHeaderValidator(HomesteadConfig))
+  val eip150Validators = EthashValidators(Eip150Config, new EthashTestBlockHeaderValidator(Eip150Config))
+  val frontierToHomesteadValidators = EthashValidators(FrontierToHomesteadAt5, new EthashTestBlockHeaderValidator(FrontierToHomesteadAt5))
+  val homesteadToEipValidators = EthashValidators(HomesteadToEIP150At5, new EthashTestBlockHeaderValidator(HomesteadToEIP150At5))
+  val homesteadToDaoValidators= EthashValidators(HomesteadToDaoAt5, new EthashTestBlockHeaderValidator(HomesteadToDaoAt5))
+  val eip158Validators = EthashValidators(Eip158Config, new EthashTestBlockHeaderValidator(Eip158Config))
+  val byzantiumValidators = EthashValidators(ByzantiumConfig, new EthashTestBlockHeaderValidator(ByzantiumConfig))
+  val constantinopleValidators = EthashValidators(ConstantinopleConfig, new EthashTestBlockHeaderValidator(ConstantinopleConfig))
+  val eip158ToByzantiumValidators = EthashValidators(Eip158ToByzantiumAt5Config, new EthashTestBlockHeaderValidator(Eip158ToByzantiumAt5Config))
+
 }

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
@@ -235,15 +235,15 @@ object Eip158ToByzantiumAt5Config extends BlockchainTestConfig {
     MonetaryPolicyConfig(5000000, 0.2, BigInt("5000000000000000000"), BigInt("3000000000000000000"))
 }
 
-object Validators {
-  def frontierValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(FrontierConfig, shouldSkipPoW)
-  def homesteadValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(HomesteadConfig, shouldSkipPoW)
-  def eip150Validators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(Eip150Config, shouldSkipPoW)
-  def frontierToHomesteadValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(FrontierToHomesteadAt5, shouldSkipPoW)
-  def homesteadToEipValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(HomesteadToEIP150At5, shouldSkipPoW)
-  def homesteadToDaoValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(HomesteadToDaoAt5, shouldSkipPoW)
-  def eip158Validators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(Eip158Config, shouldSkipPoW)
-  def byzantiumValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(ByzantiumConfig, shouldSkipPoW)
-  def constantinopleValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(ConstantinopleConfig, shouldSkipPoW)
-  def eip158ToByzantiumValidators(shouldSkipPoW: Boolean): EthashValidators = EthashValidators(Eip158ToByzantiumAt5Config, shouldSkipPoW)
+case class Validators(shouldSkipPoW: Boolean) {
+  val frontierValidators = EthashValidators(FrontierConfig, shouldSkipPoW)
+  val homesteadValidators = EthashValidators(HomesteadConfig, shouldSkipPoW)
+  val eip150Validators = EthashValidators(Eip150Config, shouldSkipPoW)
+  val frontierToHomesteadValidators = EthashValidators(FrontierToHomesteadAt5, shouldSkipPoW)
+  val homesteadToEipValidators = EthashValidators(HomesteadToEIP150At5, shouldSkipPoW)
+  val homesteadToDaoValidators = EthashValidators(HomesteadToDaoAt5, shouldSkipPoW)
+  val eip158Validators = EthashValidators(Eip158Config, shouldSkipPoW)
+  val byzantiumValidators = EthashValidators(ByzantiumConfig, shouldSkipPoW)
+  val constantinopleValidators = EthashValidators(ConstantinopleConfig, shouldSkipPoW)
+  val eip158ToByzantiumValidators = EthashValidators(Eip158ToByzantiumAt5Config, shouldSkipPoW)
 }

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/EthashTestBlockHeaderValidator.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/EthashTestBlockHeaderValidator.scala
@@ -1,0 +1,22 @@
+package io.iohk.ethereum.ets.blockchain
+
+import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
+import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
+import io.iohk.ethereum.consensus.ethash.validators.EthashBlockHeaderValidator
+import io.iohk.ethereum.consensus.validators.{ BlockHeaderError, BlockHeaderValid, BlockHeaderValidatorSkeleton }
+import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.utils.BlockchainConfig
+
+class EthashTestBlockHeaderValidator(blockchainConfig: BlockchainConfig) extends BlockHeaderValidatorSkeleton(blockchainConfig) {
+  import EthashBlockHeaderValidator._
+
+  // NOTE the below comment is from before PoW decoupling
+  // we need concurrent map since validators can be used from multiple places
+  protected val powCaches: java.util.concurrent.ConcurrentMap[Long, PowCacheData] = new java.util.concurrent.ConcurrentHashMap[Long, PowCacheData]()
+
+  protected def difficulty: DifficultyCalculator = new EthashDifficultyCalculator(blockchainConfig)
+
+  def validateEvenMore(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] =
+    Right(BlockHeaderValid)
+
+}

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -41,7 +41,7 @@ object ScenarioSetup {
 abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
 
   // according to: https://github.com/ethereum/tests/issues/480 only "NoProof" value should change our current implementation
-  val shouldSkipPoW: Boolean = scenario.sealEngine.contains("NoProof")
+  def shouldSkipPoW: Boolean = scenario.sealEngine.contains("NoProof")
 
   val (blockchainConfig, validators) = buildBlockchainConfig(scenario.network, shouldSkipPoW)
 
@@ -91,19 +91,38 @@ abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
     scenario.postState.map(addAcc => addAcc._1 -> blockchain.getAccount(addAcc._1, bestBlockNumber)).toList
   }
 
-  private def buildBlockchainConfig(network: String, shouldSkipPoW: Boolean): (BlockchainConfig, EthashValidators) = network match {
-    case "EIP150" => (Eip150Config, Validators(shouldSkipPoW).eip150Validators)
-    case "Frontier" => (FrontierConfig, Validators(shouldSkipPoW).frontierValidators)
-    case "Homestead" => (HomesteadConfig, Validators(shouldSkipPoW).homesteadValidators)
-    case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, Validators(shouldSkipPoW).frontierToHomesteadValidators)
-    case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, Validators(shouldSkipPoW).homesteadToEipValidators)
-    case "EIP158" => (Eip158Config, Validators(shouldSkipPoW).eip158Validators)
-    case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, Validators(shouldSkipPoW).homesteadToDaoValidators)
-    case "Byzantium" => (ByzantiumConfig, Validators(shouldSkipPoW).byzantiumValidators)
-    case "Constantinople" => (ConstantinopleConfig, Validators(shouldSkipPoW).constantinopleValidators)
-    case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, Validators(shouldSkipPoW).eip158ToByzantiumValidators)
+  private def buildBlockchainConfig(network: String, shouldSkipPoW: Boolean): (BlockchainConfig, EthashValidators) = {
+    if (shouldSkipPoW) withSkippedPoWValidationBlockchainConfig(network) else baseBlockchainConfig(network)
+  }
+
+  private def baseBlockchainConfig(network: String): (BlockchainTestConfig, EthashValidators) = network match {
+    case "EIP150" => (Eip150Config, Validators.eip150Validators)
+    case "Frontier" => (FrontierConfig, Validators.frontierValidators)
+    case "Homestead" => (HomesteadConfig, Validators.homesteadValidators)
+    case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, Validators.frontierToHomesteadValidators)
+    case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, Validators.homesteadToEipValidators)
+    case "EIP158" => (Eip158Config, Validators.eip158Validators)
+    case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, Validators.homesteadToDaoValidators)
+    case "Byzantium" => (ByzantiumConfig, Validators.byzantiumValidators)
+    case "Constantinople" => (ConstantinopleConfig, Validators.constantinopleValidators)
+    case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, Validators.eip158ToByzantiumValidators)
     // Some default config, test will fail or be canceled
-    case _ => (FrontierConfig, Validators(shouldSkipPoW).frontierValidators)
+    case _ => (FrontierConfig, Validators.frontierValidators)
+  }
+
+  private def withSkippedPoWValidationBlockchainConfig(network: String): (BlockchainTestConfig, EthashValidators) = network match {
+    case "EIP150" => (Eip150Config, ValidatorsWithSkippedPoW.eip150Validators)
+    case "Frontier" => (FrontierConfig, ValidatorsWithSkippedPoW.frontierValidators)
+    case "Homestead" => (HomesteadConfig, ValidatorsWithSkippedPoW.homesteadValidators)
+    case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, ValidatorsWithSkippedPoW.frontierToHomesteadValidators)
+    case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, ValidatorsWithSkippedPoW.homesteadToEipValidators)
+    case "EIP158" => (Eip158Config, ValidatorsWithSkippedPoW.eip158Validators)
+    case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, ValidatorsWithSkippedPoW.homesteadToDaoValidators)
+    case "Byzantium" => (ByzantiumConfig, ValidatorsWithSkippedPoW.byzantiumValidators)
+    case "Constantinople" => (ConstantinopleConfig, ValidatorsWithSkippedPoW.constantinopleValidators)
+    case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, ValidatorsWithSkippedPoW.eip158ToByzantiumValidators)
+    // Some default config, test will fail or be canceled
+    case _ => (FrontierConfig, ValidatorsWithSkippedPoW.frontierValidators)
   }
 
   private def decode(s: String): Array[Byte] = {

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -41,10 +41,7 @@ object ScenarioSetup {
 abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
 
   // according to: https://github.com/ethereum/tests/issues/480 only "NoProof" value should change our current implementation
-  val shouldSkipPoW: Boolean = scenario.sealEngine match {
-    case Some(param) if param == "NoProof" => true
-    case _ => false
-  }
+  val shouldSkipPoW: Boolean = scenario.sealEngine.contains("NoProof")
 
   val (blockchainConfig, validators) = buildBlockchainConfig(scenario.network, shouldSkipPoW)
 
@@ -95,18 +92,18 @@ abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
   }
 
   private def buildBlockchainConfig(network: String, shouldSkipPoW: Boolean): (BlockchainConfig, EthashValidators) = network match {
-    case "EIP150" => (Eip150Config, Validators.eip150Validators(shouldSkipPoW))
-    case "Frontier" => (FrontierConfig, Validators.frontierValidators(shouldSkipPoW))
-    case "Homestead" => (HomesteadConfig, Validators.homesteadValidators(shouldSkipPoW))
-    case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, Validators.frontierToHomesteadValidators(shouldSkipPoW))
-    case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, Validators.homesteadToEipValidators(shouldSkipPoW))
-    case "EIP158" => (Eip158Config, Validators.eip158Validators(shouldSkipPoW))
-    case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, Validators.homesteadToDaoValidators(shouldSkipPoW))
-    case "Byzantium" => (ByzantiumConfig, Validators.byzantiumValidators(shouldSkipPoW))
-    case "Constantinople" => (ConstantinopleConfig, Validators.constantinopleValidators(shouldSkipPoW))
-    case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, Validators.eip158ToByzantiumValidators(shouldSkipPoW))
+    case "EIP150" => (Eip150Config, Validators(shouldSkipPoW).eip150Validators)
+    case "Frontier" => (FrontierConfig, Validators(shouldSkipPoW).frontierValidators)
+    case "Homestead" => (HomesteadConfig, Validators(shouldSkipPoW).homesteadValidators)
+    case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, Validators(shouldSkipPoW).frontierToHomesteadValidators)
+    case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, Validators(shouldSkipPoW).homesteadToEipValidators)
+    case "EIP158" => (Eip158Config, Validators(shouldSkipPoW).eip158Validators)
+    case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, Validators(shouldSkipPoW).homesteadToDaoValidators)
+    case "Byzantium" => (ByzantiumConfig, Validators(shouldSkipPoW).byzantiumValidators)
+    case "Constantinople" => (ConstantinopleConfig, Validators(shouldSkipPoW).constantinopleValidators)
+    case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, Validators(shouldSkipPoW).eip158ToByzantiumValidators)
     // Some default config, test will fail or be canceled
-    case _ => (FrontierConfig, Validators.frontierValidators(shouldSkipPoW))
+    case _ => (FrontierConfig, Validators(shouldSkipPoW).frontierValidators)
   }
 
   private def decode(s: String): Array[Byte] = {

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/scenario.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/scenario.scala
@@ -4,7 +4,6 @@ import akka.util.ByteString
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ets.common.AccountState
 
-
 case class BlockchainScenario(
    blocks: List[BlockDef],
    genesisBlockHeader: BlockHeaderDef,
@@ -12,9 +11,9 @@ case class BlockchainScenario(
    lastblockhash: ByteString,
    network: String,
    postState: Map[Address, AccountState],
-   pre: Map[Address, AccountState]
+   pre: Map[Address, AccountState],
+   sealEngine: Option[String]
 )
-
 
 case class BlockDef(
   rlp: String,
@@ -23,7 +22,6 @@ case class BlockDef(
   transactions: Option[Seq[TransactionDef]],
   uncleHeaders: Option[Seq[BlockHeaderDef]]
 )
-
 
 case class TransactionDef(
   nonce: BigInt,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
@@ -13,7 +13,7 @@ import io.iohk.ethereum.utils.BlockchainConfig
   *
   * @param blockchainConfig specific config
   * @param shouldSkipPoW    flag that applies if proof of work should be not validated in ETS tests due to additional
-  *                         `sealEngine` param in [[io.iohk.ethereum.ets.blockchain.BlockchainScenario]].
+  *                         `sealEngine` param in `BlockchainScenario`.
   *                         By default, set to false, so that `validateEvenMore` is omitted only where it should be,
   *                         otherwise, everything should be executed as before.
   */

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
@@ -9,18 +9,10 @@ import io.iohk.ethereum.crypto
 import io.iohk.ethereum.domain.BlockHeader
 import io.iohk.ethereum.utils.BlockchainConfig
 
-/** A block header validator for Ethash.
-  *
-  * @param blockchainConfig specific config
-  * @param shouldSkipPoW    flag that applies if proof of work should be not validated in ETS tests due to additional
-  *                         `sealEngine` param in `BlockchainScenario`.
-  *                         By default, set to false, so that `validateEvenMore` is omitted only where it should be,
-  *                         otherwise, everything should be executed as before.
-  */
-class EthashBlockHeaderValidator(
-  blockchainConfig: BlockchainConfig,
-  shouldSkipPoW: Boolean = false
-) extends BlockHeaderValidatorSkeleton(blockchainConfig) {
+/**
+ * A block header validator for Ethash.
+ */
+class EthashBlockHeaderValidator(blockchainConfig: BlockchainConfig) extends BlockHeaderValidatorSkeleton(blockchainConfig) {
   import EthashBlockHeaderValidator._
 
   // NOTE the below comment is from before PoW decoupling
@@ -30,14 +22,15 @@ class EthashBlockHeaderValidator(
   protected def difficulty: DifficultyCalculator = new EthashDifficultyCalculator(blockchainConfig)
 
   def validateEvenMore(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] =
-    if (shouldSkipPoW) Right(BlockHeaderValid) else validatePoW(blockHeader)
+    validatePoW(blockHeader)
 
-  /** Validates [[io.iohk.ethereum.domain.BlockHeader.nonce]] and [[io.iohk.ethereum.domain.BlockHeader.mixHash]] are correct
-    * based on validations stated in section 4.4.4 of http://paper.gavwood.com/
-    *
-    * @param blockHeader BlockHeader to validate.
-    * @return BlockHeader if valid, an [[io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderPoWError]] otherwise
-    */
+  /**
+   * Validates [[io.iohk.ethereum.domain.BlockHeader.nonce]] and [[io.iohk.ethereum.domain.BlockHeader.mixHash]] are correct
+   * based on validations stated in section 4.4.4 of http://paper.gavwood.com/
+   *
+   * @param blockHeader BlockHeader to validate.
+   * @return BlockHeader if valid, an [[io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderPoWError]] otherwise
+   */
   protected def validatePoW(blockHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] = {
     import EthashUtils._
 

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashValidators.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashValidators.scala
@@ -44,8 +44,8 @@ trait EthashValidators extends Validators {
 }
 
 object EthashValidators {
-  def apply(blockchainConfig: BlockchainConfig): EthashValidators = {
-    val blockHeaderValidator = new EthashBlockHeaderValidator(blockchainConfig)
+  def apply(blockchainConfig: BlockchainConfig, shouldSkipPoW: Boolean = false): EthashValidators = {
+    val blockHeaderValidator = new EthashBlockHeaderValidator(blockchainConfig, shouldSkipPoW)
 
     new StdEthashValidators(
       StdBlockValidator,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/StdEthashValidators.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/StdEthashValidators.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.consensus.ethash.validators
 
-import io.iohk.ethereum.consensus.validators.{BlockValidator, SignedTransactionValidator}
+import io.iohk.ethereum.consensus.validators.{ BlockHeaderValidator, BlockValidator, SignedTransactionValidator }
 
 /**
  * Implements validators that adhere to the PoW-specific
@@ -9,7 +9,7 @@ import io.iohk.ethereum.consensus.validators.{BlockValidator, SignedTransactionV
  */
 final class StdEthashValidators private[validators](
   val blockValidator: BlockValidator,
-  val blockHeaderValidator: EthashBlockHeaderValidator,
+  val blockHeaderValidator: BlockHeaderValidator,
   val signedTransactionValidator: SignedTransactionValidator,
   val ommersValidator: OmmersValidator
 ) extends EthashValidators


### PR DESCRIPTION
… in the ETS tests format

according to this [link](https://github.com/ethereum/tests/issues/480) we need to provide new field `sealEngine` that accepts two values (for now) `Ethash` and `NoProof` in our `BlockchainScenario`
I've run ETS tests with results as follows: 
- before: failed: 15780, passed: 525
- after: failed: 4903, passed: 11402