### PR TITLE
Etcm 52 make sure mantis works on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ project/boot/
 project/plugins/project/
 .ensime
 .ensime_cache/
+.bloop
 
 # IDE folders
 .idea/
 .metals/
+metals.sbt
 .vscode/
 
 # intellij scala worksheet

--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,7 @@ scalacOptions in (Compile, console) ~= (_.filterNot(
     "-Xfatal-warnings"
   )
 ))
+Global / onChangedBuildSource := ReloadOnSourceChanges
 
 Test / parallelExecution := false
 

--- a/build.sbt
+++ b/build.sbt
@@ -87,8 +87,7 @@ val root = {
     .configs(Integration, Benchmark, Evm, Ets, Snappy, Rpc)
     .settings(commonSettings: _*)
     .settings(
-      libraryDependencies ++= dep,
-      executableScriptName := name.value
+      libraryDependencies ++= dep
     )
     .settings(inConfig(Integration)(Defaults.testSettings): _*)
     .settings(inConfig(Benchmark)(Defaults.testSettings): _*)
@@ -121,11 +120,8 @@ scalacOptions in (Compile, console) ~= (_.filterNot(
     "-Xfatal-warnings"
   )
 ))
-Global / onChangedBuildSource := ReloadOnSourceChanges
 
 Test / parallelExecution := false
-
-ThisBuild / turbo := true
 
 testOptions in Test += Tests.Argument("-oDG")
 
