### PR TITLE
[ETCM-110] Add eth_chainId RPC method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ project/plugins/project/
 .ensime
 .ensime_cache/
 .bloop
+out/
 
 # IDE folders
 .idea/

--- a/insomnia_workspace.json
+++ b/insomnia_workspace.json
@@ -1,7 +1,7 @@
 {
   "_type": "export",
   "__export_format": 4,
-  "__export_date": "2020-09-16T09:48:00.794Z",
+  "__export_date": "2020-09-21T12:39:47.334Z",
   "__export_source": "insomnia.desktop.app:v2020.3.3",
   "resources": [
     {
@@ -199,6 +199,50 @@
       "_type": "request_group"
     },
     {
+      "_id": "req_0ff71c4f648c4d3782612e9c53179321",
+      "authentication": {},
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"eth_chainId\", \n\t\"params\": [],\n  \"id\": 1\n}"
+      },
+      "created": 1600691926224,
+      "description": "",
+      "headers": [
+        {
+          "id": "pair_c33a6ada19dd4aa8b75527639519f427",
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "isPrivate": false,
+      "metaSortKey": -1600691926224,
+      "method": "POST",
+      "modified": 1600691932451,
+      "name": "eth_chainId",
+      "parameters": [],
+      "parentId": "fld_a06eb77e183c4727800eb7dc43ceabe1",
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingFollowRedirects": "global",
+      "settingRebuildPath": true,
+      "settingSendCookies": true,
+      "settingStoreCookies": true,
+      "url": "{{node_url}}",
+      "_type": "request"
+    },
+    {
+      "_id": "fld_a06eb77e183c4727800eb7dc43ceabe1",
+      "created": 1552939140291,
+      "description": "",
+      "environment": {},
+      "environmentPropertyOrder": null,
+      "metaSortKey": -1552939140292,
+      "modified": 1599825661277,
+      "name": "Eth",
+      "parentId": "wrk_097d43914a4d4aea8b6f73f647921182",
+      "_type": "request_group"
+    },
+    {
       "_id": "req_b60c1a4f9d604d868910f967c6a070d7",
       "authentication": {},
       "body": {
@@ -234,18 +278,6 @@
       "settingStoreCookies": true,
       "url": "{{ node_url }}",
       "_type": "request"
-    },
-    {
-      "_id": "fld_a06eb77e183c4727800eb7dc43ceabe1",
-      "created": 1552939140291,
-      "description": "",
-      "environment": {},
-      "environmentPropertyOrder": null,
-      "metaSortKey": -1552939140292,
-      "modified": 1599825661277,
-      "name": "Eth",
-      "parentId": "wrk_097d43914a4d4aea8b6f73f647921182",
-      "_type": "request_group"
     },
     {
       "_id": "req_97fa82439e3e46bfb8ee26400af6215d",

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/DebugJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/DebugJsonMethodsImplicits.scala
@@ -1,15 +1,14 @@
 package io.iohk.ethereum.jsonrpc
 
-import io.iohk.ethereum.jsonrpc.DebugService.{ ListPeersInfoRequest, ListPeersInfoResponse }
-import org.json4s.JsonAST.{ JArray, JString, JValue }
+import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInfoResponse}
+import io.iohk.ethereum.jsonrpc.JsonRpcController.{Codec, JsonEncoder}
+import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonDecoder.NoParamsDecoder
+import org.json4s.JsonAST.{JArray, JString, JValue}
 
 object DebugJsonMethodsImplicits extends JsonMethodsImplicits {
 
   implicit val debug_listPeersInfo: Codec[ListPeersInfoRequest, ListPeersInfoResponse] =
-    new Codec[ListPeersInfoRequest, ListPeersInfoResponse] {
-      def decodeJson(params: Option[JArray]): Either[JsonRpcError, ListPeersInfoRequest] =
-        Right(ListPeersInfoRequest())
-
+    new NoParamsDecoder(ListPeersInfoRequest()) with JsonEncoder[ListPeersInfoResponse] {
       def encodeJson(t: ListPeersInfoResponse): JValue =
         JArray(t.peers.map(a => JString(a.toString)))
     }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
@@ -2,7 +2,8 @@ package io.iohk.ethereum.jsonrpc
 
 import akka.util.ByteString
 import io.iohk.ethereum.jsonrpc.EthService._
-import io.iohk.ethereum.jsonrpc.JsonRpcController.{JsonDecoder, JsonEncoder}
+import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonDecoder.NoParamsDecoder
+import io.iohk.ethereum.jsonrpc.JsonRpcController.{Codec, JsonDecoder, JsonEncoder}
 import io.iohk.ethereum.jsonrpc.JsonRpcErrors.InvalidParams
 import io.iohk.ethereum.jsonrpc.PersonalService.{SendTransactionRequest, SendTransactionResponse, SignRequest}
 import org.json4s.{Extraction, JsonAST}
@@ -12,28 +13,17 @@ import org.json4s.JsonDSL._
 // scalastyle:off number.of.methods
 object EthJsonMethodsImplicits extends JsonMethodsImplicits {
 
-  implicit val eth_protocolVersion = new JsonDecoder[ProtocolVersionRequest] with JsonEncoder[ProtocolVersionResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, ProtocolVersionRequest] = Right(
-      ProtocolVersionRequest()
-    )
-
+  implicit val eth_protocolVersion = new NoParamsDecoder(ProtocolVersionRequest())
+    with JsonEncoder[ProtocolVersionResponse] {
     def encodeJson(t: ProtocolVersionResponse): JValue = t.value
   }
 
-  implicit val eth_chainId = new JsonDecoder[ChainIdRequest] with JsonEncoder[ChainIdResponse] {
-    def decodeJson(params: Option[JArray]) = params match {
-      case None | Some(JArray(Nil)) => Right(ChainIdRequest())
-      case other => Left(InvalidParams("eth_chainId method does not take params"))
-    }
-
+  implicit val eth_chainId = new NoParamsDecoder(ChainIdRequest()) with JsonEncoder[ChainIdResponse] {
     def encodeJson(t: ChainIdResponse) = encodeAsHex(t.value)
   }
 
-  implicit val eth_blockNumber = new JsonDecoder[BestBlockNumberRequest] with JsonEncoder[BestBlockNumberResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, BestBlockNumberRequest] = Right(
-      BestBlockNumberRequest()
-    )
-
+  implicit val eth_blockNumber = new NoParamsDecoder(BestBlockNumberRequest())
+    with JsonEncoder[BestBlockNumberResponse] {
     override def encodeJson(t: BestBlockNumberResponse): JValue = Extraction.decompose(t.bestBlockNumber)
   }
 
@@ -53,50 +43,25 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
     override def encodeJson(t: SubmitHashRateResponse): JValue = JBool(t.success)
   }
 
-  implicit val eth_gasPrice = new JsonDecoder[GetGasPriceRequest] with JsonEncoder[GetGasPriceResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetGasPriceRequest] = params match {
-      case None | Some(JArray(Nil)) => Right(GetGasPriceRequest())
-      case Some(_) => Left(InvalidParams())
-    }
-
+  implicit val eth_gasPrice = new NoParamsDecoder(GetGasPriceRequest()) with JsonEncoder[GetGasPriceResponse] {
     override def encodeJson(t: GetGasPriceResponse): JValue = encodeAsHex(t.price)
   }
 
-  implicit val eth_mining = new JsonDecoder[GetMiningRequest] with JsonEncoder[GetMiningResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetMiningRequest] = params match {
-      case None | Some(JArray(Nil)) => Right(GetMiningRequest())
-      case Some(_) => Left(InvalidParams())
-    }
-
+  implicit val eth_mining = new NoParamsDecoder(GetMiningRequest()) with JsonEncoder[GetMiningResponse] {
     override def encodeJson(t: GetMiningResponse): JValue = JBool(t.isMining)
   }
 
-  implicit val eth_hashrate = new JsonDecoder[GetHashRateRequest] with JsonEncoder[GetHashRateResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetHashRateRequest] = params match {
-      case None | Some(JArray(Nil)) => Right(GetHashRateRequest())
-      case Some(_) => Left(InvalidParams())
-    }
-
+  implicit val eth_hashrate = new NoParamsDecoder(GetHashRateRequest()) with JsonEncoder[GetHashRateResponse] {
     override def encodeJson(t: GetHashRateResponse): JsonAST.JValue = encodeAsHex(t.hashRate)
   }
 
-  implicit val eth_coinbase = new JsonDecoder[GetCoinbaseRequest] with JsonEncoder[GetCoinbaseResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetCoinbaseRequest] = params match {
-      case None | Some(JArray(Nil)) => Right(GetCoinbaseRequest())
-      case Some(_) => Left(InvalidParams())
-    }
-
+  implicit val eth_coinbase = new NoParamsDecoder(GetCoinbaseRequest()) with JsonEncoder[GetCoinbaseResponse] {
     override def encodeJson(t: GetCoinbaseResponse): JsonAST.JValue = {
       encodeAsHex(t.address.bytes)
     }
   }
 
-  implicit val eth_getWork = new JsonDecoder[GetWorkRequest] with JsonEncoder[GetWorkResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetWorkRequest] = params match {
-      case None | Some(JArray(Nil)) => Right(GetWorkRequest())
-      case Some(_) => Left(InvalidParams())
-    }
-
+  implicit val eth_getWork = new NoParamsDecoder(GetWorkRequest()) with JsonEncoder[GetWorkResponse] {
     override def encodeJson(t: GetWorkResponse): JsonAST.JValue = {
       val powHeaderHash = encodeAsHex(t.powHeaderHash)
       val dagSeed = encodeAsHex(t.dagSeed)
@@ -267,9 +232,7 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
     }
   }
 
-  implicit val eth_syncing = new JsonDecoder[SyncingRequest] with JsonEncoder[SyncingResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, SyncingRequest] = Right(SyncingRequest())
-
+  implicit val eth_syncing = new NoParamsDecoder(SyncingRequest()) with JsonEncoder[SyncingResponse] {
     def encodeJson(t: SyncingResponse): JValue = t.syncStatus match {
       case Some(syncStatus) => Extraction.decompose(syncStatus)
       case None => false
@@ -445,15 +408,9 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
       }
   }
 
-  implicit val eth_newBlockFilter = new JsonDecoder[NewBlockFilterRequest] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, NewBlockFilterRequest] =
-      Right(NewBlockFilterRequest())
-  }
+  implicit val eth_newBlockFilter = new NoParamsDecoder(NewBlockFilterRequest()) {}
 
-  implicit val eth_newPendingTransactionFilter = new JsonDecoder[NewPendingTransactionFilterRequest] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, NewPendingTransactionFilterRequest] =
-      Right(NewPendingTransactionFilterRequest())
-  }
+  implicit val eth_newPendingTransactionFilter = new NoParamsDecoder(NewPendingTransactionFilterRequest()) {}
 
   implicit val eth_uninstallFilter = new JsonDecoder[UninstallFilterRequest] with JsonEncoder[UninstallFilterResponse] {
     def decodeJson(params: Option[JArray]): Either[JsonRpcError, UninstallFilterRequest] =

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
@@ -6,7 +6,8 @@ import akka.util.ByteString
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain.Address
 import io.iohk.ethereum.jsonrpc.EthService.BlockParam
-import io.iohk.ethereum.jsonrpc.JsonRpcController.{JsonDecoder, JsonEncoder}
+import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonDecoder.NoParamsDecoder
+import io.iohk.ethereum.jsonrpc.JsonRpcController.{Codec, JsonDecoder, JsonEncoder}
 import io.iohk.ethereum.jsonrpc.JsonRpcErrors.InvalidParams
 import io.iohk.ethereum.jsonrpc.JsonSerializers.{
   AddressJsonSerializer,
@@ -26,8 +27,6 @@ import org.bouncycastle.util.encoders.Hex
 import scala.util.Try
 
 trait JsonMethodsImplicits {
-
-  trait Codec[Req, Res] extends JsonDecoder[Req] with JsonEncoder[Res]
 
   implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
     QuantitiesSerializer + UnformattedDataJsonSerializer + AddressJsonSerializer
@@ -165,25 +164,20 @@ object JsonMethodsImplicits extends JsonMethodsImplicits {
     override def encodeJson(t: Sha3Response): JValue = encodeAsHex(t.data)
   }
 
-  implicit val web3_clientVersion = new JsonDecoder[ClientVersionRequest] with JsonEncoder[ClientVersionResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, ClientVersionRequest] = Right(
-      ClientVersionRequest()
-    )
+  implicit val web3_clientVersion = new NoParamsDecoder(ClientVersionRequest())
+    with JsonEncoder[ClientVersionResponse] {
     override def encodeJson(t: ClientVersionResponse): JValue = t.value
   }
 
-  implicit val net_version = new JsonDecoder[VersionRequest] with JsonEncoder[VersionResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, VersionRequest] = Right(VersionRequest())
+  implicit val net_version = new NoParamsDecoder(VersionRequest()) with JsonEncoder[VersionResponse] {
     override def encodeJson(t: VersionResponse): JValue = t.value
   }
 
-  implicit val net_listening = new JsonDecoder[ListeningRequest] with JsonEncoder[ListeningResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, ListeningRequest] = Right(ListeningRequest())
+  implicit val net_listening = new NoParamsDecoder(ListeningRequest()) with JsonEncoder[ListeningResponse] {
     override def encodeJson(t: ListeningResponse): JValue = t.value
   }
 
-  implicit val net_peerCount = new JsonDecoder[PeerCountRequest] with JsonEncoder[PeerCountResponse] {
-    override def decodeJson(params: Option[JArray]): Either[JsonRpcError, PeerCountRequest] = Right(PeerCountRequest())
+  implicit val net_peerCount = new NoParamsDecoder(PeerCountRequest()) with JsonEncoder[PeerCountResponse] {
     override def encodeJson(t: PeerCountResponse): JValue = encodeAsHex(t.value)
   }
 
@@ -213,10 +207,8 @@ object JsonMethodsImplicits extends JsonMethodsImplicits {
       JString(t.address.toString)
   }
 
-  implicit val personal_listAccounts = new JsonDecoder[ListAccountsRequest] with JsonEncoder[ListAccountsResponse] {
-    def decodeJson(params: Option[JArray]): Either[JsonRpcError, ListAccountsRequest] =
-      Right(ListAccountsRequest())
-
+  implicit val personal_listAccounts = new NoParamsDecoder(ListAccountsRequest())
+    with JsonEncoder[ListAccountsResponse] {
     def encodeJson(t: ListAccountsResponse): JValue =
       JArray(t.addresses.map(a => JString(a.toString)))
   }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -10,10 +10,12 @@ import org.json4s.JsonAST.{JArray, JValue}
 import org.json4s.JsonDSL._
 import com.typesafe.config.{Config => TypesafeConfig}
 import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInfoResponse}
+import io.iohk.ethereum.jsonrpc.JsonRpcErrors.InvalidParams
 import io.iohk.ethereum.jsonrpc.QAService.{GetPendingTransactionsRequest, GetPendingTransactionsResponse}
 import io.iohk.ethereum.jsonrpc.TestService._
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer.JsonRpcHttpServerConfig
 import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer.JsonRpcIpcServerConfig
+
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.FiniteDuration
@@ -23,9 +25,30 @@ object JsonRpcController {
   trait JsonDecoder[T] {
     def decodeJson(params: Option[JArray]): Either[JsonRpcError, T]
   }
+  object JsonDecoder {
+    abstract class NoParamsDecoder[T](request: => T) extends JsonDecoder[T] {
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, T] =
+        params match {
+          case None | Some(JArray(Nil)) => Right(request)
+          case _ => Left(InvalidParams(s"No parameters expected"))
+        }
+    }
+  }
 
   trait JsonEncoder[T] {
     def encodeJson(t: T): JValue
+  }
+
+  trait Codec[Req, Res] extends JsonDecoder[Req] with JsonEncoder[Res]
+  object Codec {
+    import scala.language.implicitConversions
+
+    implicit def decoderWithEncoderIntoCodec[Req, Res](
+        decEnc: JsonDecoder[Req] with JsonEncoder[Res]
+    ): Codec[Req, Res] = new Codec[Req, Res] {
+      def decodeJson(params: Option[JArray]) = decEnc.decodeJson(params)
+      def encodeJson(t: Res) = decEnc.encodeJson(t)
+    }
   }
 
   trait JsonRpcConfig {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/QAJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/QAJsonMethodsImplicits.scala
@@ -1,5 +1,7 @@
 package io.iohk.ethereum.jsonrpc
 
+import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonDecoder.NoParamsDecoder
+import io.iohk.ethereum.jsonrpc.JsonRpcController.{Codec, JsonEncoder}
 import io.iohk.ethereum.jsonrpc.JsonRpcErrors.InvalidParams
 import io.iohk.ethereum.jsonrpc.QAService.{
   GetPendingTransactionsRequest,
@@ -36,13 +38,7 @@ object QAJsonMethodsImplicits extends JsonMethodsImplicits {
     }
 
   implicit val qa_getPendingTransactions: Codec[GetPendingTransactionsRequest, GetPendingTransactionsResponse] =
-    new Codec[GetPendingTransactionsRequest, GetPendingTransactionsResponse] {
-      def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetPendingTransactionsRequest] =
-        params match {
-          case Some(JArray(Nil)) | None => Right(GetPendingTransactionsRequest())
-          case _ => Left(InvalidParams())
-        }
-
+    new NoParamsDecoder(GetPendingTransactionsRequest()) with JsonEncoder[GetPendingTransactionsResponse] {
       def encodeJson(t: GetPendingTransactionsResponse): JValue =
         JArray(t.pendingTransactions.toList.map { pendingTx: PendingTransaction =>
           encodeAsHex(pendingTx.stx.tx.hash)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -7,34 +7,39 @@ import akka.testkit.TestProbe
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.consensus._
-import io.iohk.ethereum.consensus.blocks.{ PendingBlock, PendingBlockAndState }
+import io.iohk.ethereum.consensus.blocks.{PendingBlock, PendingBlockAndState}
 import io.iohk.ethereum.consensus.ethash.blocks.EthashBlockGenerator
-import io.iohk.ethereum.{Fixtures, NormalPatience, Timeouts, crypto}
-import io.iohk.ethereum.domain.{Address, Block, BlockHeader, BlockchainImpl, UInt256, _}
 import io.iohk.ethereum.db.storage.AppStateStorage
-import io.iohk.ethereum.jsonrpc.EthService._
-import io.iohk.ethereum.ommers.OmmersPool
-import io.iohk.ethereum.transactions.PendingTransactionsManager
-import io.iohk.ethereum.utils._
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ FlatSpec, Matchers }
-
-import scala.concurrent.duration.{ Duration, FiniteDuration }
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.Await
-import io.iohk.ethereum.jsonrpc.EthService.ProtocolVersionRequest
+import io.iohk.ethereum.domain.{Address, Block, BlockHeader, BlockchainImpl, UInt256, _}
+import io.iohk.ethereum.jsonrpc.EthService.{ProtocolVersionRequest, _}
 import io.iohk.ethereum.jsonrpc.FilterManager.TxLog
 import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonRpcConfig
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.Ledger.TxResult
-import io.iohk.ethereum.ledger.{ Ledger, StxLedger }
-import io.iohk.ethereum.mpt.{ ByteArrayEncoder, ByteArraySerializable, MerklePatriciaTrie }
-import io.iohk.ethereum.transactions.PendingTransactionsManager.{ PendingTransaction, PendingTransactionsResponse }
-import org.scalamock.scalatest.MockFactory
+import io.iohk.ethereum.ledger.{Ledger, StxLedger}
+import io.iohk.ethereum.mpt.{ByteArrayEncoder, ByteArraySerializable, MerklePatriciaTrie}
+import io.iohk.ethereum.ommers.OmmersPool
+import io.iohk.ethereum.transactions.PendingTransactionsManager
+import io.iohk.ethereum.transactions.PendingTransactionsManager.{PendingTransaction, PendingTransactionsResponse}
+import io.iohk.ethereum.utils._
+import io.iohk.ethereum.{Fixtures, NormalPatience, Timeouts, crypto}
 import org.bouncycastle.util.encoders.Hex
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 
 // scalastyle:off file.size.limit
-class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockFactory with NormalPatience {
+class EthServiceSpec
+    extends FlatSpec
+    with Matchers
+    with ScalaFutures
+    with MockFactory
+    with NormalPatience
+    with TypeCheckedTripleEquals {
 
 //  behavior of "EthService"
 
@@ -51,6 +56,12 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val protocolVersion = response.futureValue.right.get.value
 
     Integer.parseInt(protocolVersion.drop(2), 16) shouldEqual currentProtocolVersion
+  }
+
+  it should "return configured chain id" in new TestSetup {
+    val Right(response) = ethService.chainId(ChainIdRequest()).futureValue
+
+    assert(response === ChainIdResponse(blockchainConfig.chainId))
   }
 
   it should "answer eth_getBlockTransactionCountByHash with None when the requested block isn't in the blockchain" in new TestSetup {
@@ -86,10 +97,13 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     val invalidTxIndex = blockToRequest.body.transactionList.size
     val requestWithInvalidIndex = GetTransactionByBlockHashAndIndexRequest(blockToRequest.header.hash, invalidTxIndex)
-    val response = Await.result(
-      ethService.getTransactionByBlockHashAndIndexRequest(requestWithInvalidIndex),
-      Duration.Inf
-    ).right.get
+    val response = Await
+      .result(
+        ethService.getTransactionByBlockHashAndIndexRequest(requestWithInvalidIndex),
+        Duration.Inf
+      )
+      .right
+      .get
 
     response.transactionResponse shouldBe None
   }
@@ -111,12 +125,14 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     (appStateStorage.getBestBlockNumber _: () ⇒ BigInt).expects().returns(blockToRequest.header.number)
 
-    (blockGenerator.getPendingBlockAndState _).expects().returns(Some(PendingBlockAndState(PendingBlock(blockToRequest, Nil), fakeWorld)))
+    (blockGenerator.getPendingBlockAndState _)
+      .expects()
+      .returns(Some(PendingBlockAndState(PendingBlock(blockToRequest, Nil), fakeWorld)))
 
     val request = BlockByNumberRequest(BlockParam.Pending, fullTxs = true)
     val response = ethService.getBlockByNumber(request).futureValue.right.get
 
-    response.blockResponse.isDefined should be (true)
+    response.blockResponse.isDefined should be(true)
     val blockResponse = response.blockResponse.get
 
     blockResponse.hash shouldBe None
@@ -129,7 +145,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     (ledger.consensus _: (() ⇒ Consensus)).expects().returns(consensus)
 
-    blockchain.storeBlock(blockToRequest)
+    blockchain
+      .storeBlock(blockToRequest)
       .and(blockchain.storeTotalDifficulty(blockToRequestHash, blockTd))
       .commit()
     blockchain.saveBestKnownBlock(blockToRequest.header.number)
@@ -148,7 +165,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "answer eth_getBlockByNumber with the block response correctly when it's totalDifficulty is in blockchain" in new TestSetup {
-    blockchain.storeBlock(blockToRequest)
+    blockchain
+      .storeBlock(blockToRequest)
       .and(blockchain.storeTotalDifficulty(blockToRequestHash, blockTd))
       .commit()
 
@@ -180,14 +198,17 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "answer eth_getBlockByNumber with the block response correctly when the txs should be hashed" in new TestSetup {
-    blockchain.storeBlock(blockToRequest)
+    blockchain
+      .storeBlock(blockToRequest)
       .and(blockchain.storeTotalDifficulty(blockToRequestHash, blockTd))
       .commit()
 
     val request = BlockByNumberRequest(BlockParam.WithNumber(blockToRequestNumber), fullTxs = true)
     val response = Await.result(ethService.getBlockByNumber(request.copy(fullTxs = false)), Duration.Inf).right.get
 
-    response.blockResponse shouldBe Some(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+    response.blockResponse shouldBe Some(
+      BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd))
+    )
     response.blockResponse.get.totalDifficulty shouldBe Some(blockTd)
     response.blockResponse.get.transactions.left.toOption shouldBe Some(blockToRequest.body.transactionList.map(_.hash))
   }
@@ -199,7 +220,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "answer eth_getBlockByHash with the block response correctly when it's totalDifficulty is in blockchain" in new TestSetup {
-    blockchain.storeBlock(blockToRequest)
+    blockchain
+      .storeBlock(blockToRequest)
       .and(blockchain.storeTotalDifficulty(blockToRequestHash, blockTd))
       .commit()
 
@@ -231,14 +253,17 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "answer eth_getBlockByHash with the block response correctly when the txs should be hashed" in new TestSetup {
-    blockchain.storeBlock(blockToRequest)
+    blockchain
+      .storeBlock(blockToRequest)
       .and(blockchain.storeTotalDifficulty(blockToRequestHash, blockTd))
       .commit()
 
     val request = BlockByBlockHashRequest(blockToRequestHash, fullTxs = true)
     val response = Await.result(ethService.getByBlockHash(request.copy(fullTxs = false)), Duration.Inf).right.get
 
-    response.blockResponse shouldBe Some(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+    response.blockResponse shouldBe Some(
+      BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd))
+    )
     response.blockResponse.get.totalDifficulty shouldBe Some(blockTd)
     response.blockResponse.get.transactions.left.toOption shouldBe Some(blockToRequest.body.transactionList.map(_.hash))
   }
@@ -265,8 +290,10 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockHashAndIndexRequest(blockToRequestHash, uncleIndexToRequest)
-    val response1 = Await.result(ethService.getUncleByBlockHashAndIndex(request.copy(uncleIndex = 1)), Duration.Inf).right.get
-    val response2 = Await.result(ethService.getUncleByBlockHashAndIndex(request.copy(uncleIndex = -1)), Duration.Inf).right.get
+    val response1 =
+      Await.result(ethService.getUncleByBlockHashAndIndex(request.copy(uncleIndex = 1)), Duration.Inf).right.get
+    val response2 =
+      Await.result(ethService.getUncleByBlockHashAndIndex(request.copy(uncleIndex = -1)), Duration.Inf).right.get
 
     response1.uncleBlockResponse shouldBe None
     response2.uncleBlockResponse shouldBe None
@@ -286,7 +313,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "anwer eth_getUncleByBlockHashAndIndex correctly when the requested index has one and there's total difficulty for it" in new TestSetup {
-    blockchain.storeBlock(blockToRequestWithUncles)
+    blockchain
+      .storeBlock(blockToRequestWithUncles)
       .and(blockchain.storeTotalDifficulty(uncle.hash, uncleTd))
       .commit()
 
@@ -322,8 +350,10 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     val uncleIndexToRequest = 0
     val request = UncleByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequestNumber), uncleIndexToRequest)
-    val response1 = Await.result(ethService.getUncleByBlockNumberAndIndex(request.copy(uncleIndex = 1)), Duration.Inf).right.get
-    val response2 = Await.result(ethService.getUncleByBlockNumberAndIndex(request.copy(uncleIndex = -1)), Duration.Inf).right.get
+    val response1 =
+      Await.result(ethService.getUncleByBlockNumberAndIndex(request.copy(uncleIndex = 1)), Duration.Inf).right.get
+    val response2 =
+      Await.result(ethService.getUncleByBlockNumberAndIndex(request.copy(uncleIndex = -1)), Duration.Inf).right.get
 
     response1.uncleBlockResponse shouldBe None
     response2.uncleBlockResponse shouldBe None
@@ -343,7 +373,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   }
 
   it should "anwer eth_getUncleByBlockNumberAndIndex correctly when the requested index has one and there's total difficulty for it" in new TestSetup {
-    blockchain.storeBlock(blockToRequestWithUncles)
+    blockchain
+      .storeBlock(blockToRequestWithUncles)
       .and(blockchain.storeTotalDifficulty(uncle.hash, uncleTd))
       .commit()
 
@@ -364,11 +395,15 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     val response = ethService.syncing(SyncingRequest()).futureValue.right.get
 
-    response shouldEqual SyncingResponse(Some(EthService.SyncingStatus(
-      startingBlock = 999,
-      currentBlock = 200,
-      highestBlock = 10000
-    )))
+    response shouldEqual SyncingResponse(
+      Some(
+        EthService.SyncingStatus(
+          startingBlock = 999,
+          currentBlock = 200,
+          highestBlock = 10000
+        )
+      )
+    )
   }
 
   // scalastyle:off magic.number
@@ -429,14 +464,24 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     blockchain.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlock(blockToRequest.header.number)
 
-    val txResult = TxResult(BlockchainImpl(storagesInstance.storages).getWorldStateProxy(-1, UInt256.Zero, None,
-      noEmptyAccounts = false, ethCompatibleStorage = true), 123, Nil, ByteString("return_value"), None)
+    val txResult = TxResult(
+      BlockchainImpl(storagesInstance.storages)
+        .getWorldStateProxy(-1, UInt256.Zero, None, noEmptyAccounts = false, ethCompatibleStorage = true),
+      123,
+      Nil,
+      ByteString("return_value"),
+      None
+    )
     (stxLedger.simulateTransaction _).expects(*, *, *).returning(txResult)
 
     val tx = CallTx(
       Some(ByteString(Hex.decode("da714fe079751fa7a1ad80b76571ea6ec52a446c"))),
       Some(ByteString(Hex.decode("abbb6bebfa05aa13e908eaa492bd7a8343760477"))),
-      Some(1), 2, 3, ByteString(""))
+      Some(1),
+      2,
+      3,
+      ByteString("")
+    )
     val response = ethService.call(CallRequest(tx, BlockParam.Latest))
 
     response.futureValue shouldEqual Right(CallResponse(ByteString("return_value")))
@@ -452,7 +497,11 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val tx = CallTx(
       Some(ByteString(Hex.decode("da714fe079751fa7a1ad80b76571ea6ec52a446c"))),
       Some(ByteString(Hex.decode("abbb6bebfa05aa13e908eaa492bd7a8343760477"))),
-      Some(1), 2, 3, ByteString(""))
+      Some(1),
+      2,
+      3,
+      ByteString("")
+    )
     val response = ethService.estimateGas(CallRequest(tx, BlockParam.Latest))
 
     response.futureValue shouldEqual Right(EstimateGasResponse(123))
@@ -478,18 +527,25 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
   it should "get transaction count by block number" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
 
-    val response = ethService.getBlockTransactionCountByNumber(GetBlockTransactionCountByNumberRequest(BlockParam.WithNumber(blockToRequest.header.number)))
+    val response = ethService.getBlockTransactionCountByNumber(
+      GetBlockTransactionCountByNumberRequest(BlockParam.WithNumber(blockToRequest.header.number))
+    )
 
-    response.futureValue shouldEqual Right(GetBlockTransactionCountByNumberResponse(blockToRequest.body.transactionList.size))
+    response.futureValue shouldEqual Right(
+      GetBlockTransactionCountByNumberResponse(blockToRequest.body.transactionList.size)
+    )
   }
 
   it should "get transaction count by latest block number" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
     blockchain.saveBestKnownBlock(blockToRequest.header.number)
 
-    val response = ethService.getBlockTransactionCountByNumber(GetBlockTransactionCountByNumberRequest(BlockParam.Latest))
+    val response =
+      ethService.getBlockTransactionCountByNumber(GetBlockTransactionCountByNumberRequest(BlockParam.Latest))
 
-    response.futureValue shouldEqual Right(GetBlockTransactionCountByNumberResponse(blockToRequest.body.transactionList.size))
+    response.futureValue shouldEqual Right(
+      GetBlockTransactionCountByNumberResponse(blockToRequest.body.transactionList.size)
+    )
   }
 
   it should "handle getCode request" in new TestSetup {
@@ -500,7 +556,10 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     val mpt =
       MerklePatriciaTrie[Array[Byte], Account](storagesInstance.storages.stateStorage.getBackingStorage(0))
-        .put(crypto.kec256(address.bytes.toArray[Byte]), Account(0, UInt256(0), ByteString(""), ByteString("code hash")))
+        .put(
+          crypto.kec256(address.bytes.toArray[Byte]),
+          Account(0, UInt256(0), ByteString(""), ByteString("code hash"))
+        )
 
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
@@ -519,7 +578,9 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val id = ByteString("id")
 
     ethService.submitHashRate(SubmitHashRateRequest(12, id)).futureValue shouldEqual Right(SubmitHashRateResponse(true))
-    ethService.submitHashRate(SubmitHashRateRequest(rate, id)).futureValue shouldEqual Right(SubmitHashRateResponse(true))
+    ethService.submitHashRate(SubmitHashRateRequest(rate, id)).futureValue shouldEqual Right(
+      SubmitHashRateResponse(true)
+    )
 
     val response = ethService.getHashRate(GetHashRateRequest())
     response.futureValue shouldEqual Right(GetHashRateResponse(rate))
@@ -532,9 +593,13 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val id1 = ByteString("id1")
     val id2 = ByteString("id2")
 
-    ethService.submitHashRate(SubmitHashRateRequest(rate, id1)).futureValue shouldEqual Right(SubmitHashRateResponse(true))
+    ethService.submitHashRate(SubmitHashRateRequest(rate, id1)).futureValue shouldEqual Right(
+      SubmitHashRateResponse(true)
+    )
     Thread.sleep(minerActiveTimeout.toMillis / 2)
-    ethService.submitHashRate(SubmitHashRateRequest(rate, id2)).futureValue shouldEqual Right(SubmitHashRateResponse(true))
+    ethService.submitHashRate(SubmitHashRateRequest(rate, id2)).futureValue shouldEqual Right(
+      SubmitHashRateResponse(true)
+    )
 
     val response1 = ethService.getHashRate(GetHashRateRequest())
     response1.futureValue shouldEqual Right(GetHashRateResponse(rate * 2))
@@ -565,7 +630,9 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     (blockGenerator.getPrepared _).expects(*).returning(Some(PendingBlock(block, Nil)))
     (appStateStorage.getBestBlockNumber _).expects().returning(0)
-    ethService.submitWork(SubmitWorkRequest(ByteString("nonce"), ByteString(Hex.decode("01" * 32)), ByteString(Hex.decode("01" * 32))))
+    ethService.submitWork(
+      SubmitWorkRequest(ByteString("nonce"), ByteString(Hex.decode("01" * 32)), ByteString(Hex.decode("01" * 32)))
+    )
 
     val response = ethService.getMining(GetMiningRequest())
 
@@ -614,7 +681,9 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
   it should "return average gas price" in new TestSetup {
     blockchain.saveBestKnownBlock(42)
-    blockchain.storeBlock(Block(Fixtures.Blocks.Block3125369.header.copy(number = 42), Fixtures.Blocks.Block3125369.body)).commit()
+    blockchain
+      .storeBlock(Block(Fixtures.Blocks.Block3125369.header.copy(number = 42), Fixtures.Blocks.Block3125369.body))
+      .commit()
 
     val response = ethService.getGetGasPrice(GetGasPriceRequest())
     response.futureValue shouldEqual Right(GetGasPriceResponse(BigInt("20000000000")))
@@ -628,7 +697,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val request = GetTransactionByBlockNumberAndIndexRequest(BlockParam.Latest, txIndex)
     val response = Await.result(ethService.getTransactionByBlockNumberAndIndexRequest(request), Duration.Inf).right.get
 
-    val expectedTxResponse = TransactionResponse(blockToRequest.body.transactionList(txIndex), Some(blockToRequest.header), Some(txIndex))
+    val expectedTxResponse =
+      TransactionResponse(blockToRequest.body.transactionList(txIndex), Some(blockToRequest.header), Some(txIndex))
     response.transactionResponse shouldBe Some(expectedTxResponse)
   }
 
@@ -636,7 +706,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     blockchain.storeBlock(blockToRequest).commit()
 
     val txIndex: Int = blockToRequest.body.transactionList.length + 42
-    val request = GetTransactionByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequest.header.number), txIndex)
+    val request =
+      GetTransactionByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequest.header.number), txIndex)
     val response = Await.result(ethService.getTransactionByBlockNumberAndIndexRequest(request), Duration.Inf).right.get
 
     response.transactionResponse shouldBe None
@@ -646,7 +717,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     blockchain.storeBlock(blockToRequest).commit()
 
     val txIndex: Int = 1
-    val request = GetTransactionByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequest.header.number - 42), txIndex)
+    val request =
+      GetTransactionByBlockNumberAndIndexRequest(BlockParam.WithNumber(blockToRequest.header.number - 42), txIndex)
     val response = Await.result(ethService.getTransactionByBlockNumberAndIndexRequest(request), Duration.Inf).right.get
 
     response.transactionResponse shouldBe None
@@ -659,13 +731,15 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
 
     val mpt =
       MerklePatriciaTrie[Array[Byte], Account](storagesInstance.storages.stateStorage.getBackingStorage(0))
-        .put(crypto.kec256(address.bytes.toArray[Byte]), Account(0, UInt256(123), ByteString(""), ByteString("code hash")))
+        .put(
+          crypto.kec256(address.bytes.toArray[Byte]),
+          Account(0, UInt256(123), ByteString(""), ByteString("code hash"))
+        )
 
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchain.storeBlock(newblock).commit()
     blockchain.saveBestKnownBlock(newblock.header.number)
-
 
     val response = ethService.getBalance(GetBalanceRequest(address, BlockParam.Latest))
 
@@ -689,13 +763,19 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     }
 
     val storageMpt =
