### PR TITLE
[ETCM-126] split JsonRpcControllerSpec

### DIFF
--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -48,7 +48,7 @@ import org.scalatest.matchers.should.Matchers
 
 // scalastyle:off file.size.limit
 // scalastyle:off magic.number
-class JsonRpcControllerSpec
+class JsonRpcControllerEthSpec
     extends AnyFlatSpec
     with Matchers
     with JRCMatchers

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -25,7 +25,6 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.Future
 
-// scalastyle:off file.size.limit
 // scalastyle:off magic.number
 class JsonRpcControllerEthSpec
     extends AnyFlatSpec
@@ -78,21 +77,6 @@ class JsonRpcControllerEthSpec
       "currentBlock" -> "0xc8",
       "highestBlock" -> "0x12c"
     )
-  }
-
-  it should "handle eth_getBlockTransactionCountByHash request" in new JsonRpcControllerFixture {
-    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-
-    blockchain.storeBlock(blockToRequest).commit()
-
-    val rpcRequest = newJsonRpcRequest(
-      "eth_getBlockTransactionCountByHash",
-      List(JString(s"0x${blockToRequest.header.hashAsHexString}")),
-    )
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    val expectedTxCount = Extraction.decompose(BigInt(blockToRequest.body.transactionList.size))
-    response should haveResult(expectedTxCount)
   }
 
   it should "handle eth_getBlockByHash request" in new JsonRpcControllerFixture {
@@ -185,89 +169,6 @@ class JsonRpcControllerEthSpec
       }
 
     response should haveResult(expectedUncleBlockResponse)