@@ -145,7 +141,8 @@ scalastyleSources in Test ++= { (unmanagedSourceDirectories in Integration).valu
 
 // Packaging
 mainClass in Compile := Some("io.iohk.ethereum.App")
-discoveredMainClasses in Compile := Seq("io.iohk.ethereum.mallet.main.Mallet")
+Universal / executableScriptName := name.value
+discoveredMainClasses in Compile := Seq()
 // Requires the 'ant-javafx.jar' that comes with Oracle JDK
 // Enables creating an executable with the configuration files, has to be run on the OS corresponding to the desired version
 ThisBuild / jdkPackagerType := "image"

--- a/build.sbt
+++ b/build.sbt
@@ -13,14 +13,11 @@ val commonSettings = Seq(
     .Argument(TestFrameworks.ScalaTest, "-l", "EthashMinerSpec") // miner tests disabled by default
 )
 
-// Resolver for rocksDb
-resolvers += "rocksDb" at "https://dl.bintray.com/ethereum/maven/"
-
 val dep = {
   val akkaVersion = "2.6.9"
   val akkaHttpVersion = "10.2.0"
   val circeVersion = "0.9.3"
-  val rocksDb = "5.9.2"
+  val rocksDb = "6.11.4"
 
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
@@ -32,7 +29,7 @@ val dep = {
     "org.json4s" %% "json4s-native" % "3.5.4",
     "de.heikoseeberger" %% "akka-http-json4s" % "1.34.0",
     "io.suzaku" %% "boopickle" % "1.3.0",
-    "org.ethereum" % "rocksdbjni" % rocksDb,
+    "org.rocksdb" % "rocksdbjni" % rocksDb,
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
     "io.circe" %% "circe-parser" % circeVersion,
@@ -85,19 +82,20 @@ val Snappy = config("snappy") extend Test
 val Rpc = config("rpcTest") extend Test
 
 val root = {
-  val root = project.in(file("."))
+  val root = project
+    .in(file("."))
     .configs(Integration, Benchmark, Evm, Ets, Snappy, Rpc)
     .settings(commonSettings: _*)
     .settings(
       libraryDependencies ++= dep,
       executableScriptName := name.value
     )
-    .settings(inConfig(Integration)(Defaults.testSettings) : _*)
-    .settings(inConfig(Benchmark)(Defaults.testSettings) : _*)
-    .settings(inConfig(Evm)(Defaults.testSettings) : _*)
-    .settings(inConfig(Ets)(Defaults.testSettings) : _*)
-    .settings(inConfig(Snappy)(Defaults.testSettings) : _*)
-    .settings(inConfig(Rpc)(Defaults.testSettings) : _*)
+    .settings(inConfig(Integration)(Defaults.testSettings): _*)
+    .settings(inConfig(Benchmark)(Defaults.testSettings): _*)
+    .settings(inConfig(Evm)(Defaults.testSettings): _*)
+    .settings(inConfig(Ets)(Defaults.testSettings): _*)
+    .settings(inConfig(Snappy)(Defaults.testSettings): _*)
+    .settings(inConfig(Rpc)(Defaults.testSettings): _*)
 
   if (!nixBuild)
     root
@@ -145,7 +143,6 @@ unmanagedResourceDirectories in Compile += baseDirectory.value / "src" / "main" 
 scalastyleSources in Test ++= { (unmanagedSourceDirectories in Integration).value }
 
 // Packaging
-enablePlugins(JavaAppPackaging)
 mainClass in Compile := Some("io.iohk.ethereum.App")
 discoveredMainClasses in Compile := Seq("io.iohk.ethereum.mallet.main.Mallet")
 // Requires the 'ant-javafx.jar' that comes with Oracle JDK
@@ -160,7 +157,6 @@ jdkPackagerJVMArgs := Seq(
   "-Dlogback.configurationFile=." + sep + "conf" + sep + "logback.xml",
   "-Xss10M"
 )
-
 
 coverageExcludedPackages := "io\\.iohk\\.ethereum\\.extvm\\.msg.*"
 

--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,9 @@ scalacOptions in (Compile, console) ~= (_.filterNot(
   )
 ))
 
-parallelExecution in Test := false
+Test / parallelExecution := false
+
+ThisBuild / turbo := true
 
 testOptions in Test += Tests.Argument("-oDG")
 
@@ -142,11 +144,13 @@ unmanagedResourceDirectories in Compile += baseDirectory.value / "src" / "main" 
 (scalastyleConfig in Test) := baseDirectory.value / "scalastyle-test-config.xml"
 scalastyleSources in Test ++= { (unmanagedSourceDirectories in Integration).value }
 
+// Packaging
+enablePlugins(JavaAppPackaging)
 mainClass in Compile := Some("io.iohk.ethereum.App")
-
+discoveredMainClasses in Compile := Seq("io.iohk.ethereum.mallet.main.Mallet")
 // Requires the 'ant-javafx.jar' that comes with Oracle JDK
 // Enables creating an executable with the configuration files, has to be run on the OS corresponding to the desired version
-jdkPackagerType := "image"
+ThisBuild / jdkPackagerType := "image"
 
 Universal / mappings += (resourceDirectory in Compile).value / "logback.xml" -> "conf/logback.xml"
 
@@ -156,6 +160,7 @@ jdkPackagerJVMArgs := Seq(
   "-Dlogback.configurationFile=." + sep + "conf" + sep + "logback.xml",
   "-Xss10M"
 )
+
 
 coverageExcludedPackages := "io\\.iohk\\.ethereum\\.extvm\\.msg.*"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import scala.sys.process.Process
 val nixBuild = sys.props.isDefinedAt("nix")
 
 val commonSettings = Seq(
-  name := "mantis-core",
+  name := "mantis",
   version := "3.0",
   scalaVersion := "2.12.12",
   testOptions in Test += Tests

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 logLevel := sbt.Level.Warn
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.21")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.5")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.1.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.25")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.2")

--- a/project/repo.nix
+++ b/project/repo.nix
@@ -157,6 +157,22 @@
       url = "https://repo1.maven.org/maven2/com/github/cb372/scalacache-core_2.12/0.20.0/scalacache-core_2.12-0.20.0.pom";
       sha256 = "D367AAFE69A333382A17065264A6067C474CBFC8D61F2A8971CD3098CAABFE65";
     };
+    "nix-public/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2-javadoc.jar";
+      sha256 = "69585EC8889F9D335892F20AFAD9D70DCDFB027285FD292BA42F46F4A80D750F";
+    };
+    "nix-public/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2-sources.jar";
+      sha256 = "BB242A115302FDD8A9DB37D702C470D7105CFB477E0DBBF35A0E607A5F581D61";
+    };
+    "nix-public/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2.jar" = {
+      url = "https://repo1.maven.org/maven2/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2.jar";
+      sha256 = "4301389ED6EFFB3D8363F0B479B90A9CB787D8E265EB12E74CDB69D1AFD601DD";
+    };
+    "nix-public/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2.pom" = {
+      url = "https://repo1.maven.org/maven2/com/github/eldis/tool-launcher/0.2.2/tool-launcher-0.2.2.pom";
+      sha256 = "C0791A83C22AD1B5D2ED09B90DD8F1C23165D1621CF4D7980C37E5831B9EBF46";
+    };
     "nix-public/com/github/os72/protoc-jar/3.7.1/protoc-jar-3.7.1-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/com/github/os72/protoc-jar/3.7.1/protoc-jar-3.7.1-javadoc.jar";
       sha256 = "ADD502CC22965B3A99D8D93209C8CA1E360753B4873D4AF3A5140C0D05540982";
