### PR TITLE
Add cacluclatin senders in background. Fix mem performance

### DIFF
--- a/src/main/scala/io/iohk/ethereum/vm/Memory.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Memory.scala
@@ -39,8 +39,33 @@ class Memory private(private val underlying: ByteString) {
     val newUnderlying: ByteString =
       if (data.isEmpty)
         underlying
-      else
-        underlying.take(idx).padTo(idx, 0.toByte) ++ data ++ underlying.drop(idx + data.length)
+      else {
+        val currentLength = underlying.length
+        val dataLength = data.length
+        val newMaxLength = idx + dataLength
+
+        val newLen = math.max(newMaxLength, currentLength)
+
+        // newLen is at least as long as current length
+        val newData = new Array[Byte](newLen)
+
+        var i = 0
+        while (i < currentLength) {
+          newData(i) = underlying(i)
+          i += 1
+        }
+
+        var u = 0
+        i = idx
+        while (i < newLen && u < dataLength) {
+          newData(i) = data(u)
+          i += 1
+          u += 1
+        }
+
+        // It is safe to call unsafe as newData array won't be modified.
+        ByteString.fromArrayUnsafe(newData)
+      }
 
     new Memory(newUnderlying)
   }

--- a/src/main/scala/io/iohk/ethereum/vm/Memory.scala
+++ b/src/main/scala/io/iohk/ethereum/vm/Memory.scala
@@ -57,7 +57,7 @@ class Memory private(private val underlying: ByteString) {
 
         var u = 0
         i = idx
-        while (i < newLen && u < dataLength) {
+        while (u < dataLength) {
           newData(i) = data(u)
           i += 1
           u += 1


### PR DESCRIPTION
1. Add caluclating senders in background - It was used earlier in regular sync so this is nothing new

2. Fix performance of store operation- 
As it seems `MSTORE` is one of most frequent used opcodes in eth, and our courrent implementation clogs on it when synchronising on top of the chain.
[https://ibb.co/jJ7wvLv](url) - almost 5/6 of vm time spent in store.
This pr introduces optimised implementation.
- Microbenchmarks (which i have written on the side and are not 100% reliable) shows 4x optimization with that implementation
- block processing speed as i am currently running eth increased from `50blocks / 5min` to `50blocks/2min`
- visual vm shows that now only 1/4 vm time is spent in `MSTORE`