### PR TITLE
[FIX] Add mocked miner validations

### DIFF
--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
@@ -1,7 +1,8 @@
 package io.iohk.ethereum.ets.blockchain
 
 import akka.util.ByteString
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.Protocol
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.domain.{Address, UInt256}
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig, MonetaryPolicyConfig}
 import org.bouncycastle.util.encoders.Hex
@@ -290,19 +291,19 @@ object BlockchainTestConfig {
 object Validators {
   import BlockchainTestConfig._
 
-  val frontierValidators = EthashValidators(FrontierConfig)
-  val homesteadValidators = EthashValidators(HomesteadConfig)
-  val eip150Validators = EthashValidators(Eip150Config)
-  val frontierToHomesteadValidators = EthashValidators(FrontierToHomesteadAt5)
-  val homesteadToEipValidators = EthashValidators(HomesteadToEIP150At5)
-  val homesteadToDaoValidators= EthashValidators(HomesteadToDaoAt5)
-  val eip158Validators = EthashValidators(Eip158Config)
-  val byzantiumValidators = EthashValidators(ByzantiumConfig)
-  val constantinopleValidators = EthashValidators(ConstantinopleConfig)
-  val constantinopleFixValidators = EthashValidators(ConstantinopleFixConfig)
-  val istanbulValidators = EthashValidators(IstanbulConfig)
-  val eip158ToByzantiumValidators = EthashValidators(Eip158ToByzantiumAt5Config)
-  val byzantiumToConstantinopleAt5 = EthashValidators(ByzantiumToConstantinopleAt5)
+  val frontierValidators = ValidatorsExecutor(FrontierConfig, Protocol.Ethash)
+  val homesteadValidators = ValidatorsExecutor(HomesteadConfig, Protocol.Ethash)
+  val eip150Validators = ValidatorsExecutor(Eip150Config, Protocol.Ethash)
+  val frontierToHomesteadValidators = ValidatorsExecutor(FrontierToHomesteadAt5, Protocol.Ethash)
+  val homesteadToEipValidators = ValidatorsExecutor(HomesteadToEIP150At5, Protocol.Ethash)
+  val homesteadToDaoValidators= ValidatorsExecutor(HomesteadToDaoAt5, Protocol.Ethash)
+  val eip158Validators = ValidatorsExecutor(Eip158Config, Protocol.Ethash)
+  val byzantiumValidators = ValidatorsExecutor(ByzantiumConfig, Protocol.Ethash)
+  val constantinopleValidators = ValidatorsExecutor(ConstantinopleConfig, Protocol.Ethash)
+  val constantinopleFixValidators = ValidatorsExecutor(ConstantinopleFixConfig, Protocol.Ethash)
+  val istanbulValidators = ValidatorsExecutor(IstanbulConfig, Protocol.Ethash)
+  val eip158ToByzantiumValidators = ValidatorsExecutor(Eip158ToByzantiumAt5Config, Protocol.Ethash)
+  val byzantiumToConstantinopleAt5 = ValidatorsExecutor(ByzantiumToConstantinopleAt5, Protocol.Ethash)
 }
 
 // Connected with: https://github.com/ethereum/tests/issues/480
@@ -310,17 +311,17 @@ object ValidatorsWithSkippedPoW {
 
   import BlockchainTestConfig._
 
-  val frontierValidators =  EthashValidators(FrontierConfig, new EthashTestBlockHeaderValidator(FrontierConfig))
-  val homesteadValidators = EthashValidators(HomesteadConfig, new EthashTestBlockHeaderValidator(HomesteadConfig))
-  val eip150Validators = EthashValidators(Eip150Config, new EthashTestBlockHeaderValidator(Eip150Config))
-  val frontierToHomesteadValidators = EthashValidators(FrontierToHomesteadAt5, new EthashTestBlockHeaderValidator(FrontierToHomesteadAt5))
-  val homesteadToEipValidators = EthashValidators(HomesteadToEIP150At5, new EthashTestBlockHeaderValidator(HomesteadToEIP150At5))
-  val homesteadToDaoValidators= EthashValidators(HomesteadToDaoAt5, new EthashTestBlockHeaderValidator(HomesteadToDaoAt5))
-  val eip158Validators = EthashValidators(Eip158Config, new EthashTestBlockHeaderValidator(Eip158Config))
-  val byzantiumValidators = EthashValidators(ByzantiumConfig, new EthashTestBlockHeaderValidator(ByzantiumConfig))
-  val constantinopleValidators = EthashValidators(ConstantinopleConfig, new EthashTestBlockHeaderValidator(ConstantinopleConfig))
-  val constantinopleFixValidators = EthashValidators(ConstantinopleFixConfig, new EthashTestBlockHeaderValidator(ConstantinopleFixConfig))
-  val istanbulValidators = EthashValidators(IstanbulConfig, new EthashTestBlockHeaderValidator(IstanbulConfig))
-  val eip158ToByzantiumValidators = EthashValidators(Eip158ToByzantiumAt5Config, new EthashTestBlockHeaderValidator(Eip158ToByzantiumAt5Config))
-  val byzantiumToConstantinopleAt5 = EthashValidators(ByzantiumToConstantinopleAt5, new EthashTestBlockHeaderValidator(ByzantiumToConstantinopleAt5))
+  val frontierValidators =  ValidatorsExecutor(FrontierConfig, new EthashTestBlockHeaderValidator(FrontierConfig))
+  val homesteadValidators = ValidatorsExecutor(HomesteadConfig, new EthashTestBlockHeaderValidator(HomesteadConfig))
+  val eip150Validators = ValidatorsExecutor(Eip150Config, new EthashTestBlockHeaderValidator(Eip150Config))
+  val frontierToHomesteadValidators = ValidatorsExecutor(FrontierToHomesteadAt5, new EthashTestBlockHeaderValidator(FrontierToHomesteadAt5))
+  val homesteadToEipValidators = ValidatorsExecutor(HomesteadToEIP150At5, new EthashTestBlockHeaderValidator(HomesteadToEIP150At5))
+  val homesteadToDaoValidators= ValidatorsExecutor(HomesteadToDaoAt5, new EthashTestBlockHeaderValidator(HomesteadToDaoAt5))
+  val eip158Validators = ValidatorsExecutor(Eip158Config, new EthashTestBlockHeaderValidator(Eip158Config))
+  val byzantiumValidators = ValidatorsExecutor(ByzantiumConfig, new EthashTestBlockHeaderValidator(ByzantiumConfig))
+  val constantinopleValidators = ValidatorsExecutor(ConstantinopleConfig, new EthashTestBlockHeaderValidator(ConstantinopleConfig))
+  val constantinopleFixValidators = ValidatorsExecutor(ConstantinopleFixConfig, new EthashTestBlockHeaderValidator(ConstantinopleFixConfig))
+  val istanbulValidators = ValidatorsExecutor(IstanbulConfig, new EthashTestBlockHeaderValidator(IstanbulConfig))
+  val eip158ToByzantiumValidators = ValidatorsExecutor(Eip158ToByzantiumAt5Config, new EthashTestBlockHeaderValidator(Eip158ToByzantiumAt5Config))
+  val byzantiumToConstantinopleAt5 = ValidatorsExecutor(ByzantiumToConstantinopleAt5, new EthashTestBlockHeaderValidator(ByzantiumToConstantinopleAt5))
 }

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.ets.blockchain
 import java.util.concurrent.Executors
 
 import io.iohk.ethereum.consensus.ethash.EthashConsensus
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.{ConsensusConfig, FullConsensusConfig, TestConsensus, ethash}
 import io.iohk.ethereum.db.components.Storages.PruningModeComponent
 import io.iohk.ethereum.db.components.{SharedEphemDataSources, Storages}
@@ -25,7 +25,7 @@ object ScenarioSetup {
   val specificConfig = ethash.EthashConfig(Config.config)
   val fullConfig = FullConsensusConfig(ConsensusConfig(Config.config)(null), specificConfig)
 
-  def loadEthashConsensus(vm: VMImpl, blockchain: BlockchainImpl, blockchainConfig: BlockchainConfig, validators: EthashValidators): ethash.EthashConsensus = {
+  def loadEthashConsensus(vm: VMImpl, blockchain: BlockchainImpl, blockchainConfig: BlockchainConfig, validators: ValidatorsExecutor): ethash.EthashConsensus = {
     val consensus = EthashConsensus(vm, blockchain, blockchainConfig, fullConfig, validators)
     consensus
   }
@@ -99,11 +99,11 @@ abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
     scenario.postState.map(_.map(addAcc => addAcc._1 -> blockchain.getAccount(addAcc._1, bestBlockNumber)).toList)
   }
 
-  private def buildBlockchainConfig(network: String, shouldSkipPoW: Boolean): (BlockchainConfig, EthashValidators) = {
+  private def buildBlockchainConfig(network: String, shouldSkipPoW: Boolean): (BlockchainConfig, ValidatorsExecutor) = {
     if (shouldSkipPoW) withSkippedPoWValidationBlockchainConfig(network) else baseBlockchainConfig(network)
   }
 
-  private def baseBlockchainConfig(network: String): (BlockchainConfig, EthashValidators) = network match {
+  private def baseBlockchainConfig(network: String): (BlockchainConfig, ValidatorsExecutor) = network match {
     case "EIP150" => (Eip150Config, Validators.eip150Validators)
     case "Frontier" => (FrontierConfig, Validators.frontierValidators)
     case "Homestead" => (HomesteadConfig, Validators.homesteadValidators)
@@ -121,7 +121,7 @@ abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
     case _ => (FrontierConfig, Validators.frontierValidators)
   }
 
-  private def withSkippedPoWValidationBlockchainConfig(network: String): (BlockchainConfig, EthashValidators) = network match {
+  private def withSkippedPoWValidationBlockchainConfig(network: String): (BlockchainConfig, ValidatorsExecutor) = network match {
     case "EIP150" => (Eip150Config, ValidatorsWithSkippedPoW.eip150Validators)
     case "Frontier" => (FrontierConfig, ValidatorsWithSkippedPoW.frontierValidators)
     case "Homestead" => (HomesteadConfig, ValidatorsWithSkippedPoW.homesteadValidators)

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum.consensus
 
 import io.iohk.ethereum.consensus.ethash.EthashConsensus
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.nodebuilder._
 import io.iohk.ethereum.utils.{Config, Logger}
 
@@ -27,7 +27,7 @@ trait StdConsensusBuilder extends ConsensusBuilder {
   protected def buildEthashConsensus(): ethash.EthashConsensus = {
     val specificConfig = ethash.EthashConfig(mantisConfig)
     val fullConfig = newConfig(specificConfig)
-    val validators = EthashValidators(blockchainConfig)
+    val validators = ValidatorsExecutor(blockchainConfig, consensusConfig.protocol)
     val consensus = EthashConsensus(vm, blockchain, blockchainConfig, fullConfig, validators)
     consensus
   }

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusConfig.scala
@@ -36,7 +36,8 @@ object ConsensusConfig extends Logger {
 
 
   final val AllowedProtocols = Set(
-    Protocol.Names.Ethash
+    Protocol.Names.Ethash,
+    Protocol.Names.MockedPow
   )
 
   final val AllowedProtocolsError = (s: String) ⇒ Keys.Consensus +

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
@@ -8,7 +8,7 @@ import io.iohk.ethereum.consensus.Protocol.{Ethash, MockedPow}
 import io.iohk.ethereum.consensus.blocks.TestBlockGenerator
 import io.iohk.ethereum.consensus.ethash.MinerResponses.MinerNotExist
 import io.iohk.ethereum.consensus.ethash.blocks.{EthashBlockGenerator, EthashBlockGeneratorImpl}
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators.Validators
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.ledger.BlockPreparator
@@ -23,12 +23,12 @@ import scala.concurrent.duration._
  * Implements standard Ethereum consensus (ethash PoW).
  */
 class EthashConsensus private(
-  val vm: VMImpl,
-  blockchain: BlockchainImpl,
-  blockchainConfig: BlockchainConfig,
-  val config: FullConsensusConfig[EthashConfig],
-  val validators: EthashValidators,
-  val blockGenerator: EthashBlockGenerator
+    val vm: VMImpl,
+    blockchain: BlockchainImpl,
+    blockchainConfig: BlockchainConfig,
+    val config: FullConsensusConfig[EthashConfig],
+    val validators: ValidatorsExecutor,
+    val blockGenerator: EthashBlockGenerator
 ) extends TestConsensus with Logger  {
 
   type Config = EthashConfig
@@ -95,7 +95,7 @@ class EthashConsensus private(
   /** Internal API, used for testing */
   protected def newBlockGenerator(validators: Validators): EthashBlockGenerator = {
     validators match {
-      case _validators: EthashValidators ⇒
+      case _validators: ValidatorsExecutor ⇒
         val blockPreparator = new BlockPreparator(
           vm = vm,
           signedTxValidator = validators.signedTransactionValidator,
@@ -113,7 +113,7 @@ class EthashConsensus private(
         )
 
       case _ ⇒
-        wrongValidatorsArgument[EthashValidators](validators)
+        wrongValidatorsArgument[ValidatorsExecutor](validators)
     }
   }
 
@@ -121,7 +121,7 @@ class EthashConsensus private(
   /** Internal API, used for testing */
   def withValidators(validators: Validators): EthashConsensus = {
     validators match {
-      case _validators: EthashValidators ⇒
+      case _validators: ValidatorsExecutor ⇒
         val blockGenerator = newBlockGenerator(validators)
 
         new EthashConsensus(
@@ -134,7 +134,7 @@ class EthashConsensus private(
         )
 
       case _ ⇒
-        wrongValidatorsArgument[EthashValidators](validators)
+        wrongValidatorsArgument[ValidatorsExecutor](validators)
     }
   }
 
@@ -168,7 +168,7 @@ object EthashConsensus {
     blockchain: BlockchainImpl,
     blockchainConfig: BlockchainConfig,
     config: FullConsensusConfig[EthashConfig],
-    validators: EthashValidators
+    validators: ValidatorsExecutor
   ): EthashConsensus = {
 
     val blockPreparator = new BlockPreparator(

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/blocks/EthashBlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/blocks/EthashBlockGenerator.scala
@@ -6,7 +6,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.consensus.ConsensusConfig
 import io.iohk.ethereum.consensus.blocks._
 import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.{BlockPreparationError, BlockPreparator}
@@ -24,12 +24,12 @@ trait EthashBlockGenerator extends TestBlockGenerator {
 }
 
 class EthashBlockGeneratorImpl(
-  validators: EthashValidators,
-  blockchain: Blockchain,
-  blockchainConfig: BlockchainConfig,
-  consensusConfig: ConsensusConfig,
-  val blockPreparator: BlockPreparator,
-  blockTimestampProvider: BlockTimestampProvider = DefaultBlockTimestampProvider
+    validators: ValidatorsExecutor,
+    blockchain: Blockchain,
+    blockchainConfig: BlockchainConfig,
+    consensusConfig: ConsensusConfig,
+    val blockPreparator: BlockPreparator,
+    blockTimestampProvider: BlockTimestampProvider = DefaultBlockTimestampProvider
 ) extends BlockGeneratorSkeleton(
   blockchain,
   blockchainConfig,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/MockedPowBlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/MockedPowBlockHeaderValidator.scala
@@ -1,0 +1,18 @@
+package io.iohk.ethereum.consensus.ethash
+package validators
+
+import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
+import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
+import io.iohk.ethereum.consensus.validators.{ BlockHeaderError, BlockHeaderValid, BlockHeaderValidatorSkeleton }
+import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.utils.BlockchainConfig
+
+class MockedPowBlockHeaderValidator(blockchainConfig: BlockchainConfig) extends BlockHeaderValidatorSkeleton(blockchainConfig) {
+
+  protected def difficulty: DifficultyCalculator = new EthashDifficultyCalculator(blockchainConfig)
+
+  def validateEvenMore(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] =
+    Right(BlockHeaderValid)
+
+}
+

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/StdValidatorsExecutor.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/StdValidatorsExecutor.scala
@@ -4,12 +4,12 @@ import io.iohk.ethereum.consensus.validators.{ BlockHeaderValidator, BlockValida
 
 /**
  * Implements validators that adhere to the PoW-specific
- * [[io.iohk.ethereum.consensus.ethash.validators.EthashValidators EthashValidators]]
+ * [[io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor]]
  * interface.
  */
-final class StdEthashValidators private[validators](
+final class StdValidatorsExecutor private[validators](
   val blockValidator: BlockValidator,
   val blockHeaderValidator: BlockHeaderValidator,
   val signedTransactionValidator: SignedTransactionValidator,
   val ommersValidator: OmmersValidator
-) extends EthashValidators
+) extends ValidatorsExecutor

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidators.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/std/StdValidators.scala
@@ -12,7 +12,7 @@ import org.bouncycastle.util.encoders.Hex
  * Implements validators that adhere to the original [[io.iohk.ethereum.consensus.validators.Validators Validators]]
  * interface.
  *
- * @see [[io.iohk.ethereum.consensus.ethash.validators.StdEthashValidators StdEthashValidators]]
+ * @see [[io.iohk.ethereum.consensus.ethash.validators.StdValidatorsExecutor StdEthashValidators]]
  *      for the PoW-specific counterpart.
  */
 final class StdValidators(

--- a/src/test/scala/io/iohk/ethereum/Mocks.scala
+++ b/src/test/scala/io/iohk/ethereum/Mocks.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.OmmersError.OmmersNotValidError
 import io.iohk.ethereum.consensus.ethash.validators.OmmersValidator.OmmersValid
-import io.iohk.ethereum.consensus.ethash.validators.{ EthashValidators, OmmersValidator }
+import io.iohk.ethereum.consensus.ethash.validators.{ ValidatorsExecutor, OmmersValidator }
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderNumberError
 import io.iohk.ethereum.consensus.validators._
 import io.iohk.ethereum.consensus.validators.std.StdBlockValidator.{ BlockError, BlockTransactionsHashError, BlockValid }
@@ -55,7 +55,7 @@ object Mocks {
     }
   }
 
-  class MockValidatorsAlwaysSucceed extends EthashValidators {
+  class MockValidatorsAlwaysSucceed extends ValidatorsExecutor {
 
     override val blockValidator: BlockValidator = new BlockValidator {
       override def validateBlockAndReceipts(blockHeader: BlockHeader, receipts: Seq[Receipt]) = Right(BlockValid)
@@ -73,7 +73,7 @@ object Mocks {
 
   object MockValidatorsAlwaysSucceed extends MockValidatorsAlwaysSucceed
 
-  object MockValidatorsAlwaysFail extends EthashValidators {
+  object MockValidatorsAlwaysFail extends ValidatorsExecutor {
     override val signedTransactionValidator: SignedTransactionValidator =
       (_: SignedTransaction, _: Account, _: BlockHeader, _: UInt256, _: BigInt) => Left(SignedTransactionError.TransactionSignatureError)
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -4,9 +4,9 @@ import java.util.concurrent.Executors
 
 import io.iohk.ethereum.Mocks
 import io.iohk.ethereum.Mocks.MockVM
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators.Validators
-import io.iohk.ethereum.consensus.{Consensus, StdTestConsensusBuilder, TestConsensus}
+import io.iohk.ethereum.consensus.{Consensus, Protocol, StdTestConsensusBuilder, TestConsensus}
 import io.iohk.ethereum.domain.BlockchainImpl
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import io.iohk.ethereum.ledger.LedgerImpl
@@ -25,7 +25,7 @@ trait ScenarioSetup extends StdTestConsensusBuilder with SyncConfigBuilder with 
   protected lazy val executionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
   protected lazy val successValidators: Validators = Mocks.MockValidatorsAlwaysSucceed
   protected lazy val failureValidators: Validators = Mocks.MockValidatorsAlwaysFail
-  protected lazy val ethashValidators: EthashValidators = EthashValidators(blockchainConfig)
+  protected lazy val ethashValidators: ValidatorsExecutor = ValidatorsExecutor(blockchainConfig, Protocol.Ethash)
 
   /**
    * The default validators for the test cases.

--- a/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
@@ -7,7 +7,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.consensus.blocks.{ BlockTimestampProvider, PendingBlock }
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators._
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto._
@@ -356,7 +356,7 @@ class BlockGeneratorSpec extends FlatSpec with Matchers with PropertyChecks with
     val blockCacheSize: Int = 30
     val headerExtraData: ByteString = ByteString("mined with etc scala")
 
-    override lazy val validators: EthashValidators = ethashValidators
+    override lazy val validators: ValidatorsExecutor = ethashValidators
 
     override lazy val consensusConfig = buildConsensusConfig().
       copy(headerExtraData = headerExtraData, blockCacheSize = blockCacheSize)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -8,7 +8,7 @@ import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.consensus.blocks.PendingBlock
 import io.iohk.ethereum.consensus.ethash.blocks.EthashBlockGenerator
-import io.iohk.ethereum.consensus.ethash.validators.EthashValidators
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
 import io.iohk.ethereum.consensus.validators.SignedTransactionValidator
 import io.iohk.ethereum.consensus.{Consensus, ConsensusConfigs, TestConsensus}
 import io.iohk.ethereum.crypto.{ECDSASignature, kec256}
@@ -1955,7 +1955,7 @@ class JsonRpcControllerSpec
     val syncingController = TestProbe()
     override lazy val ledger = mock[Ledger]
     override lazy val stxLedger = mock[StxLedger]
-    override lazy val validators = mock[EthashValidators]
+    override lazy val validators = mock[ValidatorsExecutor]
     override lazy val consensus: TestConsensus = buildTestConsensus()
       .withValidators(validators)
       .withBlockGenerator(blockGenerator)


### PR DESCRIPTION
# Description

A couple of mocked miner fixes:
- Adds the mocked miner as one of the allowed protocols
- Adds mocked pow validations so that imported blocks created by mock miner doesn't fail

# Testing

Setup:
- mantis.consensus.protocol = mocked
- mantis.consensus.mining-enabled = true
- mantis.blockchains.network = "private"
- mantis.sync.do-fast-sync = false

And use the mocked miner QA endpoint to generate blocks