### PR TITLE
[Chore] Add client id for metrics

### DIFF
--- a/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
+++ b/src/main/scala/io/iohk/ethereum/metrics/Metrics.scala
@@ -33,10 +33,10 @@ case class Metrics(metricsPrefix: String, registry: MeterRegistry, serverPort: I
     */
   def gauge(name: String, computeValue: () => Double): Gauge =
     Gauge
-    // Note Never use `null` as the value for the second parameter.
-    //      If you do, you risk getting no metrics out of the gauge.
-    //      So we just use a vanilla `this` but any other non-`null`
-    //      value would also do.
+      // Note Never use `null` as the value for the second parameter.
+      //      If you do, you risk getting no metrics out of the gauge.
+      //      So we just use a vanilla `this` but any other non-`null`
+      //      value would also do.
       .builder(mkName(name), this, (_: Any) => computeValue())
       .register(registry)
 
@@ -85,7 +85,7 @@ object Metrics {
   def configure(config: MetricsConfig): Try[Unit] = {
     Try {
       if (config.enabled) {
-        val registry = MeterRegistryBuilder.build(MetricsPrefix)
+        val registry = MeterRegistryBuilder.build(MetricsPrefix, config)
         val metrics = new Metrics(MetricsPrefix, registry, config.port)
         if (setOnce(metrics))
           metrics.start()

--- a/src/main/scala/io/iohk/ethereum/metrics/MetricsConfig.scala
+++ b/src/main/scala/io/iohk/ethereum/metrics/MetricsConfig.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.metrics
 import com.typesafe.config.{Config => TypesafeConfig}
 
 final case class MetricsConfig(
+    clientId: String,
     enabled: Boolean,
     port: Int
 )
@@ -16,12 +17,14 @@ object MetricsConfig {
   }
 
   def apply(config: TypesafeConfig): MetricsConfig = {
+    val clientId = config.getString("client-id")
     val metricsConfig = config.getConfig(Keys.Metrics)
 
     val enabled = metricsConfig.getBoolean(Keys.Enabled)
     val port = metricsConfig.getInt(Keys.Port)
 
     MetricsConfig(
+      clientId = clientId,
       enabled = enabled,
       port = port
     )


### PR DESCRIPTION
## Description
I found out that either prefix and client id are not working for "externals" registers. But still we need this feature for our metrics, with high priority for the deployer instances.

![Screenshot(52)](https://user-images.githubusercontent.com/31509803/96037060-b526a480-0e3b-11eb-8f76-c488229a4ebf.png)