-      io.iohk.ethereum.domain.EthereumUInt256Mpt.storageMpt(ByteString(MerklePatriciaTrie.EmptyRootHash),
-        storagesInstance.storages.stateStorage.getBackingStorage(0))
+      io.iohk.ethereum.domain.EthereumUInt256Mpt
+        .storageMpt(
+          ByteString(MerklePatriciaTrie.EmptyRootHash),
+          storagesInstance.storages.stateStorage.getBackingStorage(0)
+        )
         .put(UInt256(333), UInt256(123))
 
     val mpt =
       MerklePatriciaTrie[Array[Byte], Account](storagesInstance.storages.stateStorage.getBackingStorage(0))
-        .put(crypto.kec256(address.bytes.toArray[Byte]), Account(0, UInt256(0), ByteString(storageMpt.getRootHash), ByteString("")))
+        .put(
+          crypto.kec256(address.bytes.toArray[Byte]),
+          Account(0, UInt256(0), ByteString(storageMpt.getRootHash), ByteString(""))
+        )
 
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
@@ -744,7 +824,9 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val response = ethService.getTransactionByHash(request)
 
     pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
-    pendingTransactionsManager.reply(PendingTransactionsResponse(Seq(PendingTransaction(txToRequestWithSender, System.currentTimeMillis))))
+    pendingTransactionsManager.reply(
+      PendingTransactionsResponse(Seq(PendingTransaction(txToRequestWithSender, System.currentTimeMillis)))
+    )
 
     response.futureValue shouldEqual Right(GetTransactionByHashResponse(Some(TransactionResponse(txToRequest))))
   }