@@ -637,33 +653,33 @@
       url = "https://repo1.maven.org/maven2/org/apache/apache/18/apache-18.pom";
       sha256 = "7831307285FD475BBC36B20AE38E7882F11C3153B1D5930F852D44EDA8F33C17";
     };
-    "nix-public/org/apache/apache/19/apache-19.pom" = {
-      url = "https://repo1.maven.org/maven2/org/apache/apache/19/apache-19.pom";
-      sha256 = "91F7A33096EA69BAC2CBAF6D01FEB934CAC002C48D8C8CFA9C240B40F1EC21DF";
+    "nix-public/org/apache/apache/21/apache-21.pom" = {
+      url = "https://repo1.maven.org/maven2/org/apache/apache/21/apache-21.pom";
+      sha256 = "AF10C108DA014F17CAFAC7B52B2B4B5A3A1C18265FA2AF97A325D9143537B380";
     };
-    "nix-public/org/apache/commons/commons-compress/1.18/commons-compress-1.18-javadoc.jar" = {
-      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.18/commons-compress-1.18-javadoc.jar";
-      sha256 = "23B382156431D6350745C571E533FABE28AEBE8DA1DE6E039E8E480BB9764DFC";
+    "nix-public/org/apache/commons/commons-compress/1.20/commons-compress-1.20-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20-javadoc.jar";
+      sha256 = "795F3D42E74EF4786045F59CAA8C015A31A165977BDCAE5F053CF103B276FC3D";
     };
-    "nix-public/org/apache/commons/commons-compress/1.18/commons-compress-1.18-sources.jar" = {
-      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.18/commons-compress-1.18-sources.jar";
-      sha256 = "C8E6896EB3D3880FFC21BB93D563B7CC0D3E2152C8181F261A748502290A5947";
+    "nix-public/org/apache/commons/commons-compress/1.20/commons-compress-1.20-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20-sources.jar";
+      sha256 = "0EB5D7F270C2FCCDAB31DAA5F7091B038AD0099B29885040604D66E07FD46A18";
     };
-    "nix-public/org/apache/commons/commons-compress/1.18/commons-compress-1.18-tests.jar" = {
-      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.18/commons-compress-1.18-tests.jar";
-      sha256 = "630A8C16D58D2D7475C82A98B032390831D22589BCCD0F9086E95E85742A41B3";
+    "nix-public/org/apache/commons/commons-compress/1.20/commons-compress-1.20-tests.jar" = {
+      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20-tests.jar";
+      sha256 = "0D3A25B099D7B6FCA3B46DB709A31921D02DF4852452FE81374679FA28A183E3";
     };
-    "nix-public/org/apache/commons/commons-compress/1.18/commons-compress-1.18.jar" = {
-      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.18/commons-compress-1.18.jar";
-      sha256 = "5F2DF1E467825E4CAC5996D44890C4201C000B43C0B23CFFC0782D28A0BEB9B0";
+    "nix-public/org/apache/commons/commons-compress/1.20/commons-compress-1.20.jar" = {
+      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.jar";
+      sha256 = "0AEB625C948C697EA7B205156E112363B59ED5E2551212CD4E460BDB72C7C06E";
     };
-    "nix-public/org/apache/commons/commons-compress/1.18/commons-compress-1.18.pom" = {
-      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.18/commons-compress-1.18.pom";
-      sha256 = "672C5FE92BD3EAB43E8D53338CAD5CA073B6529DE4EB2B38859A3EAA6C9E8119";
+    "nix-public/org/apache/commons/commons-compress/1.20/commons-compress-1.20.pom" = {
+      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.pom";
+      sha256 = "D95678E3AF56B17C7DB6CFF9645EFAD5EB59BE9F3C1CAAAF5F0146EDF04691D7";
     };
-    "nix-public/org/apache/commons/commons-parent/47/commons-parent-47.pom" = {
-      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-parent/47/commons-parent-47.pom";
-      sha256 = "8A8ECB570553BF9F1FFAE211A8D4CA9EE630C17AFE59293368FBA7BD9B42FCB7";
+    "nix-public/org/apache/commons/commons-parent/48/commons-parent-48.pom" = {
+      url = "https://repo1.maven.org/maven2/org/apache/commons/commons-parent/48/commons-parent-48.pom";
+      sha256 = "1E1F7DE9370A7B7901F128F1DACD1422BE74E3F47F9558B0F79E04C0637CA0B4";
     };
     "nix-public/org/apache/logging/log4j/log4j-api/2.11.1/log4j-api-2.11.1-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.11.1/log4j-api-2.11.1-javadoc.jar";
@@ -2237,21 +2253,21 @@
       url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.4.2/srcs/sbt-updates-sources.jar";
       sha256 = "E8749363973A15F149FE99370059A95A8119079B7782346C68652EE4F050D548";
     };
-    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/docs/sbt-native-packager-javadoc.jar" = {
-      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/docs/sbt-native-packager-javadoc.jar";
-      sha256 = "2587BBFB8070A02CDF89084BCA34B6CAA545CA90EA15C9AAF3B99A16E7561FC6";
+    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/docs/sbt-native-packager-javadoc.jar" = {
+      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/docs/sbt-native-packager-javadoc.jar";
+      sha256 = "0F6989FEA02D899E22CDE3F72D91BDF86EA32E99A0D9F4AB10C32C94ECD017BF";
     };
-    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/ivys/ivy.xml" = {
-      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/ivys/ivy.xml";
-      sha256 = "32CCF2FADD93C8A0D5C7F72386498C2DCA3CB0EF096296271C0758C798612F00";
+    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/ivys/ivy.xml" = {
+      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/ivys/ivy.xml";
+      sha256 = "C289AEEC00392CCA6451F92857D3C7EFF4BC02A819A2829E3D7BB961C57133B9";
     };
-    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/jars/sbt-native-packager.jar" = {
-      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/jars/sbt-native-packager.jar";
-      sha256 = "5BF5AD2993CD353B09735E98D17CCAC1DAD414EB362F04D06639DB476E788E6B";
+    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/jars/sbt-native-packager.jar" = {
+      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/jars/sbt-native-packager.jar";
+      sha256 = "54458E1DF2E7603AA9C533552B75B918859E4B5318C4EE4E2A19245725747613";
     };
-    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/srcs/sbt-native-packager-sources.jar" = {
-      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.3.21/srcs/sbt-native-packager-sources.jar";
-      sha256 = "AE4C22DC69E2D5972AFE1155DE1AC7D596B67F9EF02DB3A2F681B84FE0AD632A";
+    "nix-sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/srcs/sbt-native-packager-sources.jar" = {
+      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.sbt/sbt-native-packager/scala_2.12/sbt_1.0/1.7.5/srcs/sbt-native-packager-sources.jar";
+      sha256 = "B5A2E0FC8ED6A5359A4E5FEE211BCB2632E0538F3E6E269AB41BB1D5EF9D8BF4";
     };
     "nix-sbt-plugin-releases/org.portable-scala/sbt-platform-deps/scala_2.12/sbt_1.0/1.0.0/docs/sbt-platform-deps-javadoc.jar" = {
       url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/org.portable-scala/sbt-platform-deps/scala_2.12/sbt_1.0/1.0.0/docs/sbt-platform-deps-javadoc.jar";

--- a/repo.nix
+++ b/repo.nix
@@ -6,7 +6,6 @@
     }];
   "repos" = {
     "nix-public" = "";
-    "nix-rocksDb" = "";
   };
   "artifacts" = {
     "nix-public/ch/megard/akka-http-cors_2.12/1.1.0/akka-http-cors_2.12-1.1.0-javadoc.jar" = {
@@ -1789,6 +1788,22 @@
       url = "https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.pom";
       sha256 = "CCED467175F4257833F6CB07510FF97B3C75A06E1A58D882A39D79853D51C602";
     };
+    "nix-public/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4-javadoc.jar";
+      sha256 = "EAA6C896CC6DC514F4DB5B4DD2E40ADC610A294FB3B02E881730F018D3405380";
+    };
+    "nix-public/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4-sources.jar";
+      sha256 = "B803678A03603322237B39FFB63A4D5DE5676195BA9F1F3099FB5EE926C36314";
+    };
+    "nix-public/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4.jar" = {
+      url = "https://repo1.maven.org/maven2/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4.jar";
+      sha256 = "58F650062D3C87CE4170BD43BB56273B5E92AD20996BAA27A04DDB6836139B8B";
+    };
+    "nix-public/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4.pom" = {
+      url = "https://repo1.maven.org/maven2/org/rocksdb/rocksdbjni/6.11.4/rocksdbjni-6.11.4.pom";
+      sha256 = "B3A6AA2AA590DD5DD1FB9160DE220756C87BB9BA71815CE3ED39592F8A5338F6";
+    };
     "nix-public/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/org/scala-lang/modules/scala-java8-compat_2.12/0.8.0/scala-java8-compat_2.12-0.8.0-javadoc.jar";
       sha256 = "9175A09E404F75EC013219B54A51DF8788F890E0443BAE7A96FFC1AE74EF24F2";
