### PR TITLE
[ETCM-75] Support for checkpoint blocks in Blockchain

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/util/DumpChainApp.scala
@@ -162,11 +162,13 @@ object DumpChainApp extends App with NodeKeyBuilder with SecureRandomBuilder wit
 
     def saveBlockNumber(number: BigInt, hash: NodeHash): Unit = ???
 
-    def saveBestKnownBlock(number: BigInt): Unit = ???
+    def saveBestKnownBlocks(bestBlockNumber: BigInt, latestCheckpointNumber: Option[BigInt] = None): Unit = ???
 
     def getBestBlock(): Block = ???
 
     override def save(block: Block, receipts: Seq[Receipt], totalDifficulty: BigInt, saveAsBestBlock: Boolean): Unit = ???
 
     override def getStateStorage: StateStorage = ???
+
+    override def getLatestCheckpointBlockNumber(): BigInt = ???
   }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/FastSync.scala
@@ -280,6 +280,7 @@ class FastSync(
           blockchain.removeBlock(headerToRemove.hash, withState = false)
         }
       }
+      // TODO (maybe ETCM-77): Manage last checkpoint number too
       appStateStorage.putBestBlockNumber((startBlock - blocksToDiscard - 1) max 0).commit()
     }
 

--- a/src/main/scala/io/iohk/ethereum/domain/Block.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Block.scala
@@ -25,6 +25,8 @@ case class Block(header: BlockHeader, body: BlockBody) {
 
   def hash: ByteString = header.hash
 
+  val hasCheckpoint: Boolean = header.hasCheckpoint
+
   def isParentOf(child: Block): Boolean = number + 1 == child.number && child.header.parentHash == hash
 }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TestService.scala
@@ -121,7 +121,6 @@ class TestService(
     (blockchain.getBestBlockNumber() until request.blockNum by -1).foreach { n =>
       blockchain.removeBlock(blockchain.getBlockHeaderByNumber(n).get.hash, withState = false)
     }
-    blockchain.saveBestKnownBlock(request.blockNum)
     Future.successful(Right(RewindToBlockResponse()))
   }
 