@@ -761,41 +843,55 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
     pendingTransactionsManager.reply(PendingTransactionsResponse(Nil))
 
-    response.futureValue shouldEqual Right(GetTransactionByHashResponse(Some(
-      TransactionResponse(txToRequest, Some(blockWithTx.header), Some(0)))))
+    response.futureValue shouldEqual Right(
+      GetTransactionByHashResponse(Some(TransactionResponse(txToRequest, Some(blockWithTx.header), Some(0))))
+    )
   }
 
   it should "calculate correct contract address for contract creating by transaction" in new TestSetup {
     val body = BlockBody(Seq(Fixtures.Blocks.Block3125369.body.transactionList.head, contractCreatingTransaction), Nil)
     val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, body)
     val gasUsedByTx = 4242
-    blockchain.storeBlock(blockWithTx)
-      .and(blockchain.storeReceipts(Fixtures.Blocks.Block3125369.header.hash,
-        Seq(fakeReceipt, fakeReceipt.copy(cumulativeGasUsed = fakeReceipt.cumulativeGasUsed + gasUsedByTx))))
+    blockchain
+      .storeBlock(blockWithTx)
+      .and(
+        blockchain.storeReceipts(
+          Fixtures.Blocks.Block3125369.header.hash,
+          Seq(fakeReceipt, fakeReceipt.copy(cumulativeGasUsed = fakeReceipt.cumulativeGasUsed + gasUsedByTx))
+        )
+      )
       .commit()
 
     val request = GetTransactionReceiptRequest(contractCreatingTransaction.hash)
     val response = ethService.getTransactionReceipt(request)
 