-  }
-
-  it should "handle eth_getTransactionByBlockHashAndIndex request" in new JsonRpcControllerFixture {
-    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    val txIndexToRequest = blockToRequest.body.transactionList.size / 2
-
-    blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getTransactionByBlockHashAndIndex",
-      List(
-        JString(s"0x${blockToRequest.header.hashAsHexString}"),
-        JString(s"0x${Hex.toHexString(BigInt(txIndexToRequest).toByteArray)}")
-      )
-    )
-    val response = jsonRpcController.handleRequest(request).futureValue
-    val expectedStx = blockToRequest.body.transactionList.apply(txIndexToRequest)
-    val expectedTxResponse = Extraction.decompose(
-      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndexToRequest))
-    )
-
-    response should haveResult(expectedTxResponse)
-  }
-
-  it should "handle eth_getRawTransactionByBlockHashAndIndex request" in new JsonRpcControllerFixture {
-    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    val txIndexToRequest = blockToRequest.body.transactionList.size / 2
-
-    blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getRawTransactionByBlockHashAndIndex",
-      List(
-        JString(s"0x${blockToRequest.header.hashAsHexString}"),
-        JString(s"0x${Hex.toHexString(BigInt(txIndexToRequest).toByteArray)}")
-      )
-    )
-    val response = jsonRpcController.handleRequest(request).futureValue
-    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndexToRequest)
-
-    response should haveResult(expectedTxResponse)
-  }
-
-  it should "handle eth_getRawTransactionByHash request" in new JsonRpcControllerFixture {
-    val mockEthService = mock[EthService]
-    override val jsonRpcController = newJsonRpcController(mockEthService)
-
-    val txResponse: SignedTransaction = Fixtures.Blocks.Block3125369.body.transactionList.head
-    (mockEthService.getRawTransactionByHash _)
-      .expects(*)
-      .returning(Future.successful(Right(RawTransactionResponse(Some(txResponse)))))
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getRawTransactionByHash",
-      List(
-        JString("0xe9b2d3e8a2bc996a1c7742de825fdae2466ae783ce53484304efffe304ff232d")
-      )
-    )
-
-    val response = jsonRpcController.handleRequest(request).futureValue
-    response should haveResult(encodeSignedTrx(txResponse))
-  }
-
-  it should "eth_sendTransaction" in new JsonRpcControllerFixture {
-    val params = JObject(
-      "from" -> Address(42).toString,
-      "to" -> Address(123).toString,
-      "value" -> 1000
-    ) :: Nil
-
-    val txHash = ByteString(1, 2, 3, 4)
-
-    (personalService
-      .sendTransaction(_: SendTransactionRequest))
-      .expects(*)
-      .returning(Future.successful(Right(SendTransactionResponse(txHash))))
-
-    val rpcRequest = newJsonRpcRequest("eth_sendTransaction", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveResult(JString(s"0x${Hex.toHexString(txHash.toArray)}"))
   }
 
   it should "eth_getWork" in new JsonRpcControllerFixture {
@@ -543,25 +444,6 @@ class JsonRpcControllerEthSpec
     response should haveStringResult("0x3")
   }
 
-  it should "eth_getBlockTransactionCountByNumber " in new JsonRpcControllerFixture {
-    val mockEthService = mock[EthService]
-    override val jsonRpcController = newJsonRpcController(mockEthService)
-
-    (mockEthService.getBlockTransactionCountByNumber _)
-      .expects(*)
-      .returning(Future.successful(Right(GetBlockTransactionCountByNumberResponse(17))))
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getBlockTransactionCountByNumber",
-      List(
-        JString(s"0x123")
-      )
-    )
-
-    val response = jsonRpcController.handleRequest(request).futureValue
-    response should haveStringResult("0x11")
-  }
-
   it should "eth_coinbase " in new JsonRpcControllerFixture {
     // Just record the fact that this is going to be called, we do not care about the returned value
     (validators.signedTransactionValidator _: (() => SignedTransactionValidator))
@@ -575,143 +457,6 @@ class JsonRpcControllerEthSpec
 
     val response = jsonRpcController.handleRequest(request).futureValue
     response should haveStringResult("0x000000000000000000000000000000000000002a")
-  }
-
-  it should "eth_getTransactionByBlockNumberAndIndex by tag" in new JsonRpcControllerFixture {
-    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    val txIndex = 1
-
-    blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getTransactionByBlockNumberAndIndex",
-      List(
-        JString(s"latest"),
-        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
-      )
-    )
-    val response = jsonRpcController.handleRequest(request).futureValue
-    val expectedStx = blockToRequest.body.transactionList(txIndex)
-    val expectedTxResponse = Extraction.decompose(
-      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndex))
-    )
-
-    response should haveResult(expectedTxResponse)
-  }
-
-  it should "eth_getTransactionByBlockNumberAndIndex by hex number" in new JsonRpcControllerFixture {
-    val blockToRequest =
-      Block(Fixtures.Blocks.Block3125369.header.copy(number = BigInt(0xc005)), Fixtures.Blocks.Block3125369.body)
-    val txIndex = 1
-
-    blockchain.storeBlock(blockToRequest).commit()
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getTransactionByBlockNumberAndIndex",
-      List(
-        JString(s"0xC005"),
-        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
-      )
-    )
-    val response = jsonRpcController.handleRequest(request).futureValue
-    val expectedStx = blockToRequest.body.transactionList(txIndex)
-    val expectedTxResponse = Extraction.decompose(
-      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndex))
-    )
-
-    response should haveResult(expectedTxResponse)
-  }
-
-  it should "eth_getTransactionByBlockNumberAndIndex by number" in new JsonRpcControllerFixture {
-    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    val txIndex = 1
-
-    blockchain.storeBlock(blockToRequest).commit()
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getTransactionByBlockNumberAndIndex",
-      List(
-        JInt(Fixtures.Blocks.Block3125369.header.number),
-        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
-      )
-    )
-    val response = jsonRpcController.handleRequest(request).futureValue
-    val expectedStx = blockToRequest.body.transactionList(txIndex)
-    val expectedTxResponse = Extraction.decompose(
-      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndex))
-    )
-
-    response should haveResult(expectedTxResponse)
-  }
-
-  it should "eth_getRawTransactionByBlockNumberAndIndex by tag" in new JsonRpcControllerFixture {
-    // given
-    val blockToRequest: Block = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    val txIndex = 1
-
-    blockchain.storeBlock(blockToRequest).commit()
-    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getRawTransactionByBlockNumberAndIndex",
-      List(
-        JString(s"latest"),
-        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
-      )
-    )
-
-    // when
-    val response = jsonRpcController.handleRequest(request).futureValue
-
-    // then
-    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndex)
-
-    response should haveResult(expectedTxResponse)
-  }
-
-  it should "eth_getRawTransactionByBlockNumberAndIndex by hex number" in new JsonRpcControllerFixture {
-    // given
-    val blockToRequest =
-      Block(Fixtures.Blocks.Block3125369.header.copy(number = BigInt(0xc005)), Fixtures.Blocks.Block3125369.body)
-    val txIndex = 1
-
-    blockchain.storeBlock(blockToRequest).commit()
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getRawTransactionByBlockNumberAndIndex",
-      List(
-        JString(s"0xC005"),
-        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
-      )
-    )
-
-    // when
-    val response = jsonRpcController.handleRequest(request).futureValue
-
-    // then
-    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndex)
-
-    response should haveResult(expectedTxResponse)
-  }
-
-  it should "eth_getRawTransactionByBlockNumberAndIndex by number" in new JsonRpcControllerFixture {
-    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
-    val txIndex = 1
-
-    blockchain.storeBlock(blockToRequest).commit()
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getRawTransactionByBlockNumberAndIndex",
-      List(
-        JInt(Fixtures.Blocks.Block3125369.header.number),
-        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
-      )
-    )
-    val response = jsonRpcController.handleRequest(request).futureValue
-    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndex)
-
-    response should haveResult(expectedTxResponse)
   }
 
   it should "eth_getBalance" in new JsonRpcControllerFixture {
@@ -753,46 +498,6 @@ class JsonRpcControllerEthSpec
 
     val response = jsonRpcController.handleRequest(request).futureValue
     response should haveResult(JString("0x" + Hex.toHexString(ByteString("response").toArray[Byte])))
-  }
-
-  it should "eth_getTransactionCount" in new JsonRpcControllerFixture {
-    val mockEthService = mock[EthService]
-    override val jsonRpcController = newJsonRpcController(mockEthService)
-
-    (mockEthService.getTransactionCount _)
-      .expects(*)
-      .returning(Future.successful(Right(GetTransactionCountResponse(123))))
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getTransactionCount",
-      List(
-        JString(s"0x7B9Bc474667Db2fFE5b08d000F1Acc285B2Ae47D"),
-        JString(s"latest")
-      )
-    )
-
-    val response = jsonRpcController.handleRequest(request).futureValue
-    response should haveStringResult("0x7b")
-  }
-
-  it should "eth_getTransactionByHash" in new JsonRpcControllerFixture {
-    val mockEthService = mock[EthService]
-    override val jsonRpcController = newJsonRpcController(mockEthService)
-
-    val txResponse = TransactionResponse(Fixtures.Blocks.Block3125369.body.transactionList.head)
-    (mockEthService.getTransactionByHash _)
-      .expects(*)
-      .returning(Future.successful(Right(GetTransactionByHashResponse(Some(txResponse)))))
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getTransactionByHash",
-      List(
-        JString("0xe9b2d3e8a2bc996a1c7742de825fdae2466ae783ce53484304efffe304ff232d")
-      )
-    )
-
-    val response = jsonRpcController.handleRequest(request).futureValue
-    response should haveResult(Extraction.decompose(txResponse))
   }
 
   it should "eth_sign" in new JsonRpcControllerFixture {
@@ -1032,85 +737,6 @@ class JsonRpcControllerEthSpec
             "address" -> JString("0x0000000000000000000000000000000000123456"),
             "data" -> JString("0xff33"),
             "topics" -> JArray(List(JString("0x33"), JString("0x55")))
-          )
-        )
-      )
-    )
-  }
-
-  it should "eth_getTransactionReceipt" in new JsonRpcControllerFixture {
-    val mockEthService = mock[EthService]
-    override val jsonRpcController = newJsonRpcController(mockEthService)
-
-    val arbitraryValue = 42
-
-    val mockRequest = GetTransactionReceiptRequest(
-      ByteString(Hex.decode("b903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"))
-    )
-
-    val mockResponse = Right(
-      GetTransactionReceiptResponse(
-        Some(
-          TransactionReceiptResponse(
-            transactionHash = ByteString(Hex.decode("23" * 32)),
-            transactionIndex = 1,
-            blockNumber = Fixtures.Blocks.Block3125369.header.number,
-            blockHash = Fixtures.Blocks.Block3125369.header.hash,
-            cumulativeGasUsed = arbitraryValue * 10,
-            gasUsed = arbitraryValue,
-            contractAddress = Some(Address(arbitraryValue)),
-            logs = Seq(
-              TxLog(
-                logIndex = 0,
-                transactionIndex = 1,
-                transactionHash = ByteString(Hex.decode("23" * 32)),
-                blockHash = Fixtures.Blocks.Block3125369.header.hash,
-                blockNumber = Fixtures.Blocks.Block3125369.header.number,
-                address = Address(arbitraryValue),
-                data = ByteString(Hex.decode("43" * 32)),
-                topics = Seq(ByteString(Hex.decode("44" * 32)), ByteString(Hex.decode("45" * 32)))
-              )
-            )
-          )
-        )
-      )
-    )
-
-    (mockEthService.getTransactionReceipt _).expects(*).returning(Future.successful(mockResponse))
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "eth_getTransactionReceipt",
-      List(JString(s"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"))
-    )
-
-    val response = jsonRpcController.handleRequest(request).futureValue
-    response should haveResult(
-      JObject(
-        JField("transactionHash", JString("0x" + "23" * 32)),
-        JField("transactionIndex", JString("0x1")),
-        JField("blockNumber", JString("0x2fb079")),
-        JField("blockHash", JString("0x" + Hex.toHexString(Fixtures.Blocks.Block3125369.header.hash.toArray[Byte]))),
-        JField("cumulativeGasUsed", JString("0x1a4")),
-        JField("gasUsed", JString("0x2a")),
-        JField("contractAddress", JString("0x000000000000000000000000000000000000002a")),
-        JField(
-          "logs",
-          JArray(
-            List(
-              JObject(
-                JField("logIndex", JString("0x0")),
-                JField("transactionIndex", JString("0x1")),
-                JField("transactionHash", JString("0x" + "23" * 32)),
-                JField(
-                  "blockHash",
-                  JString("0x" + Hex.toHexString(Fixtures.Blocks.Block3125369.header.hash.toArray[Byte]))
-                ),
-                JField("blockNumber", JString("0x2fb079")),
-                JField("address", JString("0x000000000000000000000000000000000000002a")),
-                JField("data", JString("0x" + "43" * 32)),
-                JField("topics", JArray(List(JString("0x" + "44" * 32), JString("0x" + "45" * 32))))
-              )
-            )
           )
         )
       )

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -90,7 +90,7 @@ class JsonRpcControllerEthSpec
 
     val request = newJsonRpcRequest(
       "eth_getBlockByHash",
-      List(JString(s"0x${blockToRequest.header.hashAsHexString}"), JBool(false)),
+      List(JString(s"0x${blockToRequest.header.hashAsHexString}"), JBool(false))
     )
     val response = jsonRpcController.handleRequest(request).futureValue
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -7,7 +7,7 @@ import io.iohk.ethereum.consensus.validators.SignedTransactionValidator
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.EthService._
-import io.iohk.ethereum.jsonrpc.FilterManager.{LogFilterLogs, TxLog}
+import io.iohk.ethereum.jsonrpc.FilterManager.LogFilterLogs
 import io.iohk.ethereum.jsonrpc.JsonSerializers.{OptionNoneToJNullSerializer, QuantitiesSerializer, UnformattedDataJsonSerializer}
 import io.iohk.ethereum.jsonrpc.PersonalService._
 import io.iohk.ethereum.ommers.OmmersPool

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
@@ -1,0 +1,406 @@
+package io.iohk.ethereum.jsonrpc
+
+import akka.util.ByteString
+import io.iohk.ethereum.domain._
+import io.iohk.ethereum.jsonrpc.EthService._
+import io.iohk.ethereum.jsonrpc.FilterManager.TxLog
+import io.iohk.ethereum.jsonrpc.JsonSerializers.{OptionNoneToJNullSerializer, QuantitiesSerializer, UnformattedDataJsonSerializer}
+import io.iohk.ethereum.jsonrpc.PersonalService._
+import io.iohk.ethereum.{Fixtures, LongPatience}
+import org.bouncycastle.util.encoders.Hex
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.{DefaultFormats, Extraction, Formats}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.concurrent.Future
+
+// scalastyle:off magic.number
+class JsonRpcControllerEthTransactionSpec
+  extends AnyFlatSpec
+    with Matchers
+    with JRCMatchers
+    with ScalaCheckPropertyChecks
+    with ScalaFutures
+    with LongPatience
+    with Eventually {
+
+  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
+    QuantitiesSerializer + UnformattedDataJsonSerializer
+
+  it should "handle eth_getTransactionByBlockHashAndIndex request" in new JsonRpcControllerFixture {
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val txIndexToRequest = blockToRequest.body.transactionList.size / 2
+
+    blockchain.storeBlock(blockToRequest).commit()
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getTransactionByBlockHashAndIndex",
+      List(
+        JString(s"0x${blockToRequest.header.hashAsHexString}"),
+        JString(s"0x${Hex.toHexString(BigInt(txIndexToRequest).toByteArray)}")
+      )
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+    val expectedStx = blockToRequest.body.transactionList.apply(txIndexToRequest)
+    val expectedTxResponse = Extraction.decompose(
+      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndexToRequest))
+    )
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "handle eth_getRawTransactionByBlockHashAndIndex request" in new JsonRpcControllerFixture {
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val txIndexToRequest = blockToRequest.body.transactionList.size / 2
+
+    blockchain.storeBlock(blockToRequest).commit()
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getRawTransactionByBlockHashAndIndex",
+      List(
+        JString(s"0x${blockToRequest.header.hashAsHexString}"),
+        JString(s"0x${Hex.toHexString(BigInt(txIndexToRequest).toByteArray)}")
+      )
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndexToRequest)
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "handle eth_getRawTransactionByHash request" in new JsonRpcControllerFixture {
+    val mockEthService = mock[EthService]
+    override val jsonRpcController = newJsonRpcController(mockEthService)
+
+    val txResponse: SignedTransaction = Fixtures.Blocks.Block3125369.body.transactionList.head
+    (mockEthService.getRawTransactionByHash _)
+      .expects(*)
+      .returning(Future.successful(Right(RawTransactionResponse(Some(txResponse)))))
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getRawTransactionByHash",
+      List(
+        JString("0xe9b2d3e8a2bc996a1c7742de825fdae2466ae783ce53484304efffe304ff232d")
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveResult(encodeSignedTrx(txResponse))
+  }
+
+  it should "eth_sendTransaction" in new JsonRpcControllerFixture {
+    val params = JObject(
+      "from" -> Address(42).toString,
+      "to" -> Address(123).toString,
+      "value" -> 1000
+    ) :: Nil
+
+    val txHash = ByteString(1, 2, 3, 4)
+
+    (personalService
+      .sendTransaction(_: SendTransactionRequest))
+      .expects(*)
+      .returning(Future.successful(Right(SendTransactionResponse(txHash))))
+
+    val rpcRequest = newJsonRpcRequest("eth_sendTransaction", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveResult(JString(s"0x${Hex.toHexString(txHash.toArray)}"))
+  }
+
+  it should "eth_getTransactionByBlockNumberAndIndex by tag" in new JsonRpcControllerFixture {
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val txIndex = 1
+
+    blockchain.storeBlock(blockToRequest).commit()
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getTransactionByBlockNumberAndIndex",
+      List(
+        JString(s"latest"),
+        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
+      )
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+    val expectedStx = blockToRequest.body.transactionList(txIndex)
+    val expectedTxResponse = Extraction.decompose(
+      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndex))
+    )
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "eth_getTransactionByBlockNumberAndIndex by hex number" in new JsonRpcControllerFixture {
+    val blockToRequest =
+      Block(Fixtures.Blocks.Block3125369.header.copy(number = BigInt(0xc005)), Fixtures.Blocks.Block3125369.body)
+    val txIndex = 1
+
+    blockchain.storeBlock(blockToRequest).commit()
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getTransactionByBlockNumberAndIndex",
+      List(
+        JString(s"0xC005"),
+        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
+      )
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+    val expectedStx = blockToRequest.body.transactionList(txIndex)
+    val expectedTxResponse = Extraction.decompose(
+      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndex))
+    )
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "eth_getTransactionByBlockNumberAndIndex by number" in new JsonRpcControllerFixture {
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val txIndex = 1
+
+    blockchain.storeBlock(blockToRequest).commit()
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getTransactionByBlockNumberAndIndex",
+      List(
+        JInt(Fixtures.Blocks.Block3125369.header.number),
+        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
+      )
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+    val expectedStx = blockToRequest.body.transactionList(txIndex)
+    val expectedTxResponse = Extraction.decompose(
+      TransactionResponse(expectedStx, Some(blockToRequest.header), Some(txIndex))
+    )
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "eth_getRawTransactionByBlockNumberAndIndex by tag" in new JsonRpcControllerFixture {
+    // given
+    val blockToRequest: Block = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val txIndex = 1
+
+    blockchain.storeBlock(blockToRequest).commit()
+    blockchain.saveBestKnownBlocks(blockToRequest.header.number)
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getRawTransactionByBlockNumberAndIndex",
+      List(
+        JString(s"latest"),
+        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
+      )
+    )
+
+    // when
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    // then
+    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndex)
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "eth_getRawTransactionByBlockNumberAndIndex by hex number" in new JsonRpcControllerFixture {
+    // given
+    val blockToRequest =
+      Block(Fixtures.Blocks.Block3125369.header.copy(number = BigInt(0xc005)), Fixtures.Blocks.Block3125369.body)
+    val txIndex = 1
+
+    blockchain.storeBlock(blockToRequest).commit()
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getRawTransactionByBlockNumberAndIndex",
+      List(
+        JString(s"0xC005"),
+        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
+      )
+    )
+
+    // when
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    // then
+    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndex)
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "eth_getRawTransactionByBlockNumberAndIndex by number" in new JsonRpcControllerFixture {
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val txIndex = 1
+
+    blockchain.storeBlock(blockToRequest).commit()
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getRawTransactionByBlockNumberAndIndex",
+      List(
+        JInt(Fixtures.Blocks.Block3125369.header.number),
+        JString(s"0x${Hex.toHexString(BigInt(txIndex).toByteArray)}")
+      )
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+    val expectedTxResponse = rawTrnHex(blockToRequest.body.transactionList, txIndex)
+
+    response should haveResult(expectedTxResponse)
+  }
+
+  it should "eth_getTransactionByHash" in new JsonRpcControllerFixture {
+    val mockEthService = mock[EthService]
+    override val jsonRpcController = newJsonRpcController(mockEthService)
+
+    val txResponse = TransactionResponse(Fixtures.Blocks.Block3125369.body.transactionList.head)
+    (mockEthService.getTransactionByHash _)
+      .expects(*)
+      .returning(Future.successful(Right(GetTransactionByHashResponse(Some(txResponse)))))
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getTransactionByHash",
+      List(
+        JString("0xe9b2d3e8a2bc996a1c7742de825fdae2466ae783ce53484304efffe304ff232d")
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveResult(Extraction.decompose(txResponse))
+  }
+
+  it should "eth_getTransactionCount" in new JsonRpcControllerFixture {
+    val mockEthService = mock[EthService]
+    override val jsonRpcController = newJsonRpcController(mockEthService)
+
+    (mockEthService.getTransactionCount _)
+      .expects(*)
+      .returning(Future.successful(Right(GetTransactionCountResponse(123))))
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getTransactionCount",
+      List(
+        JString(s"0x7B9Bc474667Db2fFE5b08d000F1Acc285B2Ae47D"),
+        JString(s"latest")
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveStringResult("0x7b")
+  }
+
+  it should "eth_getBlockTransactionCountByNumber " in new JsonRpcControllerFixture {
+    val mockEthService = mock[EthService]
+    override val jsonRpcController = newJsonRpcController(mockEthService)
+
+    (mockEthService.getBlockTransactionCountByNumber _)
+      .expects(*)
+      .returning(Future.successful(Right(GetBlockTransactionCountByNumberResponse(17))))
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getBlockTransactionCountByNumber",
+      List(
+        JString(s"0x123")
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveStringResult("0x11")
+  }
+
+  it should "handle eth_getBlockTransactionCountByHash request" in new JsonRpcControllerFixture {
+    val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+
+    blockchain.storeBlock(blockToRequest).commit()
+
+    val rpcRequest = newJsonRpcRequest(
+      "eth_getBlockTransactionCountByHash",
+      List(JString(s"0x${blockToRequest.header.hashAsHexString}")),
+    )
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    val expectedTxCount = Extraction.decompose(BigInt(blockToRequest.body.transactionList.size))
+    response should haveResult(expectedTxCount)
+  }
+
+  it should "eth_getTransactionReceipt" in new JsonRpcControllerFixture {
+    val mockEthService = mock[EthService]
+    override val jsonRpcController = newJsonRpcController(mockEthService)
+
+    val arbitraryValue = 42
+
+    val mockRequest = GetTransactionReceiptRequest(
+      ByteString(Hex.decode("b903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"))
+    )
+
+    val mockResponse = Right(
+      GetTransactionReceiptResponse(
+        Some(
+          TransactionReceiptResponse(
+            transactionHash = ByteString(Hex.decode("23" * 32)),
+            transactionIndex = 1,
+            blockNumber = Fixtures.Blocks.Block3125369.header.number,
+            blockHash = Fixtures.Blocks.Block3125369.header.hash,
+            cumulativeGasUsed = arbitraryValue * 10,
+            gasUsed = arbitraryValue,
+            contractAddress = Some(Address(arbitraryValue)),
+            logs = Seq(
+              TxLog(
+                logIndex = 0,
+                transactionIndex = 1,
+                transactionHash = ByteString(Hex.decode("23" * 32)),
+                blockHash = Fixtures.Blocks.Block3125369.header.hash,
+                blockNumber = Fixtures.Blocks.Block3125369.header.number,
+                address = Address(arbitraryValue),
+                data = ByteString(Hex.decode("43" * 32)),
+                topics = Seq(ByteString(Hex.decode("44" * 32)), ByteString(Hex.decode("45" * 32)))
+              )
+            )
+          )
+        )
+      )
+    )
+
+    (mockEthService.getTransactionReceipt _).expects(*).returning(Future.successful(mockResponse))
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "eth_getTransactionReceipt",
+      List(JString(s"0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238"))
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveResult(
+      JObject(
+        JField("transactionHash", JString("0x" + "23" * 32)),
+        JField("transactionIndex", JString("0x1")),
+        JField("blockNumber", JString("0x2fb079")),
+        JField("blockHash", JString("0x" + Hex.toHexString(Fixtures.Blocks.Block3125369.header.hash.toArray[Byte]))),
+        JField("cumulativeGasUsed", JString("0x1a4")),
+        JField("gasUsed", JString("0x2a")),
+        JField("contractAddress", JString("0x000000000000000000000000000000000000002a")),
+        JField(
+          "logs",
+          JArray(
+            List(
+              JObject(
+                JField("logIndex", JString("0x0")),
+                JField("transactionIndex", JString("0x1")),
+                JField("transactionHash", JString("0x" + "23" * 32)),
+                JField(
+                  "blockHash",
+                  JString("0x" + Hex.toHexString(Fixtures.Blocks.Block3125369.header.hash.toArray[Byte]))
+                ),
+                JField("blockNumber", JString("0x2fb079")),
+                JField("address", JString("0x000000000000000000000000000000000000002a")),
+                JField("data", JString("0x" + "43" * 32)),
+                JField("topics", JArray(List(JString("0x" + "44" * 32), JString("0x" + "45" * 32))))
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
@@ -317,7 +317,7 @@ class JsonRpcControllerEthTransactionSpec
 
     val rpcRequest = newJsonRpcRequest(
       "eth_getBlockTransactionCountByHash",
-      List(JString(s"0x${blockToRequest.header.hashAsHexString}")),
+      List(JString(s"0x${blockToRequest.header.hashAsHexString}"))
     )
     val response = jsonRpcController.handleRequest(rpcRequest).futureValue
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -16,12 +16,12 @@ import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{BloomFilter, Ledger, StxLedger}
 import io.iohk.ethereum.utils.{Config, FilterConfig}
 import org.bouncycastle.util.encoders.Hex
-import org.json4s.JsonAST.JString
+import org.json4s.JsonAST.{JArray, JInt, JString, JValue}
 import org.scalamock.scalatest.MockFactory
 
 import scala.concurrent.duration._
 
-trait TestSetup extends MockFactory with EphemBlockchainTestSetup with JsonMethodsImplicits {
+trait JsonRpcControllerFixture extends MockFactory with EphemBlockchainTestSetup with JsonMethodsImplicits {
   def config: JsonRpcConfig = JsonRpcConfig(Config.config)
 
   def rawTrnHex(xs: Seq[SignedTransaction], idx: Int): Option[JString] =
@@ -116,4 +116,10 @@ trait TestSetup extends MockFactory with EphemBlockchainTestSetup with JsonMetho
   val s: ByteString = ByteString(Hex.decode("2d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee"))
   val v: Byte = ByteString(Hex.decode("1b")).last
   val sig = ECDSASignature(r, s, v)
+
+  def newJsonRpcRequest(method: String, params: List[JValue]) =
+    JsonRpcRequest("2.0", method, Some(JArray(params)), Some(JInt(1)))
+
+  def newJsonRpcRequest(method: String) =
+    JsonRpcRequest("2.0", method, None, Some(JInt(1)))
 }

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerPersonalSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerPersonalSpec.scala
@@ -1,0 +1,229 @@
+package io.iohk.ethereum.jsonrpc
+
+import java.time.Duration
+
+import akka.util.ByteString
+import io.iohk.ethereum.LongPatience
+import io.iohk.ethereum.domain._
+import io.iohk.ethereum.jsonrpc.JsonSerializers.{OptionNoneToJNullSerializer, QuantitiesSerializer, UnformattedDataJsonSerializer}
+import io.iohk.ethereum.jsonrpc.PersonalService._
+import org.bouncycastle.util.encoders.Hex
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.{DefaultFormats, Formats}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.concurrent.Future
+
+class JsonRpcControllerPersonalSpec
+  extends AnyFlatSpec
+    with Matchers
+    with JRCMatchers
+    with ScalaCheckPropertyChecks
+    with ScalaFutures
+    with LongPatience
+    with Eventually {
+
+  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
+    QuantitiesSerializer + UnformattedDataJsonSerializer
+
+  it should "personal_importRawKey" in new JsonRpcControllerFixture {
+    val key = "7a44789ed3cd85861c0bbf9693c7e1de1862dd4396c390147ecf1275099c6e6f"
+    val keyBytes = ByteString(Hex.decode(key))
+    val addr = Address("0x00000000000000000000000000000000000000ff")
+    val pass = "aaa"
+
+    (personalService.importRawKey _)
+      .expects(ImportRawKeyRequest(keyBytes, pass))
+      .returning(Future.successful(Right(ImportRawKeyResponse(addr))))
+
+    val params = JString(key) :: JString(pass) :: Nil
+    val rpcRequest = newJsonRpcRequest("personal_importRawKey", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult(addr.toString)
+  }
+
+  it should "personal_newAccount" in new JsonRpcControllerFixture {
+    val addr = Address("0x00000000000000000000000000000000000000ff")
+    val pass = "aaa"
+
+    (personalService.newAccount _)
+      .expects(NewAccountRequest(pass))
+      .returning(Future.successful(Right(NewAccountResponse(addr))))
+
+    val params = JString(pass) :: Nil
+    val rpcRequest = newJsonRpcRequest("personal_newAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult(addr.toString)
+  }
+
+  it should "personal_listAccounts" in new JsonRpcControllerFixture {
+    val addresses = List(34, 12391, 123).map(Address(_))
+    val pass = "aaa"
+
+    (personalService.listAccounts _)
+      .expects(ListAccountsRequest())
+      .returning(Future.successful(Right(ListAccountsResponse(addresses))))
+
+    val rpcRequest = newJsonRpcRequest("personal_listAccounts")
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveResult(JArray(addresses.map(a => JString(a.toString))))
+  }
+
+  it should "personal_unlockAccount" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val params = JString(address.toString) :: JString(pass) :: Nil
+
+    (personalService.unlockAccount _)
+      .expects(UnlockAccountRequest(address, pass, None))
+      .returning(Future.successful(Right(UnlockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_unlockAccount for specified duration" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val dur = "1"
+    val params = JString(address.toString) :: JString(pass) :: JString(dur) :: Nil
+
+    (personalService.unlockAccount _)
+      .expects(UnlockAccountRequest(address, pass, Some(Duration.ofSeconds(1))))
+      .returning(Future.successful(Right(UnlockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_unlockAccount should handle possible duration errors" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val dur = "alksjdfh"
+
+    val params = JString(address.toString) :: JString(pass) :: JString(dur) :: Nil
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveError(JsonRpcError(-32602, "Invalid method parameters", None))
+
+    val dur2 = Long.MaxValue
+    val params2 = JString(address.toString) :: JString(pass) :: JInt(dur2) :: Nil
+    val rpcRequest2 = newJsonRpcRequest("personal_unlockAccount", params2)
+    val response2 = jsonRpcController.handleRequest(rpcRequest2).futureValue
+    response2 should haveError(
+      JsonRpcError(-32602, "Duration should be an number of seconds, less than 2^31 - 1", None)
+    )
+  }
+
+  it should "personal_unlockAccount should handle null passed as a duration for compatibility with Parity and web3j" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val params = JString(address.toString) :: JString(pass) :: JNull :: Nil
+
+    (personalService.unlockAccount _)
+      .expects(UnlockAccountRequest(address, pass, None))
+      .returning(Future.successful(Right(UnlockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_lockAccount" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val params = JString(address.toString) :: Nil
+
+    (personalService.lockAccount _)
+      .expects(LockAccountRequest(address))
+      .returning(Future.successful(Right(LockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_lockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_sendTransaction" in new JsonRpcControllerFixture {
+    val params = JObject(
+      "from" -> Address(42).toString,
+      "to" -> Address(123).toString,
+      "value" -> 1000
+    ) :: JString("passphrase") :: Nil
+
+    val txHash = ByteString(1, 2, 3, 4)
+
+    (personalService
+      .sendTransaction(_: SendTransactionWithPassphraseRequest))
+      .expects(*)
+      .returning(Future.successful(Right(SendTransactionWithPassphraseResponse(txHash))))
+
+    val rpcRequest = newJsonRpcRequest("personal_sendTransaction", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveResult(JString(s"0x${Hex.toHexString(txHash.toArray)}"))
+  }
+
+  it should "personal_sign" in new JsonRpcControllerFixture {
+
+    (personalService.sign _)
+      .expects(
+        SignRequest(
+          ByteString(Hex.decode("deadbeaf")),
+          Address(ByteString(Hex.decode("9b2055d370f73ec7d8a03e965129118dc8f5bf83"))),
+          Some("thePassphrase")
+        )
+      )
+      .returns(Future.successful(Right(SignResponse(sig))))
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "personal_sign",
+      List(
+        JString(s"0xdeadbeaf"),
+        JString(s"0x9b2055d370f73ec7d8a03e965129118dc8f5bf83"),
+        JString("thePassphrase")
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveStringResult(
+      "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+    )
+  }
+
+  it should "personal_ecRecover" in new JsonRpcControllerFixture {
+
+    (personalService.ecRecover _)
+      .expects(EcRecoverRequest(ByteString(Hex.decode("deadbeaf")), sig))
+      .returns(
+        Future.successful(
+          Right(EcRecoverResponse(Address(ByteString(Hex.decode("9b2055d370f73ec7d8a03e965129118dc8f5bf83")))))
+        )
+      )
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "personal_ecRecover",
+      List(
+        JString(s"0xdeadbeaf"),
+        JString(
+          s"0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+        )
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveStringResult("0x9b2055d370f73ec7d8a03e965129118dc8f5bf83")
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -1,22 +1,16 @@
 package io.iohk.ethereum.jsonrpc
 
-import java.time.Duration
-
-import akka.util.ByteString
-import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInfoResponse}
 import io.iohk.ethereum.jsonrpc.EthService._
 import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonRpcConfig
 import io.iohk.ethereum.jsonrpc.JsonSerializers.{OptionNoneToJNullSerializer, QuantitiesSerializer, UnformattedDataJsonSerializer}
 import io.iohk.ethereum.jsonrpc.NetService.{ListeningResponse, PeerCountResponse, VersionResponse}
-import io.iohk.ethereum.jsonrpc.PersonalService._
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer
 import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
 import io.iohk.ethereum.network.p2p.messages.Versions
 import io.iohk.ethereum.{Fixtures, LongPatience}
-import org.bouncycastle.util.encoders.Hex
 import org.json4s.JsonAST._
 import org.json4s.JsonDSL._
 import org.json4s.{DefaultFormats, Extraction, Formats}
@@ -28,8 +22,6 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-// scalastyle:off file.size.limit
-// scalastyle:off magic.number
 class JsonRpcControllerSpec
   extends AnyFlatSpec
     with Matchers
@@ -116,152 +108,6 @@ class JsonRpcControllerSpec
     web3Response should haveStringResult(version)
   }
 
-  it should "personal_importRawKey" in new JsonRpcControllerFixture {
-    val key = "7a44789ed3cd85861c0bbf9693c7e1de1862dd4396c390147ecf1275099c6e6f"
-    val keyBytes = ByteString(Hex.decode(key))
-    val addr = Address("0x00000000000000000000000000000000000000ff")
-    val pass = "aaa"
-
-    (personalService.importRawKey _)
-      .expects(ImportRawKeyRequest(keyBytes, pass))
-      .returning(Future.successful(Right(ImportRawKeyResponse(addr))))
-
-    val params = JString(key) :: JString(pass) :: Nil
-    val rpcRequest = newJsonRpcRequest("personal_importRawKey", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveStringResult(addr.toString)
-  }
-
-  it should "personal_newAccount" in new JsonRpcControllerFixture {
-    val addr = Address("0x00000000000000000000000000000000000000ff")
-    val pass = "aaa"
-
-    (personalService.newAccount _)
-      .expects(NewAccountRequest(pass))
-      .returning(Future.successful(Right(NewAccountResponse(addr))))
-
-    val params = JString(pass) :: Nil
-    val rpcRequest = newJsonRpcRequest("personal_newAccount", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveStringResult(addr.toString)
-  }
-
-  it should "personal_listAccounts" in new JsonRpcControllerFixture {
-    val addresses = List(34, 12391, 123).map(Address(_))
-    val pass = "aaa"
-
-    (personalService.listAccounts _)
-      .expects(ListAccountsRequest())
-      .returning(Future.successful(Right(ListAccountsResponse(addresses))))
-
-    val rpcRequest = newJsonRpcRequest("personal_listAccounts")
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveResult(JArray(addresses.map(a => JString(a.toString))))
-  }
-
-  it should "personal_unlockAccount" in new JsonRpcControllerFixture {
-    val address = Address(42)
-    val pass = "aaa"
-    val params = JString(address.toString) :: JString(pass) :: Nil
-
-    (personalService.unlockAccount _)
-      .expects(UnlockAccountRequest(address, pass, None))
-      .returning(Future.successful(Right(UnlockAccountResponse(true))))
-
-    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveBooleanResult(true)
-  }
-
-  it should "personal_unlockAccount for specified duration" in new JsonRpcControllerFixture {
-    val address = Address(42)
-    val pass = "aaa"
-    val dur = "1"
-    val params = JString(address.toString) :: JString(pass) :: JString(dur) :: Nil
-
-    (personalService.unlockAccount _)
-      .expects(UnlockAccountRequest(address, pass, Some(Duration.ofSeconds(1))))
-      .returning(Future.successful(Right(UnlockAccountResponse(true))))
-
-    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveBooleanResult(true)
-  }
-
-  it should "personal_unlockAccount should handle possible duration errors" in new JsonRpcControllerFixture {
-    val address = Address(42)
-    val pass = "aaa"
-    val dur = "alksjdfh"
-
-    val params = JString(address.toString) :: JString(pass) :: JString(dur) :: Nil
-    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveError(JsonRpcError(-32602, "Invalid method parameters", None))
-
-    val dur2 = Long.MaxValue
-    val params2 = JString(address.toString) :: JString(pass) :: JInt(dur2) :: Nil
-    val rpcRequest2 = newJsonRpcRequest("personal_unlockAccount", params2)
-    val response2 = jsonRpcController.handleRequest(rpcRequest2).futureValue
-    response2 should haveError(
-      JsonRpcError(-32602, "Duration should be an number of seconds, less than 2^31 - 1", None)
-    )
-  }
-
-  it should "personal_unlockAccount should handle null passed as a duration for compatibility with Parity and web3j" in new JsonRpcControllerFixture {
-    val address = Address(42)
-    val pass = "aaa"
-    val params = JString(address.toString) :: JString(pass) :: JNull :: Nil
-
-    (personalService.unlockAccount _)
-      .expects(UnlockAccountRequest(address, pass, None))
-      .returning(Future.successful(Right(UnlockAccountResponse(true))))
-
-    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveBooleanResult(true)
-  }
-
-  it should "personal_lockAccount" in new JsonRpcControllerFixture {
-    val address = Address(42)
-    val params = JString(address.toString) :: Nil
-
-    (personalService.lockAccount _)
-      .expects(LockAccountRequest(address))
-      .returning(Future.successful(Right(LockAccountResponse(true))))
-
-    val rpcRequest = newJsonRpcRequest("personal_lockAccount", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveBooleanResult(true)
-  }
-
-  it should "personal_sendTransaction" in new JsonRpcControllerFixture {
-    val params = JObject(
-      "from" -> Address(42).toString,
-      "to" -> Address(123).toString,
-      "value" -> 1000
-    ) :: JString("passphrase") :: Nil
-
-    val txHash = ByteString(1, 2, 3, 4)
-
-    (personalService
-      .sendTransaction(_: SendTransactionWithPassphraseRequest))
-      .expects(*)
-      .returning(Future.successful(Right(SendTransactionWithPassphraseResponse(txHash))))
-
-    val rpcRequest = newJsonRpcRequest("personal_sendTransaction", params)
-    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
-
-    response should haveResult(JString(s"0x${Hex.toHexString(txHash.toArray)}"))
-  }
-
   it should "debug_listPeersInfo" in new JsonRpcControllerFixture {
     val peerStatus = Status(
       protocolVersion = Versions.PV63,
@@ -287,57 +133,6 @@ class JsonRpcControllerSpec
     val response: JsonRpcResponse = jsonRpcController.handleRequest(rpcRequest).futureValue
 
     response should haveResult(JArray(peers.map(info => JString(info.toString))))
-  }
-
-  it should "personal_sign" in new JsonRpcControllerFixture {
-
-    (personalService.sign _)
-      .expects(
-        SignRequest(
-          ByteString(Hex.decode("deadbeaf")),
-          Address(ByteString(Hex.decode("9b2055d370f73ec7d8a03e965129118dc8f5bf83"))),
-          Some("thePassphrase")
-        )
-      )
-      .returns(Future.successful(Right(SignResponse(sig))))
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "personal_sign",
-      List(
-        JString(s"0xdeadbeaf"),
-        JString(s"0x9b2055d370f73ec7d8a03e965129118dc8f5bf83"),
-        JString("thePassphrase")
-      )
-    )
-
-    val response = jsonRpcController.handleRequest(request).futureValue
-    response should haveStringResult(
-      "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
-    )
-  }
-
-  it should "personal_ecRecover" in new JsonRpcControllerFixture {
-
-    (personalService.ecRecover _)
-      .expects(EcRecoverRequest(ByteString(Hex.decode("deadbeaf")), sig))
-      .returns(
-        Future.successful(
-          Right(EcRecoverResponse(Address(ByteString(Hex.decode("9b2055d370f73ec7d8a03e965129118dc8f5bf83")))))
-        )
-      )
-
-    val request: JsonRpcRequest = newJsonRpcRequest(
-      "personal_ecRecover",
-      List(
-        JString(s"0xdeadbeaf"),
-        JString(
-          s"0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
-        )
-      )
-    )
-
-    val response = jsonRpcController.handleRequest(request).futureValue
-    response should haveStringResult("0x9b2055d370f73ec7d8a03e965129118dc8f5bf83")
   }
 
   it should "rpc_modules" in new JsonRpcControllerFixture {

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -1,0 +1,402 @@
+package io.iohk.ethereum.jsonrpc
+
+import java.time.Duration
+
+import akka.util.ByteString
+import io.iohk.ethereum.domain._
+import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInfoResponse}
+import io.iohk.ethereum.jsonrpc.EthService._
+import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonRpcConfig
+import io.iohk.ethereum.jsonrpc.JsonSerializers.{OptionNoneToJNullSerializer, QuantitiesSerializer, UnformattedDataJsonSerializer}
+import io.iohk.ethereum.jsonrpc.NetService.{ListeningResponse, PeerCountResponse, VersionResponse}
+import io.iohk.ethereum.jsonrpc.PersonalService._
+import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer
+import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer
+import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
+import io.iohk.ethereum.network.p2p.messages.Versions
+import io.iohk.ethereum.{Fixtures, LongPatience}
+import org.bouncycastle.util.encoders.Hex
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.{DefaultFormats, Extraction, Formats}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+// scalastyle:off file.size.limit
+// scalastyle:off magic.number
+class JsonRpcControllerSpec
+  extends AnyFlatSpec
+    with Matchers
+    with JRCMatchers
+    with ScalaCheckPropertyChecks
+    with ScalaFutures
+    with LongPatience
+    with Eventually {
+
+  implicit val formats: Formats = DefaultFormats.preservingEmptyValues + OptionNoneToJNullSerializer +
+    QuantitiesSerializer + UnformattedDataJsonSerializer
+
+  "JsonRpcController" should "handle valid sha3 request" in new JsonRpcControllerFixture {
+    val rpcRequest = newJsonRpcRequest("web3_sha3", JString("0x1234") :: Nil)
+
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult("0x56570de287d73cd1cb6092bb8fdee6173974955fdef345ae579ee9f475ea7432")
+  }
+
+  it should "fail when invalid request is received" in new JsonRpcControllerFixture {
+    val rpcRequest = newJsonRpcRequest("web3_sha3", JString("asdasd") :: Nil)
+
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveError(JsonRpcErrors.InvalidParams("Invalid method parameters"))
+  }
+
+  it should "handle clientVersion request" in new JsonRpcControllerFixture {
+    val rpcRequest = newJsonRpcRequest("web3_clientVersion")
+
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult(version)
+  }
+
+  it should "Handle net_peerCount request" in new JsonRpcControllerFixture {
+    (netService.peerCount _).expects(*).returning(Future.successful(Right(PeerCountResponse(123))))
+
+    val rpcRequest = newJsonRpcRequest("net_peerCount")
+
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult("0x7b")
+  }
+
+  it should "Handle net_listening request" in new JsonRpcControllerFixture {
+    (netService.listening _).expects(*).returning(Future.successful(Right(ListeningResponse(false))))
+
+    val rpcRequest = newJsonRpcRequest("net_listening")
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(false)
+  }
+
+  it should "Handle net_version request" in new JsonRpcControllerFixture {
+    val netVersion = "99"
+
+    (netService.version _).expects(*).returning(Future.successful(Right(VersionResponse(netVersion))))
+
+    val rpcRequest = newJsonRpcRequest("net_version")
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult(netVersion)
+  }
+
+  it should "only allow to call methods of enabled apis" in new JsonRpcControllerFixture {
+    override def config: JsonRpcConfig = new JsonRpcConfig {
+      override val apis = Seq("web3")
+      override val accountTransactionsMaxBlocks = 50000
+      override def minerActiveTimeout: FiniteDuration = ???
+      override def httpServerConfig: JsonRpcHttpServer.JsonRpcHttpServerConfig = ???
+      override def ipcServerConfig: JsonRpcIpcServer.JsonRpcIpcServerConfig = ???
+    }
+
+    val ethRpcRequest = newJsonRpcRequest("eth_protocolVersion")
+    val ethResponse = jsonRpcController.handleRequest(ethRpcRequest).futureValue
+
+    ethResponse should haveError(JsonRpcErrors.MethodNotFound)
+
+    val web3RpcRequest = newJsonRpcRequest("web3_clientVersion")
+    val web3Response = jsonRpcController.handleRequest(web3RpcRequest).futureValue
+
+    web3Response should haveStringResult(version)
+  }
+
+  it should "personal_importRawKey" in new JsonRpcControllerFixture {
+    val key = "7a44789ed3cd85861c0bbf9693c7e1de1862dd4396c390147ecf1275099c6e6f"
+    val keyBytes = ByteString(Hex.decode(key))
+    val addr = Address("0x00000000000000000000000000000000000000ff")
+    val pass = "aaa"
+
+    (personalService.importRawKey _)
+      .expects(ImportRawKeyRequest(keyBytes, pass))
+      .returning(Future.successful(Right(ImportRawKeyResponse(addr))))
+
+    val params = JString(key) :: JString(pass) :: Nil
+    val rpcRequest = newJsonRpcRequest("personal_importRawKey", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult(addr.toString)
+  }
+
+  it should "personal_newAccount" in new JsonRpcControllerFixture {
+    val addr = Address("0x00000000000000000000000000000000000000ff")
+    val pass = "aaa"
+
+    (personalService.newAccount _)
+      .expects(NewAccountRequest(pass))
+      .returning(Future.successful(Right(NewAccountResponse(addr))))
+
+    val params = JString(pass) :: Nil
+    val rpcRequest = newJsonRpcRequest("personal_newAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveStringResult(addr.toString)
+  }
+
+  it should "personal_listAccounts" in new JsonRpcControllerFixture {
+    val addresses = List(34, 12391, 123).map(Address(_))
+    val pass = "aaa"
+
+    (personalService.listAccounts _)
+      .expects(ListAccountsRequest())
+      .returning(Future.successful(Right(ListAccountsResponse(addresses))))
+
+    val rpcRequest = newJsonRpcRequest("personal_listAccounts")
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveResult(JArray(addresses.map(a => JString(a.toString))))
+  }
+
+  it should "personal_unlockAccount" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val params = JString(address.toString) :: JString(pass) :: Nil
+
+    (personalService.unlockAccount _)
+      .expects(UnlockAccountRequest(address, pass, None))
+      .returning(Future.successful(Right(UnlockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_unlockAccount for specified duration" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val dur = "1"
+    val params = JString(address.toString) :: JString(pass) :: JString(dur) :: Nil
+
+    (personalService.unlockAccount _)
+      .expects(UnlockAccountRequest(address, pass, Some(Duration.ofSeconds(1))))
+      .returning(Future.successful(Right(UnlockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_unlockAccount should handle possible duration errors" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val dur = "alksjdfh"
+
+    val params = JString(address.toString) :: JString(pass) :: JString(dur) :: Nil
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveError(JsonRpcError(-32602, "Invalid method parameters", None))
+
+    val dur2 = Long.MaxValue
+    val params2 = JString(address.toString) :: JString(pass) :: JInt(dur2) :: Nil
+    val rpcRequest2 = newJsonRpcRequest("personal_unlockAccount", params2)
+    val response2 = jsonRpcController.handleRequest(rpcRequest2).futureValue
+    response2 should haveError(
+      JsonRpcError(-32602, "Duration should be an number of seconds, less than 2^31 - 1", None)
+    )
+  }
+
+  it should "personal_unlockAccount should handle null passed as a duration for compatibility with Parity and web3j" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val pass = "aaa"
+    val params = JString(address.toString) :: JString(pass) :: JNull :: Nil
+
+    (personalService.unlockAccount _)
+      .expects(UnlockAccountRequest(address, pass, None))
+      .returning(Future.successful(Right(UnlockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_unlockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_lockAccount" in new JsonRpcControllerFixture {
+    val address = Address(42)
+    val params = JString(address.toString) :: Nil
+
+    (personalService.lockAccount _)
+      .expects(LockAccountRequest(address))
+      .returning(Future.successful(Right(LockAccountResponse(true))))
+
+    val rpcRequest = newJsonRpcRequest("personal_lockAccount", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveBooleanResult(true)
+  }
+
+  it should "personal_sendTransaction" in new JsonRpcControllerFixture {
+    val params = JObject(
+      "from" -> Address(42).toString,
+      "to" -> Address(123).toString,
+      "value" -> 1000
+    ) :: JString("passphrase") :: Nil
+
+    val txHash = ByteString(1, 2, 3, 4)
+
+    (personalService
+      .sendTransaction(_: SendTransactionWithPassphraseRequest))
+      .expects(*)
+      .returning(Future.successful(Right(SendTransactionWithPassphraseResponse(txHash))))
+
+    val rpcRequest = newJsonRpcRequest("personal_sendTransaction", params)
+    val response = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveResult(JString(s"0x${Hex.toHexString(txHash.toArray)}"))
+  }
+
+  it should "debug_listPeersInfo" in new JsonRpcControllerFixture {
+    val peerStatus = Status(
+      protocolVersion = Versions.PV63,
+      networkId = 1,
+      totalDifficulty = BigInt("10000"),
+      bestHash = Fixtures.Blocks.Block3125369.header.hash,
+      genesisHash = Fixtures.Blocks.Genesis.header.hash
+    )
+    val initialPeerInfo = PeerInfo(
+      remoteStatus = peerStatus,
+      totalDifficulty = peerStatus.totalDifficulty,
+      forkAccepted = true,
+      maxBlockNumber = Fixtures.Blocks.Block3125369.header.number,
+      bestBlockHash = peerStatus.bestHash
+    )
+    val peers = List(initialPeerInfo)
+
+    (debugService.listPeersInfo _)
+      .expects(ListPeersInfoRequest())
+      .returning(Future.successful(Right(ListPeersInfoResponse(peers))))
+
+    val rpcRequest = newJsonRpcRequest("debug_listPeersInfo")
+    val response: JsonRpcResponse = jsonRpcController.handleRequest(rpcRequest).futureValue
+
+    response should haveResult(JArray(peers.map(info => JString(info.toString))))
+  }
+
+  it should "personal_sign" in new JsonRpcControllerFixture {
+
+    (personalService.sign _)
+      .expects(
+        SignRequest(
+          ByteString(Hex.decode("deadbeaf")),
+          Address(ByteString(Hex.decode("9b2055d370f73ec7d8a03e965129118dc8f5bf83"))),
+          Some("thePassphrase")
+        )
+      )
+      .returns(Future.successful(Right(SignResponse(sig))))
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "personal_sign",
+      List(
+        JString(s"0xdeadbeaf"),
+        JString(s"0x9b2055d370f73ec7d8a03e965129118dc8f5bf83"),
+        JString("thePassphrase")
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveStringResult(
+      "0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+    )
+  }
+
+  it should "personal_ecRecover" in new JsonRpcControllerFixture {
+
+    (personalService.ecRecover _)
+      .expects(EcRecoverRequest(ByteString(Hex.decode("deadbeaf")), sig))
+      .returns(
+        Future.successful(
+          Right(EcRecoverResponse(Address(ByteString(Hex.decode("9b2055d370f73ec7d8a03e965129118dc8f5bf83")))))
+        )
+      )
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "personal_ecRecover",
+      List(
+        JString(s"0xdeadbeaf"),
+        JString(
+          s"0xa3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a12d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee1b"
+        )
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    response should haveStringResult("0x9b2055d370f73ec7d8a03e965129118dc8f5bf83")
+  }
+
+  it should "rpc_modules" in new JsonRpcControllerFixture {
+    val request: JsonRpcRequest = newJsonRpcRequest("rpc_modules")
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    response should haveResult(
+      JObject(
+        "net" -> "1.0",
+        "rpc" -> "1.0",
+        "personal" -> "1.0",
+        "eth" -> "1.0",
+        "web3" -> "1.0",
+        "daedalus" -> "1.0",
+        "debug" -> "1.0",
+        "qa" -> "1.0"
+      )
+    )
+  }
+
+  it should "daedalus_getAccountTransactions" in new JsonRpcControllerFixture {
+    val mockEthService: EthService = mock[EthService]
+    override val jsonRpcController = newJsonRpcController(mockEthService)
+
+    val block = Fixtures.Blocks.Block3125369
+    val sentTx = block.body.transactionList.head
+    val receivedTx = block.body.transactionList.last
+
+    (mockEthService.getAccountTransactions _)
+      .expects(*)
+      .returning(
+        Future.successful(
+          Right(
+            GetAccountTransactionsResponse(
+              Seq(
+                TransactionResponse(sentTx, Some(block.header), isOutgoing = Some(true)),
+                TransactionResponse(receivedTx, Some(block.header), isOutgoing = Some(false))
+              )
+            )
+          )
+        )
+      )
+
+    val request: JsonRpcRequest = newJsonRpcRequest(
+      "daedalus_getAccountTransactions",
+      List(
+        JString(s"0x7B9Bc474667Db2fFE5b08d000F1Acc285B2Ae47D"),
+        JInt(100),
+        JInt(200)
+      )
+    )
+
+    val response = jsonRpcController.handleRequest(request).futureValue
+    val expectedTxs = Seq(
+      Extraction.decompose(TransactionResponse(sentTx, Some(block.header), isOutgoing = Some(true))),
+      Extraction.decompose(TransactionResponse(receivedTx, Some(block.header), isOutgoing = Some(false)))
+    )
+
+    response should haveObjectResult("transactions" -> JArray(expectedTxs.toList))
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/TestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/TestSetup.scala
@@ -1,0 +1,119 @@
+package io.iohk.ethereum.jsonrpc
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import akka.util.ByteString
+import io.iohk.ethereum.{Fixtures, Timeouts}
+import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.consensus.{ConsensusConfigs, TestConsensus}
+import io.iohk.ethereum.consensus.ethash.blocks.EthashBlockGenerator
+import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
+import io.iohk.ethereum.crypto.ECDSASignature
+import io.iohk.ethereum.db.storage.AppStateStorage
+import io.iohk.ethereum.domain.{Block, BlockBody, SignedTransaction}
+import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonRpcConfig
+import io.iohk.ethereum.keystore.KeyStore
+import io.iohk.ethereum.ledger.{BloomFilter, Ledger, StxLedger}
+import io.iohk.ethereum.utils.{Config, FilterConfig}
+import org.bouncycastle.util.encoders.Hex
+import org.json4s.JsonAST.JString
+import org.scalamock.scalatest.MockFactory
+
+import scala.concurrent.duration._
+
+trait TestSetup extends MockFactory with EphemBlockchainTestSetup with JsonMethodsImplicits {
+  def config: JsonRpcConfig = JsonRpcConfig(Config.config)
+
+  def rawTrnHex(xs: Seq[SignedTransaction], idx: Int): Option[JString] =
+    xs.lift(idx)
+      .map(encodeSignedTrx)
+
+  def encodeSignedTrx(x: SignedTransaction) =
+    encodeAsHex(RawTransactionCodec.asRawTransaction(x))
+
+  val version = Config.clientVersion
+  val blockGenerator = mock[EthashBlockGenerator]
+
+  override implicit lazy val system = ActorSystem("JsonRpcControllerSpec_System")
+
+  val syncingController = TestProbe()
+  override lazy val ledger = mock[Ledger]
+  override lazy val stxLedger = mock[StxLedger]
+  override lazy val validators = mock[ValidatorsExecutor]
+  override lazy val consensus: TestConsensus = buildTestConsensus()
+    .withValidators(validators)
+    .withBlockGenerator(blockGenerator)
+
+  val keyStore = mock[KeyStore]
+
+  val pendingTransactionsManager = TestProbe()
+  val ommersPool = TestProbe()
+  val filterManager = TestProbe()
+
+  val ethashConfig = ConsensusConfigs.ethashConfig
+  override lazy val consensusConfig = ConsensusConfigs.consensusConfig
+  val fullConsensusConfig = ConsensusConfigs.fullConsensusConfig
+  val getTransactionFromPoolTimeout: FiniteDuration = 5.seconds
+
+  val filterConfig = new FilterConfig {
+    override val filterTimeout: FiniteDuration = Timeouts.normalTimeout
+    override val filterManagerQueryTimeout: FiniteDuration = Timeouts.normalTimeout
+  }
+
+  val currentProtocolVersion = 63
+
+  val appStateStorage = mock[AppStateStorage]
+  val web3Service = new Web3Service
+  val netService = mock[NetService]
+  val personalService = mock[PersonalService]
+  val debugService = mock[DebugService]
+  val qaService = mock[QAService]
+
+  val ethService = new EthService(
+    blockchain,
+    appStateStorage,
+    ledger,
+    stxLedger,
+    keyStore,
+    pendingTransactionsManager.ref,
+    syncingController.ref,
+    ommersPool.ref,
+    filterManager.ref,
+    filterConfig,
+    blockchainConfig,
+    currentProtocolVersion,
+    config,
+    getTransactionFromPoolTimeout
+  )
+
+  protected def newJsonRpcController(ethService: EthService) =
+    new JsonRpcController(
+      web3Service,
+      netService,
+      ethService,
+      personalService,
+      None,
+      debugService,
+      qaService,
+      config
+    )
+
+  val jsonRpcController =
+    new JsonRpcController(web3Service, netService, ethService, personalService, None, debugService, qaService, config)
+
+  val blockHeader = Fixtures.Blocks.ValidBlock.header.copy(
+    logsBloom = BloomFilter.EmptyBloomFilter,
+    difficulty = 10,
+    number = 2,
+    gasLimit = 0,
+    gasUsed = 0,
+    unixTimestamp = 0
+  )
+
+  val parentBlock = Block(blockHeader.copy(number = 1), BlockBody.empty)
+
+  val r: ByteString = ByteString(Hex.decode("a3f20717a250c2b0b729b7e5becbff67fdaef7e0699da4de7ca5895b02a170a1"))
+  val s: ByteString = ByteString(Hex.decode("2d887fd3b17bfdce3481f10bea41f45ba9f709d39ce8325427b57afcfc994cee"))
+  val v: Byte = ByteString(Hex.decode("1b")).last
+  val sig = ECDSASignature(r, s, v)
+}


### PR DESCRIPTION
# Description

JsonRpcControllerSpec file contained around 2000 lines of code. This is hard to maintain. Context for this PR: https://github.com/input-output-hk/mantis/pull/726#discussion_r503406911

# Proposed Solution

Split it into tests related to:
- `JsonRpcControllerPersonalSpec` personal_XYZ
- `JsonRpcControllerEthTransactionSpec` related to eth transaction requests
- `JsonRpcControllerEthSpec` other eth requests
- `JsonRpcControllerSpec` other requests

Before split there were utility function extracted that simplify creating requests and creating JsonRpcService: `newJsonRpcController`, `newJsonRpcRequest` in https://github.com/input-output-hk/mantis/pull/734/commits/53283b73265c070be4b22062a3bbad7fab577a04

# Important Changes Introduced

# Testing