@@ -2876,14 +2891,6 @@
     "nix-public/org/xerial/snappy/snappy-java/1.1.7.2/snappy-java-1.1.7.2.pom" = {
       url = "https://repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.7.2/snappy-java-1.1.7.2.pom";
       sha256 = "F4C30DDEE95B914F0233CB2ACFCBA1C934A6984EA468EC0ECE4218E5D98E17CD";
-    };
-    "nix-rocksDb/org/ethereum/rocksdbjni/5.9.2/rocksdbjni-5.9.2.jar" = {
-      url = "https://dl.bintray.com/ethereum/maven/org/ethereum/rocksdbjni/5.9.2/rocksdbjni-5.9.2.jar";
-      sha256 = "E82BD73857B0748383F8E8CEAD0EBCDE14A413A41CBDE1D85CB7980ABFC1D662";
-    };
-    "nix-rocksDb/org/ethereum/rocksdbjni/5.9.2/rocksdbjni-5.9.2.pom" = {
-      url = "https://dl.bintray.com/ethereum/maven/org/ethereum/rocksdbjni/5.9.2/rocksdbjni-5.9.2.pom";
-      sha256 = "609416E1254A938C8B42E8EA5B9EF2D8E8D8981AC8CEDF931E92937EA34FABF1";
     };
   };
 }