-    response.futureValue shouldEqual Right(GetTransactionReceiptResponse(Some(
-      TransactionReceiptResponse(
-        transactionHash = contractCreatingTransaction.hash,
-        transactionIndex = 1,
-        blockNumber = Fixtures.Blocks.Block3125369.header.number,
-        blockHash = Fixtures.Blocks.Block3125369.header.hash,
-        cumulativeGasUsed = fakeReceipt.cumulativeGasUsed + gasUsedByTx,
-        gasUsed = gasUsedByTx,
-        contractAddress = Some(createdContractAddress),
-        logs = Seq(TxLog(
-          logIndex = 0,
-          transactionIndex = 1,
-          transactionHash = contractCreatingTransaction.hash,
-          blockHash = Fixtures.Blocks.Block3125369.header.hash,
-          blockNumber = Fixtures.Blocks.Block3125369.header.number,
-          address = fakeReceipt.logs.head.loggerAddress,
-          data = fakeReceipt.logs.head.data,
-          topics = fakeReceipt.logs.head.logTopics
-        ))))))
+    response.futureValue shouldEqual Right(
+      GetTransactionReceiptResponse(
+        Some(
+          TransactionReceiptResponse(
+            transactionHash = contractCreatingTransaction.hash,
+            transactionIndex = 1,
+            blockNumber = Fixtures.Blocks.Block3125369.header.number,
+            blockHash = Fixtures.Blocks.Block3125369.header.hash,
+            cumulativeGasUsed = fakeReceipt.cumulativeGasUsed + gasUsedByTx,
+            gasUsed = gasUsedByTx,
+            contractAddress = Some(createdContractAddress),
+            logs = Seq(
+              TxLog(
+                logIndex = 0,
+                transactionIndex = 1,
+                transactionHash = contractCreatingTransaction.hash,
+                blockHash = Fixtures.Blocks.Block3125369.header.hash,
+                blockNumber = Fixtures.Blocks.Block3125369.header.number,
+                address = fakeReceipt.logs.head.loggerAddress,
+                data = fakeReceipt.logs.head.data,
+                topics = fakeReceipt.logs.head.logTopics
+              )
+            )
+          )
+        )
+      )
+    )
   }
 
   it should "return account recent transactions in newest -> oldest order" in new TestSetup {
@@ -809,13 +905,16 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val tx2 = SignedTransaction.sign(Transaction(0, 123, 456, Some(address), 2, ByteString()), keyPair, None).tx
     val tx3 = SignedTransaction.sign(Transaction(0, 123, 456, Some(address), 3, ByteString()), keyPair, None).tx
 
-    val blockWithTx1 = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body.copy(
-      transactionList = Seq(tx1)))
+    val blockWithTx1 =
+      Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body.copy(transactionList = Seq(tx1)))
 
