### PR TITLE
[ETCM-108] Factor out mkSrc

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,7 +17,7 @@ let
 
     inherit (final.mantisPkgs) mantis;
 
-    inherit (final.mantisPkgs) mantis-unwrapped;
+    mkSrc = import sources.nix-mksrc { inherit (final) lib; };
   };
 in import sources.nixpkgs {
   inherit system;

--- a/nix/pkgs/mantis/default.nix
+++ b/nix/pkgs/mantis/default.nix
@@ -1,19 +1,4 @@
-{ src, lib, gitignoreSource, callPackage, jre }: rec {
-
-  mkSrc = src:
-    let
-      isGit = builtins.pathExists (src + "/.git");
-      repo = builtins.fetchGit { url = src; submodules = true; };
-      dirty = repo.revCount == 0;
-      filterSrc = src:
-        lib.cleanSourceWith {
-          inherit src;
-          filter = path: _: !lib.hasSuffix "nix" path;
-        };
-    in if isGit then
-      if dirty then filterSrc (gitignoreSource src) else repo
-    else
-      src;
+{ src, mkSrc, lib, gitignoreSource, callPackage, jre }: rec {
 
   mantis-source = mkSrc src;
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -35,6 +35,18 @@
         "url": "https://github.com/nmattia/niv/archive/f73bf8d584148677b01859677a63191c31911eae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "nix-mksrc": {
+        "branch": "master",
+        "description": null,
+        "homepage": "",
+        "owner": "input-output-hk",
+        "repo": "nix-mksrc",
+        "rev": "c446c2da50209f06d75df9f06f9faa738939b54d",
+        "sha256": "1mnp88fvg9rkl211zsg1mjkx0kk63l9q4fdy3a4avbq8z9bjb1gf",
+        "type": "tarball",
+        "url": "https://github.com/input-output-hk/nix-mksrc/archive/c446c2da50209f06d75df9f06f9faa738939b54d.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixkite": {
         "branch": "master",
         "description": "Nixkite is a Buildkite pipeline generation tool using the NixOS module system",


### PR DESCRIPTION
# Description

`mkSrc` is a Nix function that's supposed to do the Right Thing with the source so that its hash ends up matching Hydra.
I've factored it out to a separate git repo so that I don't have to keep copy/pasting it between projects.