### PR TITLE
[ETCM-48] Add json rpc http healthcheck

### DIFF
--- a/insomnia_workspace.json
+++ b/insomnia_workspace.json
@@ -1,7 +1,7 @@
 {
   "_type": "export",
   "__export_format": 4,
-  "__export_date": "2020-09-28T17:05:07.127Z",
+  "__export_date": "2020-09-30T20:01:40.792Z",
   "__export_source": "insomnia.desktop.app:v2020.4.1",
   "resources": [
     {
@@ -271,6 +271,35 @@
       "environmentPropertyOrder": null,
       "metaSortKey": -1553869483792,
       "_type": "request_group"
+    },
+    {
+      "_id": "req_8c4ccaa3552544a4b61bc33cc9fa547c",
+      "parentId": "fld_f75b249a780c4b5e97a0a2980ad1d4b8",
+      "modified": 1580405661758,
+      "created": 1580405461883,
+      "url": "{{ node_url }}/healthcheck",
+      "name": "healthcheck node",
+      "description": "",
+      "method": "GET",
+      "body": {},
+      "parameters": [],
+      "headers": [
+        {
+          "id": "pair_088edc31f5e04f20a16b465a673871bb",
+          "name": "Cache-Control",
+          "value": "no-cache"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1552939150156.3438,
+      "isPrivate": false,
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
     },
     {
       "_id": "req_b60c1a4f9d604d868910f967c6a070d7",

--- a/src/main/scala/io/iohk/ethereum/healthcheck/Healthcheck.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/Healthcheck.scala
@@ -1,0 +1,37 @@
+package io.iohk.ethereum.healthcheck
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/**
+  * Represents a health check, runs it and interprets the outcome.
+  * The outcome can be either a normal result, an application error, or
+  * an (unexpected) exception.
+  *
+  * @param description An one-word description of the health check.
+  * @param f           The function that runs the health check.
+  * @param mapResultToError A function that interprets the result.
+  * @param mapErrorToError  A function that interprets the application error.
+  * @param mapExceptionToError A function that interprets the (unexpected) exception.
+  * @tparam Error  The type of the application error.
+  * @tparam Result The type of the actual value expected by normal termination of `f`.
+  */
+case class Healthcheck[Error, Result](
+    description: String,
+    f: () ⇒ Future[Either[Error, Result]],
+    mapResultToError: Result ⇒ Option[String] = (_: Result) ⇒ None,
+    mapErrorToError: Error ⇒ Option[String] = (error: Error) ⇒ Some(String.valueOf(error)),
+    mapExceptionToError: Throwable ⇒ Option[String] = (t: Throwable) ⇒ Some(String.valueOf(t))
+) {
+
+  def apply()(implicit ec: ExecutionContext): Future[HealthcheckResult] = {
+    f().transform {
+      case Success(Left(error)) ⇒
+        Success(HealthcheckResult(description, mapErrorToError(error)))
+      case Success(Right(result)) ⇒
+        Success(HealthcheckResult(description, mapResultToError(result)))
+      case Failure(t) ⇒
+        Success(HealthcheckResult(description, mapExceptionToError(t)))
+    }
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResponse.scala
@@ -1,0 +1,5 @@
+package io.iohk.ethereum.healthcheck
+
+final case class HealthcheckResponse(checks: List[HealthcheckResult]) {
+  lazy val isOK: Boolean = checks.forall(_.isOK)
+}

--- a/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResult.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckResult.scala
@@ -1,0 +1,18 @@
+package io.iohk.ethereum.healthcheck
+
+final case class HealthcheckResult private (description: String, status: String, error: Option[String]) {
+  assert(
+    status == HealthcheckStatus.OK && error.isEmpty || status == HealthcheckStatus.ERROR && error.isDefined
+  )
+
+  def isOK: Boolean = status == HealthcheckStatus.OK
+}
+
+object HealthcheckResult {
+  def apply(description: String, error: Option[String]): HealthcheckResult =
+    new HealthcheckResult(
+      description = description,
+      status = error.fold(HealthcheckStatus.OK)(_ ⇒ HealthcheckStatus.ERROR),
+      error = error
+    )
+}

--- a/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckStatus.scala
+++ b/src/main/scala/io/iohk/ethereum/healthcheck/HealthcheckStatus.scala
@@ -1,0 +1,6 @@
+package io.iohk.ethereum.healthcheck
+
+object HealthcheckStatus {
+  final val OK = "OK"
+  final val ERROR = "ERROR"
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerMetrics.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerMetrics.scala
@@ -13,4 +13,6 @@ case object JsonRpcControllerMetrics extends MetricsContainer {
   final val MethodsSuccessCounter = metrics.counter("json.rpc.methods.success.counter")
   final val MethodsExceptionCounter = metrics.counter("json.rpc.methods.exception.counter")
   final val MethodsErrorCounter = metrics.counter("json.rpc.methods.error.counter")
+
+  final val HealhcheckErrorCounter = metrics.counter("json.rpc.healthcheck.error.counter")
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthChecker.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthChecker.scala
@@ -1,0 +1,21 @@
+package io.iohk.ethereum.jsonrpc
+
+import io.iohk.ethereum.healthcheck.HealthcheckResponse
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait JsonRpcHealthChecker {
+  def healthCheck(): Future[HealthcheckResponse]
+
+  def handleResponse(responseF: Future[HealthcheckResponse]): Future[HealthcheckResponse] = {
+    responseF.andThen {
+      case Success(response) if (!response.isOK) =>
+        JsonRpcControllerMetrics.HealhcheckErrorCounter.increment()
+      case Failure(t) =>
+        JsonRpcControllerMetrics.HealhcheckErrorCounter.increment()
+    }
+  }
+
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthcheck.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcHealthcheck.scala
@@ -1,0 +1,9 @@
+package io.iohk.ethereum.jsonrpc
+
+import io.iohk.ethereum.healthcheck.Healthcheck
+
+object JsonRpcHealthcheck {
+  type T[R] = Healthcheck[JsonRpcError, R]
+
+  def apply[R](description: String, f: () ⇒ ServiceResponse[R]): T[R] = Healthcheck(description, f)
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/NodeJsonRpcHealthChecker.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/NodeJsonRpcHealthChecker.scala
@@ -1,0 +1,44 @@
+package io.iohk.ethereum.jsonrpc
+
+import io.iohk.ethereum.healthcheck.HealthcheckResponse
+import io.iohk.ethereum.jsonrpc.EthService._
+import io.iohk.ethereum.jsonrpc.NetService._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class NodeJsonRpcHealthChecker(
+    netService: NetService,
+    ethService: EthService
+) extends JsonRpcHealthChecker {
+
+  protected def mainService: String = "node health"
+
+  final val listeningHC = JsonRpcHealthcheck("listening", () ⇒ netService.listening(NetService.ListeningRequest()))
+  final val peerCountHC = JsonRpcHealthcheck("peerCount", () ⇒ netService.peerCount(PeerCountRequest()))
+  final val earliestBlockHC = JsonRpcHealthcheck(
+    "earliestBlock",
+    () ⇒ ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Earliest, true))
+  )
+  final val latestBlockHC = JsonRpcHealthcheck(
+    "latestBlock",
+    () ⇒ ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Latest, true))
+  )
+  final val pendingBlockHC = JsonRpcHealthcheck(
+    "pendingBlock",
+    () ⇒ ethService.getBlockByNumber(BlockByNumberRequest(BlockParam.Pending, true))
+  )
+
+  override def healthCheck(): Future[HealthcheckResponse] = {
+    val listeningF = listeningHC()
+    val peerCountF = peerCountHC()
+    val earliestBlockF = earliestBlockHC()
+    val latestBlockF = latestBlockHC()
+    val pendingBlockF = pendingBlockHC()
+
+    val allChecksF = List(listeningF, peerCountF, earliestBlockF, latestBlockF, pendingBlockF)
+    val responseF = Future.sequence(allChecksF).map(HealthcheckResponse)
+
+    handleResponse(responseF)
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/BasicJsonRpcHttpServer.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/server/http/BasicJsonRpcHttpServer.scala
@@ -9,9 +9,13 @@ import io.iohk.ethereum.utils.Logger
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 
-class BasicJsonRpcHttpServer(val jsonRpcController: JsonRpcController, config: JsonRpcHttpServerConfig)
-                            (implicit val actorSystem: ActorSystem)
-  extends JsonRpcHttpServer with Logger {
+class BasicJsonRpcHttpServer(
+    val jsonRpcController: JsonRpcController,
+    val jsonRpcHealthChecker: JsonRpcHealthChecker,
+    config: JsonRpcHttpServerConfig
+)(implicit val actorSystem: ActorSystem)
+    extends JsonRpcHttpServer
+    with Logger {
 
   def run(): Unit = {
     val bindingResultF = Http(actorSystem).newServerAt(config.interface, config.port).bind(route)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServerSpec.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.util.ByteString
 import ch.megard.akka.http.cors.scaladsl.model.HttpOriginMatcher
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer.JsonRpcHttpServerConfig
-import io.iohk.ethereum.jsonrpc.{JsonRpcController, JsonRpcResponse}
+import io.iohk.ethereum.jsonrpc.{JsonRpcController, JsonRpcResponse, JsonRpcHealthChecker}
 import org.json4s.JsonAST.{JInt, JString}
 import org.scalamock.scalatest.MockFactory
 import scala.concurrent.Future
@@ -17,26 +17,32 @@ import org.scalatest.matchers.should.Matchers
 class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest {
 
   it should "pass valid json request to controller" in new TestSetup {
-    (mockJsonRpcController.handleRequest _).expects(*).returning(Future.successful(JsonRpcResponse("2.0", Some(JString("this is a response")), None, JInt(1))))
+    (mockJsonRpcController.handleRequest _)
+      .expects(*)
+      .returning(Future.successful(JsonRpcResponse("2.0", Some(JString("this is a response")), None, JInt(1))))
 
     val jsonRequest = ByteString("""{"jsonrpc":"2.0", "method": "asd", "id": "1"}""")
-    val postRequest = HttpRequest(HttpMethods.POST, uri = "/", entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
+    val postRequest =
+      HttpRequest(HttpMethods.POST, uri = "/", entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
 
-    postRequest ~>  Route.seal(mockJsonRpcHttpServer.route) ~> check {
+    postRequest ~> Route.seal(mockJsonRpcHttpServer.route) ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[String] shouldEqual """{"jsonrpc":"2.0","result":"this is a response","id":1}"""
     }
   }
 
   it should "pass valid batch json request to controller" in new TestSetup {
-    (mockJsonRpcController.handleRequest _).expects(*)
+    (mockJsonRpcController.handleRequest _)
+      .expects(*)
       .twice()
       .returning(Future.successful(JsonRpcResponse("2.0", Some(JString("this is a response")), None, JInt(1))))
 
-    val jsonRequest = ByteString("""[{"jsonrpc":"2.0", "method": "asd", "id": "1"}, {"jsonrpc":"2.0", "method": "asd", "id": "2"}]""")
-    val postRequest = HttpRequest(HttpMethods.POST, uri = "/", entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
+    val jsonRequest =
+      ByteString("""[{"jsonrpc":"2.0", "method": "asd", "id": "1"}, {"jsonrpc":"2.0", "method": "asd", "id": "2"}]""")
+    val postRequest =
+      HttpRequest(HttpMethods.POST, uri = "/", entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
 
-    postRequest ~>  Route.seal(mockJsonRpcHttpServer.route) ~> check {
+    postRequest ~> Route.seal(mockJsonRpcHttpServer.route) ~> check {
       status === StatusCodes.OK
       responseAs[String] shouldEqual """[{"jsonrpc":"2.0","result":"this is a response","id":1},{"jsonrpc":"2.0","result":"this is a response","id":1}]"""
     }
@@ -44,9 +50,10 @@ class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRout
 
   it should "return BadRequest when malformed request is received" in new TestSetup {
     val jsonRequest = ByteString("""{"jsonrpc":"2.0", "method": "this is not a valid json""")
-    val postRequest = HttpRequest(HttpMethods.POST, uri = "/", entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
+    val postRequest =
+      HttpRequest(HttpMethods.POST, uri = "/", entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
 
-    postRequest ~>  Route.seal(mockJsonRpcHttpServer.route) ~> check {
+    postRequest ~> Route.seal(mockJsonRpcHttpServer.route) ~> check {
       status shouldEqual StatusCodes.BadRequest
     }
   }
@@ -57,26 +64,30 @@ class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRout
       HttpMethods.POST,
       uri = "/",
       headers = Origin(HttpOrigin("http://non_accepted_origin.com")) :: Nil,
-      entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
+      entity = HttpEntity(MediaTypes.`application/json`, jsonRequest)
+    )
 
     import mockJsonRpcHttpServerWithCors.myRejectionHandler
-    postRequest ~>  Route.seal(mockJsonRpcHttpServerWithCors.route) ~> check {
+    postRequest ~> Route.seal(mockJsonRpcHttpServerWithCors.route) ~> check {
       status shouldEqual StatusCodes.Forbidden
     }
   }
 
   it should "accept CORS Requests" in new TestSetup {
 
-    (mockJsonRpcController.handleRequest _).expects(*).returning(Future.successful(JsonRpcResponse("2.0", Some(JString("this is a response")), None, JInt(1))))
+    (mockJsonRpcController.handleRequest _)
+      .expects(*)
+      .returning(Future.successful(JsonRpcResponse("2.0", Some(JString("this is a response")), None, JInt(1))))
 
     val jsonRequest = ByteString("""{"jsonrpc":"2.0", "method": "eth_blockNumber", "id": "1"}""")
     val postRequest = HttpRequest(
       HttpMethods.POST,
       uri = "/",
       headers = Origin(corsAllowedOrigin) :: Nil,
-      entity = HttpEntity(MediaTypes.`application/json`, jsonRequest))
+      entity = HttpEntity(MediaTypes.`application/json`, jsonRequest)
+    )
 
-    postRequest ~>  Route.seal(mockJsonRpcHttpServerWithCors.route) ~> check {
+    postRequest ~> Route.seal(mockJsonRpcHttpServerWithCors.route) ~> check {
       status shouldEqual StatusCodes.OK
     }
   }
@@ -94,8 +105,10 @@ class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRout
     }
 
     val mockJsonRpcController = mock[JsonRpcController]
+    val mockJsonRpcHealthChecker = mock[JsonRpcHealthChecker]
     val mockJsonRpcHttpServer = new JsonRpcHttpServer {
-      val jsonRpcController = mockJsonRpcController
+      override val jsonRpcController = mockJsonRpcController
+      override val jsonRpcHealthChecker = mockJsonRpcHealthChecker
 
       def run(): Unit = ()
 
@@ -105,7 +118,8 @@ class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRout
     val corsAllowedOrigin = HttpOrigin("http://localhost:3333")
 
     val mockJsonRpcHttpServerWithCors = new JsonRpcHttpServer {
-      val jsonRpcController = mockJsonRpcController
+      override val jsonRpcController = mockJsonRpcController
+      override val jsonRpcHealthChecker = mockJsonRpcHealthChecker
 
       def run(): Unit = ()
 


### PR DESCRIPTION
# Description

This healthcheck functionality needs to be back ported from the other project, given is needed for testnet cluster purposes.

# How to test

Manually run the node and use:
```
curl --request GET \
  --url http://127.0.0.1:8546/healthcheck \
  --header 'cache-control: no-cache'
```
Expected response
```
{
  "checks": [
    {
      "description": "listening",
      "status": "OK"
    },
    {
      "description": "peerCount",
      "status": "OK"
    },
    {
      "description": "earliestBlock",
      "status": "OK"
    },
    {
      "description": "latestBlock",
      "status": "OK"
    },
    {
      "description": "pendingBlock",
      "status": "OK"
    }
  ]
}
```