-    val blockWithTxs2and3 = Block(Fixtures.Blocks.Block3125369.header.copy(number = 3125370), Fixtures.Blocks.Block3125369.body.copy(
-      transactionList = Seq(tx2, tx3)))
+    val blockWithTxs2and3 = Block(
+      Fixtures.Blocks.Block3125369.header.copy(number = 3125370),
+      Fixtures.Blocks.Block3125369.body.copy(transactionList = Seq(tx2, tx3))
+    )
 
-    blockchain.storeBlock(blockWithTx1)
+    blockchain
+      .storeBlock(blockWithTx1)
       .and(blockchain.storeBlock(blockWithTxs2and3))
       .commit()
 
@@ -830,17 +929,16 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
         tx3,
         blockHeader = Some(blockWithTxs2and3.header),
         pending = Some(false),
-        isOutgoing = Some(false)),
+        isOutgoing = Some(false)
+      ),
       TransactionResponse(
         tx2,
         blockHeader = Some(blockWithTxs2and3.header),
         pending = Some(false),
-        isOutgoing = Some(false)),
-      TransactionResponse(
-        tx1,
-        blockHeader = Some(blockWithTx1.header),
-        pending = Some(false),
-        isOutgoing = Some(false)))
+        isOutgoing = Some(false)
+      ),
+      TransactionResponse(tx1, blockHeader = Some(blockWithTx1.header), pending = Some(false), isOutgoing = Some(false))
+    )
 
     response.futureValue shouldEqual Right(GetAccountTransactionsResponse(expectedTxs))
   }