--- a/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/db/storage/StateStorageSpec.scala
@@ -70,7 +70,7 @@ class StateStorageSpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
 
       if (testCache.shouldPersist) {
         val sizeBefore = ints.size
-        archiveStateStorage.onBlockSave(1, 0) { None =>
+        archiveStateStorage.onBlockSave(1, 0) { () =>
           ints = 1 :: ints
         }
 
@@ -88,7 +88,7 @@ class StateStorageSpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
 
       if (testCache.shouldPersist) {
         val sizeBefore = ints.size
-        archiveStateStorage.onBlockRollback(1, 0) { None =>
+        archiveStateStorage.onBlockRollback(1, 0) { () =>
           ints = 1 :: ints
         }
 
@@ -118,7 +118,7 @@ class StateStorageSpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
 
       if (testCache.shouldPersist) {
         val sizeBefore = ints.size
-        referenceCounteStateStorage.onBlockSave(1, 0) { None =>
+        referenceCounteStateStorage.onBlockSave(1, 0) { () =>
           ints = 1 :: ints
         }
 
@@ -136,7 +136,7 @@ class StateStorageSpec extends AnyFlatSpec with Matchers with ScalaCheckProperty
 
       if (testCache.shouldPersist) {
         val sizeBefore = ints.size
-        referenceCounteStateStorage.onBlockRollback(1, 0) { None =>
+        referenceCounteStateStorage.onBlockRollback(1, 0) { () =>
           ints = 1 :: ints
         }
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -48,7 +48,7 @@ class EthServiceSpec
 
   it should "answer eth_blockNumber with the latest block number" in new TestSetup {
     val bestBlockNumber = 10
-    blockchain.saveBestKnownBlock(bestBlockNumber)
+    blockchain.saveBestKnownBlocks(bestBlockNumber)
 
     val response = Await.result(ethService.bestBlockNumber(BestBlockNumberRequest()), Duration.Inf).right.get
     response.bestBlockNumber shouldEqual bestBlockNumber
@@ -248,7 +248,7 @@ class EthServiceSpec
       .storeBlock(blockToRequest)
       .and(blockchain.storeTotalDifficulty(blockToRequestHash, blockTd))
       .commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     (blockGenerator.getPendingBlockAndState _).expects().returns(None)
 
@@ -490,7 +490,7 @@ class EthServiceSpec
   it should "return syncing info if the peer is syncing" in new TestSetup {
     (appStateStorage.getSyncStartingBlock _).expects().returning(999)
     (appStateStorage.getEstimatedHighestBlock _).expects().returning(10000)
-    blockchain.saveBestKnownBlock(200)
+    blockchain.saveBestKnownBlocks(200)
 
     val response = ethService.syncing(SyncingRequest()).futureValue.right.get
 
@@ -509,7 +509,7 @@ class EthServiceSpec
   it should "return no syncing info if the peer is not syncing" in new TestSetup {
     (appStateStorage.getSyncStartingBlock _).expects().returning(999)
     (appStateStorage.getEstimatedHighestBlock _).expects().returning(1000)
-    blockchain.saveBestKnownBlock(1000)
+    blockchain.saveBestKnownBlocks(1000)
     val response = ethService.syncing(SyncingRequest()).futureValue.right.get
 
     response shouldEqual SyncingResponse(None)
@@ -561,7 +561,7 @@ class EthServiceSpec
 
   it should "execute call and return a value" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txResult = TxResult(
       BlockchainImpl(storagesInstance.storages)
@@ -588,7 +588,7 @@ class EthServiceSpec
 
   it should "execute estimateGas and return a value" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val estimatedGas = BigInt(123)
     (stxLedger.binarySearchGasEstimation _).expects(*, *, *).returning(estimatedGas)
@@ -608,7 +608,7 @@ class EthServiceSpec
 
   it should "get uncle count by block number" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val response = ethService.getUncleCountByBlockNumber(GetUncleCountByBlockNumberRequest(BlockParam.Latest))
 
@@ -637,7 +637,7 @@ class EthServiceSpec
 
   it should "get transaction count by latest block number" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val response =
       ethService.getBlockTransactionCountByNumber(GetBlockTransactionCountByNumberRequest(BlockParam.Latest))
@@ -663,7 +663,7 @@ class EthServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchain.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlock(newblock.header.number)
+    blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethService.getCode(GetCodeRequest(address, BlockParam.Latest))
 
@@ -779,7 +779,7 @@ class EthServiceSpec
   }
 
   it should "return average gas price" in new TestSetup {
-    blockchain.saveBestKnownBlock(42)
+    blockchain.saveBestKnownBlocks(42)
     blockchain
       .storeBlock(Block(Fixtures.Blocks.Block3125369.header.copy(number = 42), Fixtures.Blocks.Block3125369.body))
       .commit()
@@ -790,7 +790,7 @@ class EthServiceSpec
 
   it should "getTransactionByBlockNumberAndIndexRequest return transaction by index" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txIndex: Int = 1
     val request = GetTransactionByBlockNumberAndIndexRequest(BlockParam.Latest, txIndex)
@@ -825,7 +825,7 @@ class EthServiceSpec
 
   it should "getRawTransactionByBlockNumberAndIndexRequest return transaction by index" in new TestSetup {
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val txIndex: Int = 1
     val request = GetTransactionByBlockNumberAndIndexRequest(BlockParam.Latest, txIndex)
@@ -872,7 +872,7 @@ class EthServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchain.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlock(newblock.header.number)
+    blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethService.getBalance(GetBalanceRequest(address, BlockParam.Latest))
 
@@ -913,7 +913,7 @@ class EthServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchain.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlock(newblock.header.number)
+    blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethService.getStorageAt(GetStorageAtRequest(address, 333, BlockParam.Latest))
     response.futureValue.map(v => UInt256(v.value)) shouldEqual Right(UInt256(123))
@@ -931,7 +931,7 @@ class EthServiceSpec
     val newBlockHeader = blockToRequest.header.copy(stateRoot = ByteString(mpt.getRootHash))
     val newblock = blockToRequest.copy(header = newBlockHeader)
     blockchain.storeBlock(newblock).commit()
-    blockchain.saveBestKnownBlock(newblock.header.number)
+    blockchain.saveBestKnownBlocks(newblock.header.number)
 
     val response = ethService.getTransactionCount(GetTransactionCountRequest(address, BlockParam.Latest))
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -130,7 +130,7 @@ class JsonRpcControllerSpec
 
   it should "handle eth_blockNumber request" in new TestSetup {
     val bestBlockNumber = 10
-    blockchain.saveBestKnownBlock(bestBlockNumber)
+    blockchain.saveBestKnownBlocks(bestBlockNumber)
 
     val rpcRequest = JsonRpcRequest("2.0", "eth_blockNumber", None, Some(1))
     val response = jsonRpcController.handleRequest(rpcRequest).futureValue
@@ -143,7 +143,7 @@ class JsonRpcControllerSpec
     (appStateStorage.getBestBlockNumber _).expects().returning(200)
     (appStateStorage.getEstimatedHighestBlock _).expects().returning(300)
 
-    blockchain.saveBestKnownBlock(200)
+    blockchain.saveBestKnownBlocks(200)
     val rpcRequest = JsonRpcRequest("2.0", "eth_syncing", None, Some(1))
 
     val response = jsonRpcController.handleRequest(rpcRequest).futureValue
@@ -305,7 +305,7 @@ class JsonRpcControllerSpec
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
 
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -334,7 +334,7 @@ class JsonRpcControllerSpec
     val txIndexToRequest = blockToRequest.body.transactionList.size / 2
 
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -764,7 +764,7 @@ class JsonRpcControllerSpec
     blockchain
       .storeBlock(Block(Fixtures.Blocks.Block3125369.header.copy(number = 42), Fixtures.Blocks.Block3125369.body))
       .commit()
-    blockchain.saveBestKnownBlock(42)
+    blockchain.saveBestKnownBlocks(42)
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -1023,7 +1023,7 @@ class JsonRpcControllerSpec
     val txIndex = 1
 
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",
@@ -1110,7 +1110,7 @@ class JsonRpcControllerSpec
     val txIndex = 1
 
     blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlock(blockToRequest.header.number)
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
 
     val request: JsonRpcRequest = JsonRpcRequest(
       "2.0",


### PR DESCRIPTION
# Description

added saving last checkpoint number during block save and rollback

# Important Changes Introduced

- saving last checkpoint number to the memory and persisting it with best block number after cache persist during block save
- persisting last checkpoint number and best block number immediately during block remove

# Testing

unit tests