--- a/src/main/scala/io/iohk/ethereum/db/dataSource/RocksDbDataSource.scala
+++ b/src/main/scala/io/iohk/ethereum/db/dataSource/RocksDbDataSource.scala
@@ -83,7 +83,7 @@ class RocksDbDataSource(
     try {
       withResources(new WriteOptions()){ writeOptions =>
         withResources(new WriteBatch()){ batch =>
-          toRemove.foreach{ key => batch.remove(handles(namespace), key.toArray) }
+          toRemove.foreach{ key => batch.delete(handles(namespace), key.toArray) }
           toUpsert.foreach{ case (k, v) => batch.put(handles(namespace), k.toArray, v.toArray) }
 
           db.write(writeOptions, batch)
@@ -115,7 +115,7 @@ class RocksDbDataSource(
     try {
       withResources(new WriteOptions()){ writeOptions =>
         withResources(new WriteBatch()){ batch =>
-          toRemove.foreach{ key => batch.remove(key) }
+          toRemove.foreach{ key => batch.delete(key) }
           toUpsert.foreach{ case (k, v) => batch.put(k, v) }
 
           db.write(writeOptions, batch)
@@ -193,10 +193,10 @@ class RocksDbDataSource(
 
       val tableCfg = new BlockBasedTableConfig()
         .setBlockSize(blockSize)
-        .setBlockCacheSize(blockCacheSize)
+        .setBlockCache(new ClockCache(blockCacheSize))
         .setCacheIndexAndFilterBlocks(true)
         .setPinL0FilterAndIndexBlocksInCache(true)
-        .setFilter(new BloomFilter(10, false))
+        .setFilterPolicy(new BloomFilter(10, false))
 
       val options = new Options()
         .setCreateIfMissing(createIfMissing)
@@ -253,10 +253,10 @@ object RocksDbDataSource {
 
       val tableCfg = new BlockBasedTableConfig()
         .setBlockSize(blockSize)
-        .setBlockCacheSize(blockCacheSize)
+        .setBlockCache(new ClockCache(blockCacheSize))
         .setCacheIndexAndFilterBlocks(true)
         .setPinL0FilterAndIndexBlocksInCache(true)
-        .setFilter(new BloomFilter(10, false))
+        .setFilterPolicy(new BloomFilter(10, false))
 
       val options = new DBOptions()
         .setCreateIfMissing(createIfMissing)

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -536,7 +536,7 @@ trait GenesisDataLoaderBuilder {
 
 trait SecureRandomBuilder {
   lazy val secureRandom: SecureRandom =
-    Config.secureRandomAlgo.map(SecureRandom.getInstance).getOrElse(new SecureRandom())
+    Config.secureRandomAlgo.flatMap(name => Try(SecureRandom.getInstance(name)).toOption).getOrElse(new SecureRandom())
 }
 
 /** Provides the basic functionality of a Node, except the consensus algorithm.

--- a/src/main/scala/io/iohk/ethereum/utils/Ref.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Ref.scala
@@ -3,13 +3,13 @@ package io.iohk.ethereum.utils
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * An [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicReference.html java.util.concurrent.atomic.AtomicReference]] that can be set once.
- */
+  * An [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicReference.html AtomicReference]] that can be set once.
+  */
 class Ref[T <: AnyRef] {
   private[this] final val ref = new AtomicReference[Option[T]](None)
 
   // set once (but not necessarily compute once)
-  final def setOnce(t: ⇒T): Boolean = ref.get().isEmpty && ref.compareAndSet(None, Some(t))
+  final def setOnce(t: ⇒ T): Boolean = ref.get().isEmpty && ref.compareAndSet(None, Some(t))
 
   final def isDefined: Boolean = ref.get().isDefined
   final def isEmpty: Boolean = ref.get().isEmpty

--- a/src/main/scala/io/iohk/ethereum/utils/Ref.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Ref.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.utils
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * An [[java.util.concurrent.atomic.AtomicReference AtomicReference]] that can be set once.
+ * An [[https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicReference.html java.util.concurrent.atomic.AtomicReference]] that can be set once.
  */
 class Ref[T <: AnyRef] {
   private[this] final val ref = new AtomicReference[Option[T]](None)


### PR DESCRIPTION
# Description

This PR fixes issues found when trying to run Mantis on Windows, that is:
  - generating proper `.bat` files
  - fixing the way `SecureRandom` instance is obtained
  - KeyStore tests which were too UNIX-oriented
  - Update RocksDB to latest version, so Ethereum fork doesn't need to be used

# Testing

All tests, `sbt dist` and syncing from both sbt and dist package should work