@@ -863,7 +961,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     pendingTransactionsManager.expectMsg(PendingTransactionsManager.GetPendingTransactions)
     pendingTransactionsManager.reply(PendingTransactionsResponse(Seq(pendingTx)))
 
-    val expectedSent = Seq(TransactionResponse(signedTx.tx, blockHeader = None, pending = Some(true), isOutgoing = Some(true)))
+    val expectedSent =
+      Seq(TransactionResponse(signedTx.tx, blockHeader = None, pending = Some(true), isOutgoing = Some(true)))
 
     response.futureValue shouldEqual Right(GetAccountTransactionsResponse(expectedSent))
   }
@@ -876,9 +975,8 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     override lazy val ledger = mock[Ledger]
     override lazy val stxLedger = mock[StxLedger]
 
-    override lazy val blockchainConfig = BlockchainConfig (
+    override lazy val blockchainConfig = BlockchainConfig(
       ethCompatibleStorage = true,
-
       //unused
       eip155BlockNumber = 0,
       chainId = 0x03.toByte,
@@ -959,7 +1057,6 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val uncleTd = uncle.difficulty
     val blockToRequestWithUncles = blockToRequest.copy(body = BlockBody(Nil, Seq(uncle)))
 
-
     val difficulty = 131072
     val parentBlock = Block(
       header = BlockHeader(
@@ -1013,37 +1110,48 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val r = ByteString(Hex.decode("b3493e863e48a8d67572910933114a4c0e49dac0cb199e01df1575f35141a881"))
     val s = ByteString(Hex.decode("5ba423ae55087e013686f89ad71a449093745f7edb4eb39f30acd30a8964522d"))
 
-    val payload = ByteString(Hex.decode("60606040526040516101e43803806101e483398101604052808051820191906020018051906020019091908051" +
-      "9060200190919050505b805b83835b600060018351016001600050819055503373ffffffffffffffffffffffff" +
-      "ffffffffffffffff16600260005060016101008110156100025790900160005b50819055506001610102600050" +
-      "60003373ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600050819055" +
-      "50600090505b82518110156101655782818151811015610002579060200190602002015173ffffffffffffffff" +
-      "ffffffffffffffffffffffff166002600050826002016101008110156100025790900160005b50819055508060" +
-      "0201610102600050600085848151811015610002579060200190602002015173ffffffffffffffffffffffffff" +
-      "ffffffffffffff168152602001908152602001600020600050819055505b80600101905080506100b9565b8160" +
-      "00600050819055505b50505080610105600050819055506101866101a3565b610107600050819055505b505b50" +
-      "5050602f806101b56000396000f35b600062015180420490506101b2565b905636600080376020600036600073" +
-      "6ab9dd83108698b9ca8d03af3c7eb91c0e54c3fc60325a03f41560015760206000f30000000000000000000000" +
-      "000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000" +
-      "000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000" +
-      "0000000000000000000000000000000000000000000000000000020000000000000000000000006c9fbd9a7f06" +
-      "d62ce37db2ab1e1b0c288edc797a000000000000000000000000c482d695f42b07e0d6a22925d7e49b46fd9a3f80"))
+    val payload = ByteString(
+      Hex.decode(
+        "60606040526040516101e43803806101e483398101604052808051820191906020018051906020019091908051" +
+          "9060200190919050505b805b83835b600060018351016001600050819055503373ffffffffffffffffffffffff" +
+          "ffffffffffffffff16600260005060016101008110156100025790900160005b50819055506001610102600050" +
+          "60003373ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600050819055" +
+          "50600090505b82518110156101655782818151811015610002579060200190602002015173ffffffffffffffff" +
+          "ffffffffffffffffffffffff166002600050826002016101008110156100025790900160005b50819055508060" +
+          "0201610102600050600085848151811015610002579060200190602002015173ffffffffffffffffffffffffff" +
+          "ffffffffffffff168152602001908152602001600020600050819055505b80600101905080506100b9565b8160" +
+          "00600050819055505b50505080610105600050819055506101866101a3565b610107600050819055505b505b50" +
+          "5050602f806101b56000396000f35b600062015180420490506101b2565b905636600080376020600036600073" +
+          "6ab9dd83108698b9ca8d03af3c7eb91c0e54c3fc60325a03f41560015760206000f30000000000000000000000" +
+          "000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000" +
+          "000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000" +
+          "0000000000000000000000000000000000000000000000000000020000000000000000000000006c9fbd9a7f06" +
+          "d62ce37db2ab1e1b0c288edc797a000000000000000000000000c482d695f42b07e0d6a22925d7e49b46fd9a3f80"
+      )
+    )
 
     //tx 0xb7b8cc9154896b25839ede4cd0c2ad193adf06489fdd9c0a9dfce05620c04ec1
-    val contractCreatingTransaction: SignedTransaction = SignedTransaction(Transaction(
-      nonce = 2550,
-      gasPrice = BigInt("20000000000"),
-      gasLimit = 3000000,
-      receivingAddress = None,
-      value = 0,
-      payload
-    ), v, r, s, 0x3d.toByte)
+    val contractCreatingTransaction: SignedTransaction = SignedTransaction(
+      Transaction(
+        nonce = 2550,
+        gasPrice = BigInt("20000000000"),
+        gasLimit = 3000000,
+        receivingAddress = None,
+        value = 0,
+        payload
+      ),
+      v,
+      r,
+      s,
+      0x3d.toByte
+    )
 
     val fakeReceipt = Receipt.withHashOutcome(
       postTransactionStateHash = ByteString(Hex.decode("01" * 32)),
       cumulativeGasUsed = 43,
       logsBloomFilter = ByteString(Hex.decode("00" * 256)),
-      logs = Seq(TxLogEntry(Address(42), Seq(ByteString(Hex.decode("01" * 32))), ByteString(Hex.decode("03" * 32)))))
+      logs = Seq(TxLogEntry(Address(42), Seq(ByteString(Hex.decode("01" * 32))), ByteString(Hex.decode("03" * 32))))
+    )
 
     val createdContractAddress = Address(Hex.decode("c1d93b46be245617e20e75978f5283c889ae048d"))
 
@@ -1052,7 +1160,12 @@ class EthServiceSpec extends FlatSpec with Matchers with ScalaFutures with MockF
     val txToRequestWithSender = SignedTransactionWithSender(txToRequest, txSender)
 
     val txToRequestHash = txToRequest.hash
-    val fakeWorld = blockchain.getReadOnlyWorldStateProxy(None, UInt256.Zero, None,
-      noEmptyAccounts = false, ethCompatibleStorage = true)
+    val fakeWorld = blockchain.getReadOnlyWorldStateProxy(
+      None,
+      UInt256.Zero,
+      None,
+      noEmptyAccounts = false,
+      ethCompatibleStorage = true
+    )
   }
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -52,6 +52,7 @@ import scala.concurrent.duration._
 class JsonRpcControllerSpec
     extends FlatSpec
     with Matchers
+    with JRCMatchers
     with ScalaCheckPropertyChecks
     with ScalaFutures
     with NormalPatience
@@ -133,6 +134,13 @@ class JsonRpcControllerSpec
     response.id shouldBe JInt(1)
     response.error shouldBe None
     response.result shouldBe Some(JString("0x3f"))
+  }
+
+  it should "handle eth_chainId" in new TestSetup {
+    val request = JsonRpcRequest("2.0", "eth_chainId", None, Some(1))
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    response should haveResult("0x3d")
   }
 
   it should "handle eth_blockNumber request" in new TestSetup {


### PR DESCRIPTION
# Description

According to Ethereum RPC Spec, Mantis lacks `eth_chainId` method, which makes it much harder to issue transactions from Luna.

PS. This PR got so big due to auto-formatting. Changes crucial for this task are really minimal (test for eth service, test for rpc controller, insomnia entry, controller entry, json codec, eth service method).

# Testing

1. All tests should pass
2. `eth_chainId` in Insomnia should return configured value in hex format according to spec (https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/etclabscore/ethereum-json-rpc-specification/master/openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false)

