### PR TITLE
Etcm 175 sync reporting issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -158,8 +158,10 @@ addCommandAlias(
 addCommandAlias(
   "pp",
   """;compile-all
-    |;test
+    |;scalafmtAll
     |;scalastyle
     |;test:scalastyle
+    |;test
+    |;it:test
     |""".stripMargin
 )

--- a/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/RegularSyncItSpecUtils.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorRef
 import akka.util.ByteString
 import cats.effect.Resource
 import io.iohk.ethereum.Mocks.MockValidatorsAlwaysSucceed
-import io.iohk.ethereum.blockchain.sync.PeersClient
+import io.iohk.ethereum.blockchain.sync.{PeersClient, SyncProtocol}
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcasterActor.BroadcastBlock
 import io.iohk.ethereum.blockchain.sync.regular.RegularSync
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
@@ -80,7 +80,7 @@ object RegularSyncItSpecUtils {
     )
 
     def startRegularSync(): Task[Unit] = Task {
-      regularSync ! RegularSync.Start
+      regularSync ! SyncProtocol.Start
     }
 
     def broadcastBlock(
@@ -116,7 +116,7 @@ object RegularSyncItSpecUtils {
       val currentWolrd = getMptForBlock(block)
       val (newBlock, newTd, newWorld) =
         createChildBlock(block, currentTd, currentWolrd, plusDifficulty)(updateWorldForBlock)
-      regularSync ! RegularSync.MinedBlock(newBlock)
+      regularSync ! SyncProtocol.MinedBlock(newBlock)
     }
 
     def mineNewBlocks(delay: FiniteDuration, nBlocks: Int)(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -543,6 +543,8 @@ mantis {
   }
 
   async {
+    ask-timeout = 100.millis
+
     dispatchers {
       block-forger {
         type = Dispatcher

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncController.scala
@@ -27,13 +27,11 @@ class SyncController(
 ) extends Actor
     with ActorLogging {
 
-  import SyncController._
-
   def scheduler: Scheduler = externalSchedulerOpt getOrElse context.system.scheduler
 
   override def receive: Receive = idle
 
-  def idle: Receive = { case Start =>
+  def idle: Receive = { case SyncProtocol.Start =>
     start()
   }
 
@@ -89,7 +87,7 @@ class SyncController(
       ),
       "fast-sync"
     )
-    fastSync ! FastSync.Start
+    fastSync ! SyncProtocol.Start
     context become runningFastSync(fastSync)
   }
 
@@ -112,7 +110,7 @@ class SyncController(
       ),
       "regular-sync"
     )
-    regularSync ! RegularSync.Start
+    regularSync ! SyncProtocol.Start
     context become runningRegularSync(regularSync)
   }
 
@@ -150,6 +148,4 @@ object SyncController {
         syncConfig
       )
     )
-
-  case object Start
 }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncProtocol.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncProtocol.scala
@@ -1,0 +1,36 @@
+package io.iohk.ethereum.blockchain.sync
+import io.iohk.ethereum.domain.Block
+
+object SyncProtocol {
+  sealed trait SyncProtocolMsg
+  case object Start extends SyncProtocolMsg
+  case object GetStatus extends SyncProtocolMsg
+  case class MinedBlock(block: Block) extends SyncProtocolMsg
+
+  sealed trait Status {
+    def syncing: Boolean = this match {
+      case Status.Syncing(_, _, _) => true
+      case Status.NotSyncing => false
+      case Status.SyncDone => false
+    }
+
+    def notSyncing: Boolean = !syncing
+  }
+  object Status {
+    case class Progress(current: BigInt, target: BigInt) {
+      val isEmpty: Boolean = current == 0 && target == 0
+      val nonEmpty = !isEmpty
+    }
+    object Progress {
+      val empty = Progress(0, 0)
+    }
+    case class Syncing(
+        startingBlockNumber: BigInt,
+        blocksProgress: Progress,
+        stateNodesProgress: Option[Progress] // relevant only in fast sync, but is required by RPC spec
+    ) extends Status
+
+    case object NotSyncing extends Status
+    case object SyncDone extends Status
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerActor.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/SyncStateSchedulerActor.scala
@@ -15,6 +15,7 @@ import io.iohk.ethereum.blockchain.sync.SyncStateSchedulerActor.{
   StartSyncingTo,
   StateSyncFinished,
   SyncStateSchedulerActorCommand,
+  StateSyncStats,
   WaitingForNewTargetBlock
 }
 import io.iohk.ethereum.utils.ByteStringUtils
@@ -116,6 +117,7 @@ class SyncStateSchedulerActor(downloader: ActorRef, sync: SyncStateScheduler, sy
           context.stop(self)
         case Right((newState, statistics)) =>
           if (newState.numberOfPendingRequests == 0) {
+            reportStats(syncInitiator, currentStats, currentState)
             finalizeSync(newState, targetBlock, syncInitiator)
           } else {
             log.debug(
@@ -135,16 +137,13 @@ class SyncStateSchedulerActor(downloader: ActorRef, sync: SyncStateScheduler, sy
             if (state2.memBatch.size >= syncConfig.stateSyncPersistBatchSize) {
               log.debug("Current membatch size is {}, persisting nodes to database", state2.memBatch.size)
               val state3 = sync.persistBatch(state2, targetBlock)
-              context.become(
-                syncing(
-                  state3,
-                  currentStats.addStats(statistics).addSaved(state2.memBatch.size),
-                  targetBlock,
-                  syncInitiator
-                )
-              )
+              val newStats = currentStats.addStats(statistics).addSaved(state2.memBatch.size)
+              reportStats(syncInitiator, newStats, state3)
+              context.become(syncing(state3, newStats, targetBlock, syncInitiator))
             } else {
-              context.become(syncing(state2, currentStats.addStats(statistics), targetBlock, syncInitiator))
+              val newStats = currentStats.addStats(statistics)
+              reportStats(syncInitiator, newStats, state2)
+              context.become(syncing(state2, newStats, targetBlock, syncInitiator))
             }
           }
       }
@@ -173,6 +172,18 @@ class SyncStateSchedulerActor(downloader: ActorRef, sync: SyncStateScheduler, sy
     loadingCancelable.cancel()
     super.postStop()
   }
+
+  private def reportStats(
+      to: ActorRef,
+      currentStats: ProcessingStatistics,
+      currentState: SyncStateScheduler.SchedulerState
+  ): Unit = {
+    to ! StateSyncStats(
+      currentStats.saved + currentState.memBatch.size,
+      currentState.numberOfPendingRequests
+    )
+  }
+
 }
 
 object SyncStateSchedulerActor {
@@ -190,6 +201,8 @@ object SyncStateSchedulerActor {
   sealed trait SyncStateSchedulerActorResponse
   case object StateSyncFinished extends SyncStateSchedulerActorResponse
   case object WaitingForNewTargetBlock extends SyncStateSchedulerActorResponse
+
+  case class StateSyncStats(saved: Long, missing: Long)
 
   case class GetMissingNodes(nodesToGet: List[ByteString])
   case class MissingNodes(missingNodes: List[SyncResponse], downloaderCapacity: Int)

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -14,6 +14,7 @@ import io.iohk.ethereum.blockchain.sync.regular.BlockFetcherState.{
   AwaitingHeadersToBeIgnored
 }
 import io.iohk.ethereum.blockchain.sync.regular.BlockImporter.{ImportNewBlock, NotOnTop, OnTop}
+import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
 import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class BlockFetcher(
     val peersClient: ActorRef,
     val peerEventBus: ActorRef,
+    val supervisor: ActorRef,
     val syncConfig: SyncConfig,
     implicit val scheduler: Scheduler
 ) extends Actor
@@ -117,6 +119,11 @@ class BlockFetcher(
           }
         }
 
+      //First successful fetch
+      if (state.waitingHeaders.isEmpty) {
+        supervisor ! ProgressProtocol.StartedFetching
+      }
+
       fetchBlocks(newState)
     case RetryHeadersRequest if state.isFetchingHeaders =>
       log.debug("Time-out occurred while waiting for headers")
@@ -178,6 +185,8 @@ class BlockFetcher(
         case Right(validHashes) => state.withPossibleNewTopAt(validHashes.lastOption.map(_.number))
       }
 
+      supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
+
       fetchBlocks(newState)
     case MessageFromPeer(NewBlock(block, _, _), peerId) =>
       val newBlockNr = block.number
@@ -191,20 +200,25 @@ class BlockFetcher(
         val newState = state.withPeerForBlocks(peerId, Seq(newBlockNr)).withKnownTopAt(newBlockNr)
         state.importer ! OnTop
         state.importer ! ImportNewBlock(block, peerId)
+        supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
         context become started(newState)
         // there are some blocks waiting for import but it seems that we reached top on fetch side so we can enqueue new block for import
       } else if (newBlockNr == nextExpectedBlock && !state.isFetching && state.waitingHeaders.isEmpty) {
         log.debug("Enqueue new block for import")
         val newState = state.appendNewBlock(block, peerId)
+        supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
         context become started(newState)
         // waiting for some bodies but we don't have this header yet - at least we can use new block header
       } else if (newBlockNr == state.nextToLastBlock && !state.isFetchingHeaders) {
         log.debug("Waiting for bodies. Add only headers")
-        state.appendHeaders(List(block.header)) |> fetchBlocks
+        val newState = state.appendHeaders(List(block.header))
+        supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
+        fetchBlocks(newState)
         // we're far from top
       } else if (newBlockNr > nextExpectedBlock) {
         log.debug("Far from top")
         val newState = state.withKnownTopAt(newBlockNr)
+        supervisor ! ProgressProtocol.GotNewBlock(newState.knownTop)
         fetchBlocks(newState)
       }
     case BlockImportFailed(blockNr, reason) =>
@@ -317,8 +331,14 @@ class BlockFetcher(
 
 object BlockFetcher {
 
-  def props(peersClient: ActorRef, peerEventBus: ActorRef, syncConfig: SyncConfig, scheduler: Scheduler): Props =
-    Props(new BlockFetcher(peersClient, peerEventBus, syncConfig, scheduler))
+  def props(
+      peersClient: ActorRef,
+      peerEventBus: ActorRef,
+      supervisor: ActorRef,
+      syncConfig: SyncConfig,
+      scheduler: Scheduler
+  ): Props =
+    Props(new BlockFetcher(peersClient, peerEventBus, supervisor, syncConfig, scheduler))
 
   sealed trait FetchMsg
   case class Start(importer: ActorRef, fromBlock: BigInt) extends FetchMsg

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockImporter.scala
@@ -4,10 +4,9 @@ import akka.actor.Actor.Receive
 import akka.actor.{Actor, ActorLogging, ActorRef, NotInfluenceReceiveTimeout, Props, ReceiveTimeout}
 import akka.util.ByteString
 import cats.data.NonEmptyList
-import cats.instances.future._
-import cats.instances.list._
-import cats.syntax.apply._
+import cats.implicits._
 import io.iohk.ethereum.blockchain.sync.regular.BlockBroadcasterActor.BroadcastBlocks
+import io.iohk.ethereum.blockchain.sync.regular.RegularSync.ProgressProtocol
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.crypto.{ECDSASignature, kec256}
 import io.iohk.ethereum.domain.{Block, Blockchain, Checkpoint, SignedTransaction}
@@ -22,8 +21,8 @@ import io.iohk.ethereum.utils.{BlockchainConfig, ByteStringUtils}
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.utils.FunctorOps._
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 // scalastyle:off cyclomatic.complexity parameter.number
@@ -36,7 +35,8 @@ class BlockImporter(
     ommersPool: ActorRef,
     broadcaster: ActorRef,
     pendingTransactionsManager: ActorRef,
-    checkpointBlockGenerator: CheckpointBlockGenerator
+    checkpointBlockGenerator: CheckpointBlockGenerator,
+    supervisor: ActorRef
 ) extends Actor
     with ActorLogging {
   import BlockImporter._
@@ -117,6 +117,7 @@ class BlockImporter(
   private def start(): Unit = {
     log.debug("Starting Regular Sync, current best block is {}", startingBlockNumber)
     fetcher ! BlockFetcher.Start(self, startingBlockNumber)
+    supervisor ! ProgressProtocol.StartingFrom(startingBlockNumber)
     context become running(ImporterState.initial)
   }
 
@@ -176,6 +177,11 @@ class BlockImporter(
       ec: ExecutionContext
   ): Future[(List[Block], Option[Any])] =
     if (blocks.isEmpty) {
+      importedBlocks.headOption match {
+        case Some(block) => supervisor ! ProgressProtocol.ImportedBlock(block.number)
+        case None => ()
+      }
+
       Future.successful((importedBlocks, None))
     } else {
       val restOfBlocks = blocks.tail
@@ -223,6 +229,7 @@ class BlockImporter(
             val (blocks, tds) = importedBlocksData.map(data => (data.block, data.td)).unzip
             broadcastBlocks(blocks, tds)
             updateTxPool(importedBlocksData.map(_.block), Seq.empty)
+            supervisor ! ProgressProtocol.ImportedBlock(block.number)
 
           case BlockEnqueued => ()
 
@@ -233,6 +240,10 @@ class BlockImporter(
           case ChainReorganised(oldBranch, newBranch, totalDifficulties) =>
             updateTxPool(newBranch, oldBranch)
             broadcastBlocks(newBranch, totalDifficulties)
+            newBranch.lastOption match {
+              case Some(newBlock) => supervisor ! ProgressProtocol.ImportedBlock(newBlock.number)
+              case None => ()
+            }
 
           case BlockImportFailed(error) =>
             if (informFetcherOnFail) {
@@ -326,7 +337,7 @@ class BlockImporter(
 }
 
 object BlockImporter {
-
+  // scalastyle:off parameter.number
   def props(
       fetcher: ActorRef,
       ledger: Ledger,
@@ -336,7 +347,8 @@ object BlockImporter {
       ommersPool: ActorRef,
       broadcaster: ActorRef,
       pendingTransactionsManager: ActorRef,
-      checkpointBlockGenerator: CheckpointBlockGenerator
+      checkpointBlockGenerator: CheckpointBlockGenerator,
+      supervisor: ActorRef
   ): Props =
     Props(
       new BlockImporter(
@@ -348,7 +360,8 @@ object BlockImporter {
         ommersPool,
         broadcaster,
         pendingTransactionsManager,
-        checkpointBlockGenerator
+        checkpointBlockGenerator,
+        supervisor
       )
     )
 
@@ -371,7 +384,11 @@ object BlockImporter {
   case class ResolvingMissingNode(blocksToRetry: NonEmptyList[Block]) extends NewBehavior
   case class ResolvingBranch(from: BigInt) extends NewBehavior
 
-  case class ImporterState(isOnTop: Boolean, importing: Boolean, resolvingBranchFrom: Option[BigInt]) {
+  case class ImporterState(
+      isOnTop: Boolean,
+      importing: Boolean,
+      resolvingBranchFrom: Option[BigInt]
+  ) {
     def onTop(): ImporterState = copy(isOnTop = true)
 
     def notOnTop(): ImporterState = copy(isOnTop = false)
@@ -388,6 +405,10 @@ object BlockImporter {
   }
 
   object ImporterState {
-    val initial: ImporterState = ImporterState(isOnTop = false, importing = false, resolvingBranchFrom = None)
+    def initial: ImporterState = ImporterState(
+      isOnTop = false,
+      importing = false,
+      resolvingBranchFrom = None
+    )
   }
 }

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashMiner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashMiner.scala
@@ -1,9 +1,11 @@
 package io.iohk.ethereum.consensus
 package ethash
 
+import java.io.{File, FileInputStream, FileOutputStream}
+
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.util.ByteString
-import io.iohk.ethereum.blockchain.sync.regular.RegularSync
+import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.consensus.blocks.PendingBlock
 import io.iohk.ethereum.consensus.ethash.EthashUtils.ProofOfWork
 import io.iohk.ethereum.consensus.ethash.MinerProtocol.{StartMining, StopMining}
@@ -14,8 +16,8 @@ import io.iohk.ethereum.jsonrpc.EthService.SubmitHashRateRequest
 import io.iohk.ethereum.nodebuilder.Node
 import io.iohk.ethereum.utils.BigIntExtensionMethods._
 import io.iohk.ethereum.utils.{ByteStringUtils, ByteUtils}
-import java.io.{File, FileInputStream, FileOutputStream}
 import org.bouncycastle.util.encoders.Hex
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.util.{Failure, Random, Success, Try}
@@ -92,7 +94,7 @@ class EthashMiner(
             log.info(
               s"Mining successful with ${ByteStringUtils.hash2string(pow.mixHash)} and nonce ${ByteStringUtils.hash2string(nonce)}"
             )
-            syncController ! RegularSync.MinedBlock(
+            syncController ! SyncProtocol.MinedBlock(
               block.copy(header = block.header.copy(nonce = nonce, mixHash = pow.mixHash))
             )
           case _ => log.info("Mining unsuccessful")

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/MockedMiner.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/MockedMiner.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.consensus.ethash
 
 import akka.actor.Status.Failure
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import io.iohk.ethereum.blockchain.sync.regular.RegularSync.MinedBlock
+import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.consensus.blocks.PendingBlock
 import io.iohk.ethereum.consensus.ethash.MinerProtocol.{StartMining, StopMining}
 import io.iohk.ethereum.consensus.ethash.MinerResponses.{MinerIsWorking, MiningError, MiningOrdered}
@@ -12,6 +12,7 @@ import io.iohk.ethereum.consensus.wrongConsensusArgument
 import io.iohk.ethereum.domain.{Block, Blockchain}
 import io.iohk.ethereum.nodebuilder.Node
 import io.iohk.ethereum.utils.ByteStringUtils
+
 import scala.concurrent.duration._
 
 class MockedMiner(
@@ -75,7 +76,7 @@ class MockedMiner(
         minedBlock.idTag,
         minedBlock.body.transactionList.map(_.hashAsHexString)
       )
-      syncEventListener ! MinedBlock(minedBlock)
+      syncEventListener ! SyncProtocol.MinedBlock(minedBlock)
       // because of using seconds to calculate block timestamp, we can't mine blocks faster than one block per second
       context.system.scheduler.scheduleOnce(1.second, self, MineBlock)
       context.become(working(numBlocks - 1, withTransactions, minedBlock))

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -1,5 +1,9 @@
 package io.iohk.ethereum.nodebuilder
 
+import java.security.SecureRandom
+import java.time.Clock
+import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.{ActorRef, ActorSystem}
 import io.iohk.ethereum.blockchain.data.GenesisDataLoader
 import io.iohk.ethereum.blockchain.sync.{BlockchainHostActor, SyncController}
@@ -37,7 +41,7 @@ import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 // scalastyle:off number.of.types
@@ -68,6 +72,10 @@ trait KeyStoreConfigBuilder {
 trait NodeKeyBuilder {
   self: SecureRandomBuilder =>
   lazy val nodeKey: AsymmetricCipherKeyPair = loadAsymmetricCipherKeyPair(Config.nodeKeyFile, secureRandom)
+}
+
+trait AsyncConfigBuilder {
+  val asyncConfig = AsyncConfig(Config.config)
 }
 
 trait ActorSystemBuilder {
@@ -331,11 +339,11 @@ trait EthServiceBuilder {
     with FilterManagerBuilder
     with FilterConfigBuilder
     with TxPoolConfigBuilder
-    with JSONRpcConfigBuilder =>
+    with JSONRpcConfigBuilder
+    with AsyncConfigBuilder =>
 
   lazy val ethService = new EthService(
     blockchain,
-    storagesInstance.storages.appStateStorage,
     ledger,
     stxLedger,
     keyStore,
@@ -347,7 +355,8 @@ trait EthServiceBuilder {
     blockchainConfig,
     Config.Network.protocolVersion,
     jsonRpcConfig,
-    txPoolConfig.getTransactionFromPoolTimeout
+    txPoolConfig.getTransactionFromPoolTimeout,
+    asyncConfig.askTimeout
   )
 }
 
@@ -638,4 +647,5 @@ trait Node
     with ConsensusConfigBuilder
     with LedgerBuilder
     with KeyStoreConfigBuilder
+    with AsyncConfigBuilder
     with CheckpointBlockGeneratorBuilder

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/StdNode.scala
@@ -1,6 +1,6 @@
 package io.iohk.ethereum.nodebuilder
 
-import io.iohk.ethereum.blockchain.sync.SyncController
+import io.iohk.ethereum.blockchain.sync.SyncProtocol
 import io.iohk.ethereum.consensus.StdConsensusBuilder
 import io.iohk.ethereum.metrics.{Metrics, MetricsConfig}
 import io.iohk.ethereum.network.discovery.DiscoveryListener
@@ -34,7 +34,7 @@ abstract class BaseNode extends Node {
       discoveryListener ! DiscoveryListener.Start
     }
 
-  private[this] def startSyncController(): Unit = syncController ! SyncController.Start
+  private[this] def startSyncController(): Unit = syncController ! SyncProtocol.Start
 
   private[this] def startConsensus(): Unit = consensus.startProtocol(this)
 

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -2,7 +2,7 @@ package io.iohk.ethereum.utils
 
 import java.net.InetSocketAddress
 
-import akka.util.ByteString
+import akka.util.{ByteString, Timeout}
 import com.typesafe.config.{ConfigFactory, Config => TypesafeConfig}
 import io.iohk.ethereum.db.dataSource.RocksDbConfig
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, BasicPruning, InMemoryPruning, PruningMode}
@@ -212,6 +212,12 @@ object Config {
     override val maxSize: Long = cacheConfig.getInt("max-size")
     override val maxHoldTime: FiniteDuration = cacheConfig.getDuration("max-hold-time").toMillis.millis
   }
+}
+
+case class AsyncConfig(askTimeout: Timeout)
+object AsyncConfig {
+  def apply(mantisConfig: TypesafeConfig): AsyncConfig =
+    AsyncConfig(mantisConfig.atKey("async").getDuration("ask-timeout").toMillis.millis)
 }
 
 trait KeyStoreConfig {

--- a/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
+++ b/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
@@ -1,25 +1,62 @@
 package io.iohk.ethereum
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.Block
+import io.iohk.ethereum.crypto.generateKeyPair
+import io.iohk.ethereum.domain.{Address, Block, BlockBody, SignedTransaction, Transaction}
+import io.iohk.ethereum.nodebuilder.SecureRandomBuilder
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import mouse.all._
 
-object BlockHelpers {
+import scala.math.BigInt
+import scala.util.Random
 
-  def generateChain(amount: Int, parent: Block): Seq[Block] = {
-    (1 to amount).foldLeft[Seq[Block]](Nil){ case (acc, _) =>
-      val baseBlock = Fixtures.Blocks.ValidBlock.block
+object BlockHelpers extends SecureRandomBuilder {
 
-      val parentHeader = acc.lastOption.getOrElse(parent)
-      val blockHeader = baseBlock.header.copy(
-        number = parentHeader.number + 1,
-        parentHash = parentHeader.hash,
-        // Random nonce used for having our blocks be different
-        nonce = ByteString(Math.random().toString)
-      )
-      val block = baseBlock.copy(header = blockHeader)
+  // scalastyle:off magic.number
+  val defaultHeader = Fixtures.Blocks.ValidBlock.header.copy(
+    difficulty = 1000000,
+    number = 1,
+    gasLimit = 1000000,
+    gasUsed = 0,
+    unixTimestamp = 0
+  )
 
-      acc :+ block
-    }
+  val defaultTx = Transaction(
+    nonce = 42,
+    gasPrice = 1,
+    gasLimit = 90000,
+    receivingAddress = Address(123),
+    value = 0,
+    payload = ByteString.empty
+  )
+
+  val genesis: Block = Block(defaultHeader.copy(number = 0), BlockBody(Nil, Nil))
+
+  val keyPair: AsymmetricCipherKeyPair = generateKeyPair(secureRandom)
+
+  def randomHash(): ByteString =
+    ObjectGenerators.byteStringOfLengthNGen(32).sample.get
+
+  def generateChain(amount: Int, parent: Block, adjustBlock: Block => Block = identity): List[Block] =
+    (1 to amount).toList.foldLeft[List[Block]](Nil)((generated, _) => {
+      val theParent = generated.lastOption.getOrElse(parent)
+      generated :+ (theParent |> generateBlock |> adjustBlock)
+    })
+
+  def generateBlock(nr: BigInt, parent: Block): Block = {
+    val header = defaultHeader.copy(
+      extraData = randomHash(),
+      number = nr,
+      parentHash = parent.hash,
+      nonce = ByteString(Random.nextLong())
+    )
+    val ommer = defaultHeader.copy(extraData = randomHash())
+    val tx = defaultTx.copy(payload = randomHash())
+    val stx = SignedTransaction.sign(tx, keyPair, None)
+
+    Block(header, BlockBody(List(stx.tx), List(ommer)))
   }
+
+  def generateBlock(parent: Block): Block = generateBlock(parent.number + 1, parent)
 
 }

--- a/src/test/scala/io/iohk/ethereum/ByteGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ByteGenerators.scala
@@ -33,3 +33,4 @@ trait ByteGenerators {
     } yield byteStringList.zip(arrayList)
   }
 }
+object ByteGenerators extends ByteGenerators {}

--- a/src/test/scala/io/iohk/ethereum/Fixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/Fixtures.scala
@@ -14,6 +14,7 @@ object Fixtures {
       val transactionHashes: Seq[ByteString]
       val size: Long
 
+      def number: BigInt = header.number
       def block: Block = Block(header, body)
     }
 

--- a/src/test/scala/io/iohk/ethereum/SpecBase.scala
+++ b/src/test/scala/io/iohk/ethereum/SpecBase.scala
@@ -6,15 +6,14 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
-
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import scala.language.higherKinds
 import org.scalatest.diagrams.Diagrams
 import org.scalatest.flatspec.AsyncFlatSpecLike
 import org.scalatest.freespec.AsyncFreeSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpecLike
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.higherKinds
 
 trait SpecBase extends TypeCheckedTripleEquals with Diagrams with Matchers { self: AsyncTestSuite =>
 
@@ -40,7 +39,7 @@ trait SpecBase extends TypeCheckedTripleEquals with Diagrams with Matchers { sel
 
   def testCaseF(theTest: => Future[Assertion]): Future[Assertion] = customTestCaseF(())(_ => theTest)
 
-  def testCase(theTest: => Assertion): Future[Assertion] = testCaseM(Task.pure(theTest))
+  def testCase(theTest: => Assertion): Future[Assertion] = testCaseM(Task { theTest })
 }
 
 trait FlatSpecBase extends AsyncFlatSpecLike with SpecBase {}

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/EtcPeerManagerFake.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/EtcPeerManagerFake.scala
@@ -1,0 +1,136 @@
+package io.iohk.ethereum.blockchain.sync
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.TestActor.AutoPilot
+import akka.testkit.TestProbe
+import akka.util.ByteString
+import cats.effect.concurrent.Deferred
+import io.iohk.ethereum.blockchain.sync.PeerListSupport.PeersMap
+import io.iohk.ethereum.domain.{Block, BlockHeader}
+import io.iohk.ethereum.network.EtcPeerManagerActor
+import io.iohk.ethereum.network.EtcPeerManagerActor.SendMessage
+import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
+import io.iohk.ethereum.network.p2p.messages.PV62.{BlockBodies, BlockHeaders, GetBlockBodies, GetBlockHeaders}
+import io.iohk.ethereum.network.p2p.messages.PV63.{GetNodeData, GetReceipts, NodeData, Receipts}
+import io.iohk.ethereum.utils.Config.SyncConfig
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import monix.reactive.subjects.{ReplaySubject, Subject}
+
+class EtcPeerManagerFake(
+    syncConfig: SyncConfig,
+    peers: PeersMap,
+    blocks: List[Block],
+    getMptNodes: List[ByteString] => List[ByteString]
+)(implicit system: ActorSystem, scheduler: Scheduler) {
+  private val responsesSubject: Subject[MessageFromPeer, MessageFromPeer] = ReplaySubject()
+  private val requestsSubject: Subject[SendMessage, SendMessage] = ReplaySubject()
+  private val peersConnectedDeferred = Deferred.unsafe[Task, Unit]
+
+  val probe = TestProbe("etc_peer_manager")
+  val autoPilot =
+    new EtcPeerManagerFake.EtcPeerManagerAutoPilot(
+      requestsSubject,
+      responsesSubject,
+      peersConnectedDeferred,
+      peers,
+      blocks,
+      getMptNodes
+    )
+  probe.setAutoPilot(autoPilot)
+
+  def ref = probe.ref
+
+  val requests: Observable[SendMessage] = requestsSubject
+  val responses: Observable[MessageFromPeer] = responsesSubject
+  val onPeersConnected: Task[Unit] = peersConnectedDeferred.get
+  val pivotBlockSelected: Observable[BlockHeader] = responses
+    .collect { case MessageFromPeer(BlockHeaders(Seq(header)), peer) =>
+      (header, peer)
+    }
+    .bufferTumbling(peers.size)
+    .concatMap(headersFromPeers => {
+      val (headers, respondedPeers) = headersFromPeers.unzip
+
+      if (headers.distinct.size == 1 && respondedPeers.toSet == peers.keySet.map(_.id)) {
+        Observable.pure(headers.head)
+      } else {
+        Observable.empty
+      }
+    })
+
+  val fetchedHeaders = responses
+    .collect {
+      case MessageFromPeer(BlockHeaders(headers), _) if headers.size == syncConfig.blockHeadersPerRequest => headers
+    }
+  val fetchedBodies = responses
+    .collect { case MessageFromPeer(BlockBodies(bodies), _) =>
+      bodies
+    }
+  val requestedReceipts = requests.collect(
+    Function.unlift(msg =>
+      msg.message.underlyingMsg match {
+        case GetReceipts(hashes) => Some(hashes)
+        case _ => None
+      }
+    )
+  )
+  val fetchedBlocks = fetchedBodies
+    .scan[(List[Block], List[Block])]((Nil, blocks)) { case ((_, remainingBlocks), bodies) =>
+      remainingBlocks.splitAt(bodies.size)
+    }
+    .map(_._1)
+    .combineLatestMap(requestedReceipts)((blocks, _) => blocks) // a big simplification, but should be sufficient here
+
+  val fetchedState = responses.collect { case MessageFromPeer(NodeData(values), peerId) =>
+    values
+  }
+
+}
+object EtcPeerManagerFake {
+  class EtcPeerManagerAutoPilot(
+      requests: Subject[SendMessage, SendMessage],
+      responses: Subject[MessageFromPeer, MessageFromPeer],
+      peersConnected: Deferred[Task, Unit],
+      peers: PeersMap,
+      blocks: List[Block],
+      getMptNodes: List[ByteString] => List[ByteString]
+  )(implicit scheduler: Scheduler)
+      extends AutoPilot {
+    def run(sender: ActorRef, msg: Any) = {
+      msg match {
+        case EtcPeerManagerActor.GetHandshakedPeers =>
+          sender ! EtcPeerManagerActor.HandshakedPeers(peers)
+          peersConnected.complete(()).onErrorHandle(_ => ()).runSyncUnsafe()
+        case sendMsg @ EtcPeerManagerActor.SendMessage(rawMsg, peerId) =>
+          requests.onNext(sendMsg)
+          val response = rawMsg.underlyingMsg match {
+            case GetBlockHeaders(startingBlock, maxHeaders, _, false) =>
+              val blockMatchesStart: Block => Boolean = block =>
+                startingBlock.fold(nr => block.number == nr, hash => block.hash == hash)
+              val headers = blocks.tails
+                .find(_.headOption.exists(blockMatchesStart))
+                .toList
+                .flatten
+                .take(maxHeaders.toInt)
+                .map(_.header)
+              BlockHeaders(headers)
+
+            case GetBlockBodies(hashes) =>
+              val bodies = hashes.flatMap(hash => blocks.find(_.hash == hash)).map(_.body)
+              BlockBodies(bodies)
+
+            case GetReceipts(blockHashes) =>
+              Receipts(blockHashes.map(_ => Nil))
+
+            case GetNodeData(mptElementsHashes) =>
+              NodeData(getMptNodes(mptElementsHashes.toList))
+          }
+          val theResponse = MessageFromPeer(response, peerId)
+          sender ! theResponse
+          responses.onNext(theResponse)
+      }
+      this
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/FastSyncSpec.scala
@@ -1,0 +1,181 @@
+package io.iohk.ethereum.blockchain.sync
+
+import akka.actor.ActorSystem
+import akka.pattern.ask
+import akka.testkit.{TestKit, TestProbe}
+import akka.util.Timeout
+import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status
+import io.iohk.ethereum.blockchain.sync.SyncProtocol.Status.Progress
+import io.iohk.ethereum.utils.Config.SyncConfig
+import io.iohk.ethereum.utils.GenOps.GenOps
+import io.iohk.ethereum.{FreeSpecBase, ObjectGenerators, SpecFixtures, WithActorSystemShutDown}
+import monix.eval.Task
+import monix.reactive.Observable
+import io.iohk.ethereum.BlockHelpers
+import io.iohk.ethereum.network.p2p.messages.CommonMessages
+
+import scala.concurrent.duration.DurationInt
+
+class FastSyncSpec
+    extends TestKit(ActorSystem("FastSync_testing"))
+    with FreeSpecBase
+    with SpecFixtures
+    with WithActorSystemShutDown {
+  implicit val timeout: Timeout = Timeout(10.seconds)
+
+  class Fixture extends EphemBlockchainTestSetup with TestSyncConfig with TestSyncPeers {
+    override lazy val syncConfig: SyncConfig =
+      defaultSyncConfig.copy(pivotBlockOffset = 5, fastSyncBlockValidationX = 5, fastSyncThrottle = 1.millis)
+    lazy val (stateRoot, trieProvider) = {
+      val stateNodesData = ObjectGenerators.genMultipleNodeData(20).pickValue
+
+      lazy val trieProvider = StateSyncUtils.TrieProvider()
+      lazy val stateRoot = trieProvider.buildWorld(stateNodesData)
+
+      (stateRoot, trieProvider)
+    }
+
+    lazy val testBlocks = BlockHelpers.generateChain(
+      20,
+      BlockHelpers.genesis,
+      block => block.copy(header = block.header.copy(stateRoot = stateRoot))
+    )
+
+    lazy val bestBlockAtStart = testBlocks(10)
+    lazy val expectedPivotBlockNumber = bestBlockAtStart.number - syncConfig.pivotBlockOffset
+    lazy val expectedTargetBlockNumber = expectedPivotBlockNumber + syncConfig.fastSyncBlockValidationX
+    lazy val testPeers = twoAcceptedPeers.mapValues(peerInfo => {
+      val lastBlock = bestBlockAtStart
+      peerInfo
+        .withBestBlockData(lastBlock.number, lastBlock.hash)
+        .copy(remoteStatus = peerInfo.remoteStatus match {
+          case s63: CommonMessages.Status63 => s63.copy(bestHash = lastBlock.hash)
+          case s64: CommonMessages.Status64 => s64.copy(bestHash = lastBlock.hash)
+        })
+    })
+    lazy val etcPeerManager =
+      new EtcPeerManagerFake(
+        syncConfig,
+        testPeers,
+        testBlocks,
+        req => trieProvider.getNodes(req).map(_.data)
+      )
+    lazy val peerEventBus = TestProbe("peer_event-bus")
+    lazy val fastSync = system.actorOf(
+      FastSync.props(
+        fastSyncStateStorage = storagesInstance.storages.fastSyncStateStorage,
+        appStateStorage = storagesInstance.storages.appStateStorage,
+        blockchain = blockchain,
+        validators = validators,
+        peerEventBus = peerEventBus.ref,
+        etcPeerManager = etcPeerManager.ref,
+        syncConfig = syncConfig,
+        scheduler = system.scheduler
+      )
+    )
+
+    val saveGenesis: Task[Unit] = Task {
+      blockchain.save(BlockHelpers.genesis, receipts = Nil, totalDifficulty = 1, saveAsBestBlock = true)
+    }
+
+    val startSync: Task[Unit] = Task { fastSync ! SyncProtocol.Start }
+
+    val getSyncStatus: Task[Status] =
+      Task.deferFuture((fastSync ? SyncProtocol.GetStatus).mapTo[Status])
+  }
+
+  override def createFixture(): Fixture = new Fixture
+
+  "FastSync" - {
+    "for reporting progress" - {
+      "returns NotSyncing until pivot block is selected and first data being fetched" in testCaseM { fixture =>
+        import fixture._
+
+        (for {
+          _ <- startSync
+          status <- getSyncStatus
+        } yield assert(status === Status.NotSyncing)).timeout(timeout.duration)
+      }
+
+      "returns Syncing when pivot block is selected and started fetching data" in testCaseM { fixture =>
+        import fixture._
+
+        (for {
+          _ <- saveGenesis
+          _ <- startSync
+          _ <- etcPeerManager.onPeersConnected
+          _ <- etcPeerManager.pivotBlockSelected.firstL
+          _ <- etcPeerManager.fetchedHeaders.firstL
+          status <- getSyncStatus
+        } yield {
+          status match {
+            case Status.Syncing(startingBlockNumber, blocksProgress, stateNodesProgress) =>
+              assert(startingBlockNumber === BigInt(0))
+              assert(blocksProgress.target === expectedPivotBlockNumber)
+              assert(stateNodesProgress === Some(Progress(0, 1)))
+            case Status.NotSyncing | Status.SyncDone => fail("Expected syncing status")
+          }
+        })
+          .timeout(timeout.duration)
+      }
+
+      "returns Syncing with block progress once both header and body is fetched" in testCaseM { fixture =>
+        import fixture._
+
+        (for {
+          _ <- saveGenesis
+          _ <- startSync
+          _ <- etcPeerManager.onPeersConnected
+          _ <- etcPeerManager.pivotBlockSelected.firstL
+          blocksBatch <- etcPeerManager.fetchedBlocks.firstL
+          status <- getSyncStatus
+          lastBlockFromBatch = blocksBatch.last.number
+        } yield {
+          status match {
+            case Status.Syncing(startingBlockNumber, blocksProgress, stateNodesProgress) =>
+              assert(startingBlockNumber === BigInt(0))
+              assert(blocksProgress.current >= lastBlockFromBatch)
+              assert(blocksProgress.target === expectedPivotBlockNumber)
+              assert(stateNodesProgress === Some(Progress(0, 1)))
+            case Status.NotSyncing | Status.SyncDone => fail("Expected other state")
+          }
+        })
+          .timeout(timeout.duration)
+      }
+
+      "returns Syncing with state nodes progress" in customTestCaseM(new Fixture {
+        override lazy val syncConfig =
+          defaultSyncConfig.copy(
+            peersScanInterval = 1.second,
+            pivotBlockOffset = 5,
+            fastSyncBlockValidationX = 1,
+            fastSyncThrottle = 1.millis
+          )
+      }) { fixture: Fixture =>
+        import fixture._
+
+        (for {
+          _ <- saveGenesis
+          _ <- startSync
+          _ <- etcPeerManager.onPeersConnected
+          _ <- etcPeerManager.pivotBlockSelected.firstL
+          _ <- Observable
+            .interval(10.millis)
+            .mapEval(_ => getSyncStatus)
+            .collect {
+              case stat @ Status.Syncing(_, Progress(current, _), _) if current >= expectedTargetBlockNumber => stat
+            }
+            .firstL
+          _ <- Observable
+            .interval(10.millis)
+            .mapEval(_ => getSyncStatus)
+            .collect {
+              case stat @ Status.Syncing(_, _, Some(stateNodesProgress)) if stateNodesProgress.target > 1 =>
+                stat
+            }
+            .firstL
+        } yield succeed).timeout(timeout.duration)
+      }
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -53,6 +53,7 @@ class StateSyncSpec
   "StateSync" should "sync state to different tries" in new TestSetup() {
     forAll(ObjectGenerators.genMultipleNodeData(3000)) { nodeData =>
       val initiator = TestProbe()
+      initiator.ignoreMsg { case SyncStateSchedulerActor.StateSyncStats(_, _) => true }
       val trieProvider = TrieProvider()
       val target = trieProvider.buildWorld(nodeData)
       setAutoPilotWithProvider(trieProvider)
@@ -64,6 +65,7 @@ class StateSyncSpec
   it should "sync state to different tries when peers provide different set of data each time" in new TestSetup() {
     forAll(ObjectGenerators.genMultipleNodeData(1000)) { nodeData =>
       val initiator = TestProbe()
+      initiator.ignoreMsg { case SyncStateSchedulerActor.StateSyncStats(_, _) => true }
       val trieProvider1 = TrieProvider()
       val target = trieProvider1.buildWorld(nodeData)
       setAutoPilotWithProvider(trieProvider1, partialResponseConfig)
@@ -75,6 +77,7 @@ class StateSyncSpec
   it should "sync state to different tries when peer provide mixed responses" in new TestSetup() {
     forAll(ObjectGenerators.genMultipleNodeData(1000)) { nodeData =>
       val initiator = TestProbe()
+      initiator.ignoreMsg { case SyncStateSchedulerActor.StateSyncStats(_, _) => true }
       val trieProvider1 = TrieProvider()
       val target = trieProvider1.buildWorld(nodeData)
       setAutoPilotWithProvider(trieProvider1, mixedResponseConfig)
@@ -125,6 +128,7 @@ class StateSyncSpec
     }
     val nodeData = (0 until 1000).map(i => MptNodeData(Address(i), None, Seq(), i))
     val initiator = TestProbe()
+    initiator.ignoreMsg { case SyncStateSchedulerActor.StateSyncStats(_, _) => true }
     val trieProvider1 = TrieProvider()
     val target = trieProvider1.buildWorld(nodeData)
     setAutoPilotWithProvider(trieProvider1)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncControllerSpec.scala
@@ -1,7 +1,5 @@
 package io.iohk.ethereum.blockchain.sync
 
-import java.net.InetSocketAddress
-
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{TestActorRef, TestProbe}
@@ -14,16 +12,15 @@ import io.iohk.ethereum.consensus.validators.{BlockHeaderValid, BlockHeaderValid
 import io.iohk.ethereum.domain.{Account, BlockBody, BlockHeader, Receipt}
 import io.iohk.ethereum.ledger.Ledger
 import io.iohk.ethereum.ledger.Ledger.VMImpl
-import io.iohk.ethereum.network.EtcPeerManagerActor.{HandshakedPeers, PeerInfo, SendMessage}
+import io.iohk.ethereum.network.EtcPeerManagerActor
+import io.iohk.ethereum.network.EtcPeerManagerActor.{HandshakedPeers, SendMessage}
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
 import io.iohk.ethereum.network.p2p.messages.PV62.GetBlockBodies.GetBlockBodiesEnc
 import io.iohk.ethereum.network.p2p.messages.PV62.GetBlockHeaders.GetBlockHeadersEnc
 import io.iohk.ethereum.network.p2p.messages.PV62._
 import io.iohk.ethereum.network.p2p.messages.PV63.GetNodeData.GetNodeDataEnc
 import io.iohk.ethereum.network.p2p.messages.PV63.GetReceipts.GetReceiptsEnc
 import io.iohk.ethereum.network.p2p.messages.PV63.{NodeData, Receipts}
-import io.iohk.ethereum.network.{EtcPeerManagerActor, Peer}
 import io.iohk.ethereum.utils.Config.SyncConfig
 import io.iohk.ethereum.{Fixtures, Mocks}
 import org.bouncycastle.util.encoders.Hex
@@ -52,30 +49,30 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
   }
 
   "SyncController" should "download pivot block and request block headers" in new TestSetup() {
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(twoAcceptedPeers)
 
-    setupAutoPilot(etcPeerManager, handshakedPeers, defaultpivotBlockHeader, BlockchainData(Seq()))
+    setupAutoPilot(etcPeerManager, handshakedPeers, defaultPivotBlockHeader, BlockchainData(Seq()))
 
     eventually(timeout = eventuallyTimeOut) {
       val syncState = storagesInstance.storages.fastSyncStateStorage.getSyncState().get
       syncState.bestBlockHeaderNumber shouldBe 0
-      syncState.pivotBlock == defaultpivotBlockHeader
+      syncState.pivotBlock == defaultPivotBlockHeader
     }
   }
 
   it should "download better pivot block, request state, blocks and finish when downloaded" in new TestSetup() {
     startWithState(defaultStateBeforeNodeRestart)
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
 
     val newBlocks =
       getHeaders(defaultStateBeforeNodeRestart.bestBlockHeaderNumber + 1, syncConfig.blockHeadersPerRequest)
 
-    setupAutoPilot(etcPeerManager, handshakedPeers, defaultpivotBlockHeader, BlockchainData(newBlocks))
+    setupAutoPilot(etcPeerManager, handshakedPeers, defaultPivotBlockHeader, BlockchainData(newBlocks))
 
     val watcher = TestProbe()
     watcher.watch(syncController)
@@ -85,14 +82,14 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
       val children = syncController.children
       assert(storagesInstance.storages.appStateStorage.isFastSyncDone())
       assert(children.exists(ref => ref.path.name == "regular-sync"))
-      assert(blockchain.getBestBlockNumber() == defaultpivotBlockHeader.number)
+      assert(blockchain.getBestBlockNumber() == defaultPivotBlockHeader.number)
     }
   }
 
   it should "gracefully handle receiving empty receipts while syncing" in new TestSetup() {
     startWithState(defaultStateBeforeNodeRestart)
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
     val watcher = TestProbe()
@@ -104,7 +101,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     setupAutoPilot(
       etcPeerManager,
       handshakedPeers,
-      defaultpivotBlockHeader,
+      defaultPivotBlockHeader,
       BlockchainData(newBlocks),
       failedReceiptsTries = 1
     )
@@ -114,29 +111,31 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
       //switch to regular download
       val children = syncController.children
       assert(children.exists(ref => ref.path.name == "regular-sync"))
-      assert(blockchain.getBestBlockNumber() == defaultpivotBlockHeader.number)
+      assert(blockchain.getBestBlockNumber() == defaultPivotBlockHeader.number)
     }
   }
 
-  it should "handle blocks that fail validation" in new TestSetup(_validators = new Mocks.MockValidatorsAlwaysSucceed {
-    override val blockHeaderValidator: BlockHeaderValidator = { (blockHeader, getBlockHeaderByHash) =>
-      Left(HeaderPoWError)
+  it should "handle blocks that fail validation" in new TestSetup(
+    _validators = new Mocks.MockValidatorsAlwaysSucceed {
+      override val blockHeaderValidator: BlockHeaderValidator = { (blockHeader, getBlockHeaderByHash) =>
+        Left(HeaderPoWError)
+      }
     }
-  }) {
+  ) {
     startWithState(
       defaultStateBeforeNodeRestart.copy(nextBlockToFullyValidate =
         defaultStateBeforeNodeRestart.bestBlockHeaderNumber + 1
       )
     )
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
 
     val newBlocks =
       getHeaders(defaultStateBeforeNodeRestart.bestBlockHeaderNumber + 1, syncConfig.blockHeadersPerRequest)
 
-    setupAutoPilot(etcPeerManager, handshakedPeers, defaultpivotBlockHeader, BlockchainData(newBlocks), 0, 0)
+    setupAutoPilot(etcPeerManager, handshakedPeers, defaultPivotBlockHeader, BlockchainData(newBlocks), 0, 0)
 
     val watcher = TestProbe()
     watcher.watch(syncController)
@@ -153,18 +152,18 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
   it should "rewind fast-sync state if received header have no known parent" in new TestSetup() {
     startWithState(defaultStateBeforeNodeRestart)
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
 
     val newBlocks = Seq(
-      defaultpivotBlockHeader.copy(
+      defaultPivotBlockHeader.copy(
         number = defaultStateBeforeNodeRestart.bestBlockHeaderNumber + 1,
         parentHash = ByteString(1, 2, 3)
       )
     )
 
-    setupAutoPilot(etcPeerManager, handshakedPeers, defaultpivotBlockHeader, BlockchainData(newBlocks))
+    setupAutoPilot(etcPeerManager, handshakedPeers, defaultPivotBlockHeader, BlockchainData(newBlocks))
 
     val watcher = TestProbe()
     watcher.watch(syncController)
@@ -188,7 +187,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
 
     startWithState(defaultStateBeforeNodeRestart)
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
     val watcher = TestProbe()
@@ -197,16 +196,15 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     val newBlocks =
       getHeaders(defaultStateBeforeNodeRestart.bestBlockHeaderNumber + 1, syncConfig.blockHeadersPerRequest)
 
-    setupAutoPilot(etcPeerManager, handshakedPeers, defaultpivotBlockHeader, BlockchainData(newBlocks))
-
+    setupAutoPilot(etcPeerManager, handshakedPeers, defaultPivotBlockHeader, BlockchainData(newBlocks))
     val fast = syncController.getSingleChild("fast-sync")
 
     eventually(timeout = eventuallyTimeOut) {
-      storagesInstance.storages.fastSyncStateStorage.getSyncState().get.pivotBlock shouldBe defaultpivotBlockHeader
+      storagesInstance.storages.fastSyncStateStorage.getSyncState().get.pivotBlock shouldBe defaultPivotBlockHeader
     }
 
     // Send block that is way forward, we should ignore that block and blacklist that peer
-    val futureHeaders = Seq(defaultpivotBlockHeader.copy(number = defaultpivotBlockHeader.number + 20))
+    val futureHeaders = Seq(defaultPivotBlockHeader.copy(number = defaultPivotBlockHeader.number + 20))
     val stateBefore = storagesInstance.storages.fastSyncStateStorage.getSyncState().get
     fast ! PeerRequestHandler.ResponseReceived(peer1, BlockHeaders(futureHeaders), 2L)
 
@@ -232,11 +230,11 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
   }) {
     startWithState(defaultStateBeforeNodeRestart)
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
 
-    val newPivot = defaultpivotBlockHeader.copy(number = defaultpivotBlockHeader.number + 20)
+    val newPivot = defaultPivotBlockHeader.copy(number = defaultPivotBlockHeader.number + 20)
     val peerWithNewPivot = defaultPeer1Info.copy(maxBlockNumber = bestBlock + 20)
     val newHanshaked = HandshakedPeers(Map(peer1 -> peerWithNewPivot))
 
@@ -245,10 +243,10 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     val newBlocks =
       getHeaders(defaultStateBeforeNodeRestart.bestBlockHeaderNumber + 1, syncConfig.blockHeadersPerRequest)
 
-    setupAutoPilot(etcPeerManager, handshakedPeers, defaultpivotBlockHeader, BlockchainData(newBlocks))
+    setupAutoPilot(etcPeerManager, handshakedPeers, defaultPivotBlockHeader, BlockchainData(newBlocks))
 
     eventually(timeout = eventuallyTimeOut) {
-      storagesInstance.storages.fastSyncStateStorage.getSyncState().get.pivotBlock shouldBe defaultpivotBlockHeader
+      storagesInstance.storages.fastSyncStateStorage.getSyncState().get.pivotBlock shouldBe defaultPivotBlockHeader
     }
 
     setupAutoPilot(etcPeerManager, newHanshaked, newPivot, BlockchainData(newBlocks))
@@ -267,13 +265,13 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
 
   it should "not process, out of date new pivot block" in new TestSetup() {
     startWithState(defaultStateBeforeNodeRestart)
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val staleNewPeer1Info = defaultPeer1Info.copy(maxBlockNumber = bestBlock - 2)
-    val staleHeader = defaultpivotBlockHeader.copy(number = defaultpivotBlockHeader.number - 2)
+    val staleHeader = defaultPivotBlockHeader.copy(number = defaultPivotBlockHeader.number - 2)
     val staleHandshakedPeers = HandshakedPeers(Map(peer1 -> staleNewPeer1Info))
 
-    val freshHeader = defaultpivotBlockHeader
+    val freshHeader = defaultPivotBlockHeader
     val freshPeerInfo1 = defaultPeer1Info
     val freshHandshakedPeers = HandshakedPeers(Map(peer1 -> freshPeerInfo1))
 
@@ -292,15 +290,15 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     setupAutoPilot(etcPeerManager, freshHandshakedPeers, freshHeader, BlockchainData(newBlocks), onlyPivot = true)
 
     eventually(timeout = eventuallyTimeOut) {
-      storagesInstance.storages.fastSyncStateStorage.getSyncState().get.pivotBlock shouldBe defaultpivotBlockHeader
+      storagesInstance.storages.fastSyncStateStorage.getSyncState().get.pivotBlock shouldBe defaultPivotBlockHeader
     }
   }
 
   it should "start state download only when pivot block is fresh enough" in new TestSetup() {
     startWithState(defaultStateBeforeNodeRestart)
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
-    val freshHeader = defaultpivotBlockHeader.copy(number = defaultpivotBlockHeader.number + 9)
+    val freshHeader = defaultPivotBlockHeader.copy(number = defaultPivotBlockHeader.number + 9)
     val freshPeerInfo1 = defaultPeer1Info.copy(maxBlockNumber = bestBlock + 9)
     val freshHandshakedPeers = HandshakedPeers(Map(peer1 -> freshPeerInfo1))
 
@@ -317,7 +315,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
         .bestBlockHeaderNumber shouldBe freshHeader.number + syncConfig.fastSyncBlockValidationX
     }
 
-    val freshHeader1 = defaultpivotBlockHeader.copy(number = defaultpivotBlockHeader.number + 19)
+    val freshHeader1 = defaultPivotBlockHeader.copy(number = defaultPivotBlockHeader.number + 19)
     val freshPeerInfo1a = defaultPeer1Info.copy(maxBlockNumber = bestBlock + 19)
     val freshHandshakedPeers1 = HandshakedPeers(Map(peer1 -> freshPeerInfo1a))
 
@@ -344,7 +342,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
 
     startWithState(defaultStateBeforeNodeRestart)
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
     val watcher = TestProbe()
@@ -356,7 +354,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     setupAutoPilot(
       etcPeerManager,
       handshakedPeers,
-      defaultpivotBlockHeader,
+      defaultPivotBlockHeader,
       BlockchainData(newBlocks),
       failedBodiesTries = 1
     )
@@ -366,14 +364,14 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
       //switch to regular download
       val children = syncController.children
       assert(children.exists(ref => ref.path.name == "regular-sync"))
-      assert(blockchain.getBestBlockNumber() == defaultpivotBlockHeader.number)
+      assert(blockchain.getBestBlockNumber() == defaultPivotBlockHeader.number)
     }
   }
 
   it should "update pivot block during state sync if it goes stale" in new TestSetup() {
     startWithState(defaultStateBeforeNodeRestart)
 
-    syncController ! SyncController.Start
+    syncController ! SyncProtocol.Start
 
     val handshakedPeers = HandshakedPeers(singlePeer)
 
@@ -383,7 +381,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     setupAutoPilot(
       etcPeerManager,
       handshakedPeers,
-      defaultpivotBlockHeader,
+      defaultPivotBlockHeader,
       BlockchainData(newBlocks),
       failedNodeRequest = true
     )
@@ -397,7 +395,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     }
     val peerWithBetterBlock = defaultPeer1Info.copy(maxBlockNumber = bestBlock + syncConfig.maxPivotBlockAge)
     val newHandshakedPeers = HandshakedPeers(Map(peer1 -> peerWithBetterBlock))
-    val newPivot = defaultpivotBlockHeader.copy(number = defaultpivotBlockHeader.number + syncConfig.maxPivotBlockAge)
+    val newPivot = defaultPivotBlockHeader.copy(number = defaultPivotBlockHeader.number + syncConfig.maxPivotBlockAge)
 
     setupAutoPilot(etcPeerManager, newHandshakedPeers, newPivot, BlockchainData(newBlocks), failedNodeRequest = true)
 
@@ -426,6 +424,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
       blocksForWhichLedgerFails: Seq[BigInt] = Nil,
       _validators: Validators = new Mocks.MockValidatorsAlwaysSucceed
   ) extends EphemBlockchainTestSetup
+      with TestSyncPeers
       with TestSyncConfig {
     var stateDownloadStarted = false
 
@@ -494,59 +493,6 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
     blockchain.storeTotalDifficulty(baseBlockHeader.parentHash, BigInt(0)).commit()
 
     val startDelayMillis = 200
-
-    val peer1TestProbe: TestProbe = TestProbe("peer1")(system)
-    val peer2TestProbe: TestProbe = TestProbe("peer2")(system)
-    val peer3TestProbe: TestProbe = TestProbe("peer3")(system)
-
-    val peer1 = Peer(new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
-    val peer2 = Peer(new InetSocketAddress("127.0.0.2", 0), peer2TestProbe.ref, false)
-    val peer3 = Peer(new InetSocketAddress("127.0.0.3", 0), peer3TestProbe.ref, false)
-
-    val peer1Status = Status(1, 1, 20, ByteString("peer1_bestHash"), ByteString("unused"))
-    val peer2Status = Status(1, 1, 20, ByteString("peer2_bestHash"), ByteString("unused"))
-
-    val bestBlock = 400000
-    val expectedPivotBlock = bestBlock - syncConfig.pivotBlockOffset
-
-    val defaultPeer1Info = PeerInfo(
-      peer1Status,
-      forkAccepted = true,
-      totalDifficulty = peer1Status.totalDifficulty,
-      maxBlockNumber = bestBlock,
-      latestCheckpointNumber = peer1Status.latestCheckpointNumber,
-      bestBlockHash = peer1Status.bestHash
-    )
-
-    val twoAcceptedPeers = Map(
-      peer1 -> PeerInfo(
-        peer1Status,
-        forkAccepted = true,
-        totalDifficulty = peer1Status.totalDifficulty,
-        maxBlockNumber = bestBlock,
-        latestCheckpointNumber = peer1Status.latestCheckpointNumber,
-        bestBlockHash = peer1Status.bestHash
-      ),
-      peer2 -> PeerInfo(
-        peer2Status,
-        forkAccepted = true,
-        totalDifficulty = peer1Status.totalDifficulty,
-        maxBlockNumber = bestBlock,
-        latestCheckpointNumber = peer1Status.latestCheckpointNumber,
-        bestBlockHash = peer2Status.bestHash
-      )
-    )
-
-    val singlePeer = Map(
-      peer1 -> PeerInfo(
-        peer1Status,
-        forkAccepted = true,
-        totalDifficulty = peer1Status.totalDifficulty,
-        maxBlockNumber = bestBlock,
-        latestCheckpointNumber = peer1Status.latestCheckpointNumber,
-        bestBlockHash = peer1Status.bestHash
-      )
-    )
 
     case class BlockchainData(
         headers: Map[BigInt, BlockHeader],
@@ -640,11 +586,15 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
 
     val defaultStateRoot = "deae1dfad5ec8dcef15915811e1f044d2543674fd648f94345231da9fc2646cc"
 
-    val defaultpivotBlockHeader =
+    val defaultPivotBlockHeader =
       baseBlockHeader.copy(number = defaultExpectedPivotBlock, stateRoot = ByteString(Hex.decode(defaultStateRoot)))
 
     val defaultState =
-      SyncState(defaultpivotBlockHeader, defaultSafeDownloadTarget, bestBlockHeaderNumber = defaultBestBlock)
+      SyncState(
+        defaultPivotBlockHeader,
+        safeDownloadTarget = defaultSafeDownloadTarget,
+        bestBlockHeaderNumber = defaultBestBlock
+      )
 
     val defaultStateMptLeafWithAccount =
       ByteString(
@@ -653,7 +603,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
         )
       )
 
-    val beforeRestartPivot = defaultpivotBlockHeader.copy(number = defaultExpectedPivotBlock - 1)
+    val beforeRestartPivot = defaultPivotBlockHeader.copy(number = defaultExpectedPivotBlock - 1)
     val defaultStateBeforeNodeRestart = defaultState.copy(
       pivotBlock = beforeRestartPivot,
       bestBlockHeaderNumber = defaultExpectedPivotBlock,
@@ -662,7 +612,7 @@ class SyncControllerSpec extends AnyFlatSpec with Matchers with BeforeAndAfter w
 
     def getHeaders(from: BigInt, number: BigInt): Seq[BlockHeader] = {
       val headers = (from until from + number).toSeq.map { nr =>
-        defaultpivotBlockHeader.copy(number = nr)
+        defaultPivotBlockHeader.copy(number = nr)
       }
 
       def genChain(

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncConfig.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncConfig.scala
@@ -7,8 +7,8 @@ import scala.concurrent.duration._
 
 trait TestSyncConfig extends SyncConfigBuilder {
   def defaultSyncConfig: SyncConfig = SyncConfig(
-    printStatusInterval = 1.hour,
-    persistStateSnapshotInterval = 20.seconds,
+    printStatusInterval = 1.second,
+    persistStateSnapshotInterval = 2.seconds,
     pivotBlockOffset = 500,
     branchResolutionRequestSize = 2,
     blacklistDuration = 5.seconds,

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncPeers.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncPeers.scala
@@ -1,0 +1,66 @@
+package io.iohk.ethereum.blockchain.sync
+import java.net.InetSocketAddress
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import akka.util.ByteString
+import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
+import io.iohk.ethereum.network.Peer
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
+
+trait TestSyncPeers { self: TestSyncConfig =>
+  implicit def system: ActorSystem
+
+  val peer1TestProbe: TestProbe = TestProbe("peer1")(system)
+  val peer2TestProbe: TestProbe = TestProbe("peer2")(system)
+  val peer3TestProbe: TestProbe = TestProbe("peer3")(system)
+
+  val peer1 = Peer(new InetSocketAddress("127.0.0.1", 0), peer1TestProbe.ref, false)
+  val peer2 = Peer(new InetSocketAddress("127.0.0.2", 0), peer2TestProbe.ref, false)
+  val peer3 = Peer(new InetSocketAddress("127.0.0.3", 0), peer3TestProbe.ref, false)
+
+  val peer1Status = Status(1, 1, 20, ByteString("peer1_bestHash"), ByteString("unused"))
+  val peer2Status = Status(1, 1, 20, ByteString("peer2_bestHash"), ByteString("unused"))
+
+  val bestBlock = 400000
+  val expectedPivotBlock = bestBlock - syncConfig.pivotBlockOffset
+
+  val defaultPeer1Info = PeerInfo(
+    peer1Status,
+    forkAccepted = true,
+    totalDifficulty = peer1Status.totalDifficulty,
+    maxBlockNumber = bestBlock,
+    bestBlockHash = peer1Status.bestHash,
+    latestCheckpointNumber = peer1Status.latestCheckpointNumber
+  )
+
+  val twoAcceptedPeers = Map(
+    peer1 -> PeerInfo(
+      peer1Status,
+      forkAccepted = true,
+      totalDifficulty = peer1Status.totalDifficulty,
+      maxBlockNumber = bestBlock,
+      bestBlockHash = peer1Status.bestHash,
+      latestCheckpointNumber = peer1Status.latestCheckpointNumber
+    ),
+    peer2 -> PeerInfo(
+      peer2Status,
+      forkAccepted = true,
+      totalDifficulty = peer1Status.totalDifficulty,
+      maxBlockNumber = bestBlock,
+      bestBlockHash = peer2Status.bestHash,
+      latestCheckpointNumber = peer1Status.latestCheckpointNumber
+    )
+  )
+
+  val singlePeer = Map(
+    peer1 -> PeerInfo(
+      peer1Status,
+      forkAccepted = true,
+      totalDifficulty = peer1Status.totalDifficulty,
+      maxBlockNumber = bestBlock,
+      bestBlockHash = peer1Status.bestHash,
+      latestCheckpointNumber = peer1Status.latestCheckpointNumber
+    )
+  )
+}

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -134,6 +134,7 @@ class BlockFetcherSpec extends TestKit(ActorSystem("BlockFetcherSpec_System")) w
     val peersClient: TestProbe = TestProbe()
     val peerEventBus: TestProbe = TestProbe()
     val importer: TestProbe = TestProbe()
+    val regularSync: TestProbe = TestProbe()
 
     override lazy val syncConfig = defaultSyncConfig.copy(
       // Same request size was selected for simplification purposes of the flow
@@ -151,6 +152,7 @@ class BlockFetcherSpec extends TestKit(ActorSystem("BlockFetcherSpec_System")) w
         .props(
           peersClient.ref,
           peerEventBus.ref,
+          regularSync.ref,
           syncConfig,
           time.scheduler
         )

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -3,19 +3,18 @@ package io.iohk.ethereum.blockchain.sync.regular
 import java.net.InetSocketAddress
 
 import akka.actor.{ActorRef, ActorSystem, PoisonPill}
+import akka.pattern.ask
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{TestKitBase, TestProbe}
-import akka.util.ByteString
-import akka.util.ByteString.{empty => bEmpty}
+import akka.util.{ByteString, Timeout}
 import cats.Eq
-import cats.instances.list._
-import cats.syntax.functor._
+import cats.implicits._
+import io.iohk.ethereum.BlockHelpers
 import io.iohk.ethereum.blockchain.sync.PeerListSupport.PeersMap
-import io.iohk.ethereum.blockchain.sync.{EphemBlockchainTestSetup, PeersClient, TestSyncConfig}
+import io.iohk.ethereum.blockchain.sync._
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
-import io.iohk.ethereum.crypto.generateKeyPair
-import io.iohk.ethereum.domain._
 import io.iohk.ethereum.domain.BlockHeaderImplicits._
+import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger._
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.PeerEventBusActor.PeerEvent.MessageFromPeer
@@ -27,24 +26,26 @@ import io.iohk.ethereum.network.p2p.messages.PV63.{GetNodeData, NodeData}
 import io.iohk.ethereum.network.{Peer, PeerId}
 import io.iohk.ethereum.nodebuilder.SecureRandomBuilder
 import io.iohk.ethereum.utils.Config.SyncConfig
-import io.iohk.ethereum.{Fixtures, ObjectGenerators}
-import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-import org.scalamock.scalatest.MockFactory
+import monix.eval.Task
+import monix.reactive.Observable
+import monix.reactive.subjects.ReplaySubject
+import org.scalamock.scalatest.AsyncMockFactory
 import org.scalatest.matchers.should.Matchers
 
 import scala.collection.mutable
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.math.BigInt
 import scala.reflect.ClassTag
 
 // Fixture classes are wrapped in a trait due to problems with making mocks available inside of them
-trait RegularSyncFixtures { self: Matchers with MockFactory =>
-  abstract class RegularSyncFixture(_system: ActorSystem)
+trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
+  class RegularSyncFixture(_system: ActorSystem)
       extends TestKitBase
       with EphemBlockchainTestSetup
       with TestSyncConfig
       with SecureRandomBuilder {
+    implicit lazy val timeout: Timeout = remainingOrDefault
     implicit override lazy val system: ActorSystem = _system
     override lazy val syncConfig: SyncConfig =
       defaultSyncConfig.copy(blockHeadersPerRequest = 2, blockBodiesPerRequest = 2)
@@ -76,58 +77,23 @@ trait RegularSyncFixtures { self: Matchers with MockFactory =>
         .withDispatcher("akka.actor.default-dispatcher")
     )
 
-    // scalastyle:off magic.number
-    val defaultHeader = Fixtures.Blocks.ValidBlock.header.copy(
-      difficulty = 1000000,
-      number = 1,
-      gasLimit = 1000000,
-      gasUsed = 0,
-      unixTimestamp = 0
-    )
-
-    val defaultTx = Transaction(
-      nonce = 42,
-      gasPrice = 1,
-      gasLimit = 90000,
-      receivingAddress = Address(123),
-      value = 0,
-      payload = bEmpty
-    )
-
     val defaultTd = 12345
 
-    val keyPair: AsymmetricCipherKeyPair = generateKeyPair(secureRandom)
-
-    val genesis: Block = Block(defaultHeader.copy(number = 0), BlockBody(Nil, Nil))
-    val testBlocks: List[Block] = getBlocks(20, genesis)
+    val testBlocks: List[Block] = BlockHelpers.generateChain(20, BlockHelpers.genesis)
     val testBlocksChunked: List[List[Block]] = testBlocks.grouped(syncConfig.blockHeadersPerRequest).toList
 
     override lazy val ledger = new TestLedgerImpl
 
-    blockchain.save(block = genesis, receipts = Nil, totalDifficulty = BigInt(10000), saveAsBestBlock = true)
+    blockchain.save(
+      block = BlockHelpers.genesis,
+      receipts = Nil,
+      totalDifficulty = BigInt(10000),
+      saveAsBestBlock = true
+    )
     // scalastyle:on magic.number
 
     def done(): Unit =
       regularSync ! PoisonPill
-
-    def randomHash(): ByteString =
-      ObjectGenerators.byteStringOfLengthNGen(32).sample.get
-
-    def getBlocks(amount: Int, parent: Block): List[Block] =
-      (1 to amount).toList.foldLeft[List[Block]](Nil)((generated, _) => {
-        val theParent = generated.lastOption.getOrElse(parent)
-        generated :+ getBlock(theParent)
-      })
-
-    def getBlock(nr: BigInt, parent: Block): Block = {
-      val header = defaultHeader.copy(extraData = randomHash(), number = nr, parentHash = parent.hash)
-      val ommer = defaultHeader.copy(extraData = randomHash())
-      val tx = defaultTx.copy(payload = randomHash())
-      val stx = SignedTransaction.sign(tx, keyPair, None)
-
-      Block(header, BlockBody(List(stx.tx), List(ommer)))
-    }
-    def getBlock(parent: Block): Block = getBlock(parent.number + 1, parent)
 
     def peerId(number: Int): PeerId = PeerId(s"peer_$number")
 
@@ -148,9 +114,14 @@ trait RegularSyncFixtures { self: Matchers with MockFactory =>
 
     def peerByNumber(number: Int): Peer = handshakedPeers.keys.toList.sortBy(_.id.value).apply(number)
 
-    def blockHeadersRequest(fromChunk: Int): PeersClient.Request[GetBlockHeaders] = PeersClient.Request.create(
+    def blockHeadersChunkRequest(fromChunk: Int): PeersClient.Request[GetBlockHeaders] = {
+      val block = testBlocksChunked(fromChunk).headNumberUnsafe
+      blockHeadersRequest(block)
+    }
+
+    def blockHeadersRequest(fromBlock: BigInt): PeersClient.Request[GetBlockHeaders] = PeersClient.Request.create(
       GetBlockHeaders(
-        Left(testBlocksChunked(fromChunk).headNumberUnsafe),
+        Left(fromBlock),
         syncConfig.blockHeadersPerRequest,
         skip = 0,
         reverse = false
@@ -163,30 +134,48 @@ trait RegularSyncFixtures { self: Matchers with MockFactory =>
         case msg @ PeersClient.BlacklistPeer(id, _) if id == peer.id => msg
       }
 
+    val getSyncStatus: Task[SyncProtocol.Status] =
+      Task.deferFuture((regularSync ? SyncProtocol.GetStatus).mapTo[SyncProtocol.Status])
+
+    def pollForStatus(predicate: SyncProtocol.Status => Boolean) = Observable
+      .repeatEvalF(getSyncStatus.delayExecution(10.millis))
+      .takeWhileInclusive(predicate andThen (!_))
+      .lastL
+      .timeout(remainingOrDefault)
+
+    def fishForStatus[B](picker: PartialFunction[SyncProtocol.Status, B]) = Observable
+      .repeatEvalF(getSyncStatus.delayExecution(10.millis))
+      .collect(picker)
+      .firstL
+      .timeout(remainingOrDefault)
+
     class TestLedgerImpl extends LedgerImpl(blockchain, blockchainConfig, syncConfig, consensus, system.dispatcher) {
       protected val results = mutable.Map[ByteString, () => Future[BlockImportResult]]()
-      protected val importedBlocks = mutable.Set[Block]()
+      protected val importedBlocksSet = mutable.Set[Block]()
+      private val importedBlocksSubject = ReplaySubject[Block]()
+
+      val importedBlocks: Observable[Block] = importedBlocksSubject
 
       override def importBlock(
           block: Block
       )(implicit blockExecutionContext: ExecutionContext): Future[BlockImportResult] = {
-        importedBlocks.add(block)
-        results(block.hash)()
+        importedBlocksSet.add(block)
+        results(block.hash)().flatTap(_ => importedBlocksSubject.onNext(block))
       }
 
       override def getBlockByHash(hash: ByteString): Option[Block] =
-        importedBlocks.find(_.hash == hash)
+        importedBlocksSet.find(_.hash == hash)
 
       def setImportResult(block: Block, result: () => Future[BlockImportResult]): Unit =
         results(block.header.hash) = result
 
       def didTryToImportBlock(predicate: Block => Boolean): Boolean =
-        importedBlocks.exists(predicate)
+        importedBlocksSet.exists(predicate)
 
       def didTryToImportBlock(block: Block): Boolean =
         didTryToImportBlock(_.hash == block.hash)
 
-      def bestBlock: Block = importedBlocks.maxBy(_.number)
+      def bestBlock: Block = importedBlocksSet.maxBy(_.number)
     }
 
     class PeersClientAutoPilot(blocks: List[Block] = testBlocks) extends AutoPilot {
@@ -256,7 +245,7 @@ trait RegularSyncFixtures { self: Matchers with MockFactory =>
 
       def expectMsgEq[T: Eq](max: FiniteDuration, msg: T): T = {
         val received = probe.expectMsgClass(max, msg.getClass)
-        assert(Eq[T].eqv(received, msg))
+        assert(Eq[T].eqv(received, msg), s"Expected ${msg}, got ${received}")
         received
       }
 
@@ -288,9 +277,9 @@ trait RegularSyncFixtures { self: Matchers with MockFactory =>
       (x, y) => x.message == y.message && x.peerSelector == y.peerSelector
   }
 
-  abstract class OnTopFixture(system: ActorSystem) extends RegularSyncFixture(system) {
+  class OnTopFixture(system: ActorSystem) extends RegularSyncFixture(system) {
 
-    val newBlock: Block = getBlock(testBlocks.last)
+    val newBlock: Block = BlockHelpers.generateBlock(testBlocks.last)
 
     override lazy val ledger: TestLedgerImpl = stub[TestLedgerImpl]
 
@@ -327,7 +316,7 @@ trait RegularSyncFixtures { self: Matchers with MockFactory =>
       blockFetcher ! MessageFromPeer(NewBlock(block, block.number), peer.id)
 
     def goToTop(): Unit = {
-      regularSync ! RegularSync.Start
+      regularSync ! SyncProtocol.Start
 
       waitForSubscription()
       sendLastTestBlockAsTop()

--- a/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
@@ -406,7 +406,9 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val fullBlock = pendingBlock.block.copy(header =
       pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp)
     )
-    validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(BlockHeaderValid)
+    validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
+      BlockHeaderValid
+    )
     blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx)
     fullBlock.header.extraData shouldBe headerExtraData

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/MinerSpecSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/MinerSpecSetup.scala
@@ -4,8 +4,7 @@ import akka.actor.ActorSystem
 import akka.testkit.{TestActorRef, TestProbe}
 import akka.util.ByteString
 import io.iohk.ethereum.Fixtures
-import io.iohk.ethereum.blockchain.sync.ScenarioSetup
-import io.iohk.ethereum.blockchain.sync.regular.RegularSync.MinedBlock
+import io.iohk.ethereum.blockchain.sync.{ScenarioSetup, SyncProtocol}
 import io.iohk.ethereum.consensus.blocks.PendingBlock
 import io.iohk.ethereum.consensus.ethash.blocks.EthashBlockGenerator
 import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
@@ -13,6 +12,7 @@ import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.Ledger.VMImpl
 import org.bouncycastle.util.encoders.Hex
 import org.scalamock.scalatest.MockFactory
+
 import scala.concurrent.Future
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -26,7 +26,7 @@ abstract class MinerSpecSetup(implicit system: ActorSystem) extends ScenarioSetu
   val sync = TestProbe()
 
   def waitForMinedBlock(implicit timeout: Duration): Block = {
-    sync.expectMsgPF[Block](timeout) { case m: MinedBlock =>
+    sync.expectMsgPF[Block](timeout) { case m: SyncProtocol.MinedBlock =>
       m.block
     }
   }

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/BlockWithCheckpointHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/BlockWithCheckpointHeaderValidatorSpec.scala
@@ -225,7 +225,7 @@ class BlockWithCheckpointHeaderValidatorSpec
     val duplicatedSigner = ByteString(crypto.pubKeyFromKeyPair(keys.head))
     val expectedSigners =
       (keys.map(kp => ByteString(crypto.pubKeyFromKeyPair(kp))) :+ duplicatedSigner)
-      .sortBy(_.toSeq)
+        .sortBy(_.toSeq)
     actualSigners shouldEqual expectedSigners
 
     val headerWithInvalidCheckpoint = checkpointBlockGenerator
@@ -247,7 +247,8 @@ class BlockWithCheckpointHeaderValidatorSpec
   }
 
   it should "return when failure when checkpoint has too many signatures" in new TestSetup {
-    val invalidCheckpoint = validCheckpoint.copy(signatures = (validCheckpoint.signatures ++ validCheckpoint.signatures).sorted)
+    val invalidCheckpoint =
+      validCheckpoint.copy(signatures = (validCheckpoint.signatures ++ validCheckpoint.signatures).sorted)
     val invalidBlockHeaderExtraFields = HefPostEcip1097(false, Some(invalidCheckpoint))
     val invalidBlockHeader = validBlockHeaderWithCheckpoint.copy(extraFields = invalidBlockHeaderExtraFields)
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -74,7 +74,6 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
 
   val ethService = new EthService(
     blockchain,
-    appStateStorage,
     ledger,
     stxLedger,
     keyStore,
@@ -86,7 +85,8 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
     blockchainConfig,
     currentProtocolVersion,
     config,
-    getTransactionFromPoolTimeout
+    getTransactionFromPoolTimeout,
+    Timeouts.shortTimeout
   )
 
   protected def newJsonRpcController(ethService: EthService) =

--- a/src/test/scala/io/iohk/ethereum/testing/ActorsTesting.scala
+++ b/src/test/scala/io/iohk/ethereum/testing/ActorsTesting.scala
@@ -1,0 +1,18 @@
+package io.iohk.ethereum.testing
+import akka.actor.ActorRef
+import akka.testkit.TestActor.AutoPilot
+
+object ActorsTesting {
+  def simpleAutoPilot(makeResponse: PartialFunction[Any, Any]): AutoPilot = {
+    new AutoPilot {
+      def run(sender: ActorRef, msg: Any) = {
+        val response = makeResponse.lift(msg)
+        response match {
+          case Some(value) => sender ! value
+          case _ => ()
+        }
+        this
+      }
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/utils/GenOps.scala
+++ b/src/test/scala/io/iohk/ethereum/utils/GenOps.scala
@@ -1,0 +1,15 @@
+package io.iohk.ethereum.utils
+import org.scalacheck.Gen
+
+object GenOps {
+  implicit class GenOps[T](gen: Gen[T]) {
+    def pickValue: T =
+      Stream
+        .continually(gen)
+        .map(_.sample)
+        .collectFirst { case Some(value) =>
+          value
+        }
+        .get
+  }
+}


### PR DESCRIPTION
# Description

Update `eth_syncing` method to standarized output (https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/etclabscore/ethereum-json-rpc-specification/master/openrpc.json&uiSchema%5BappBar%5D%5Bui:input%5D=false)) and move sync progress reporting into sync module. 


# Important Changes Introduced

A `SyncProtocol` is used now for high-level communication between sync controller and specific implementations as well as outside sync controller. Probably it makes sense to further extend that change and hide it behind a well-typed task-returning interfaces.

State breakage is related to changed datatype for tracking state nodes progress - from `Int` to `Long` (as in sync state scheduler)

# Testing

1. All automatic tests should pass (most notably unit and it ones)
2. When sync is actually happening (data is being actively fetched from network) - `eth_syncing` should return full response, including information about state nodes.

