### PR TITLE
[ETCM-174] Sorting of checkpoint signatures

### DIFF
--- a/src/main/scala/io/iohk/ethereum/consensus/blocks/CheckpointBlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/blocks/CheckpointBlockGenerator.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.consensus.blocks
 
 import akka.util.ByteString
+import io.iohk.ethereum.crypto.ECDSASignatureImplicits.ECDSASignatureOrdering
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1097
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BloomFilter
@@ -12,6 +13,7 @@ class CheckpointBlockGenerator {
     // we are using a predictable value for timestamp so that each federation node generates identical block
     // see ETCM-173
     val timestamp = parent.header.unixTimestamp + 1
+    val checkpointWithSortedSignatures = Checkpoint(checkpoint.signatures.sorted)
 
     val header = BlockHeader(
       parentHash = parent.hash,
@@ -29,7 +31,7 @@ class CheckpointBlockGenerator {
       gasUsed = UInt256.Zero,
       mixHash = ByteString.empty,
       nonce = ByteString.empty,
-      extraFields = HefPostEcip1097(false, Some(checkpoint))
+      extraFields = HefPostEcip1097(false, Some(checkpointWithSortedSignatures))
     )
 
     Block(header, BlockBody.empty)

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/BlockHeaderValidator.scala
@@ -42,6 +42,7 @@ object BlockHeaderError {
   case class HeaderWrongNumberOfCheckpointSignatures(sigCount: Int) extends BlockHeaderError
   case class HeaderInvalidCheckpointSignatures(invalidSignaturesWithPublics: Seq[(ECDSASignature, Option[String])])
       extends BlockHeaderError
+  case object HeaderInvalidOrderOfCheckpointSignatures extends BlockHeaderError
   case class HeaderFieldNotEmptyError(msg: String) extends BlockHeaderError
   case class HeaderNotMatchParentError(msg: String) extends BlockHeaderError
   case object CheckpointHeaderTreasuryOptOutError extends BlockHeaderError

--- a/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
+++ b/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
@@ -183,4 +183,5 @@ object ECDSASignatureImplicits {
     }
   }
 
+  implicit val ECDSASignatureOrdering: Ordering[ECDSASignature] = Ordering.by(sig => (sig.r, sig.s, sig.v))
 }

--- a/src/test/scala/io/iohk/ethereum/checkpointing/CheckpointingTestHelpers.scala
+++ b/src/test/scala/io/iohk/ethereum/checkpointing/CheckpointingTestHelpers.scala
@@ -6,6 +6,7 @@ import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1097
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.ledger.BloomFilter
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import io.iohk.ethereum.crypto.ECDSASignatureImplicits.ECDSASignatureOrdering
 
 object CheckpointingTestHelpers {
   def createBlockWithCheckpoint(
@@ -45,5 +46,5 @@ object CheckpointingTestHelpers {
   ): Seq[ECDSASignature] =
     keys.map { k =>
       ECDSASignature.sign(hash.toArray, k)
-    }
+    }.sorted
 }


### PR DESCRIPTION
# Description
Sort checkpoint signatures lexicographically to prevent having the same checkpoint block with a different hash (different order of signatures).

**Remember about changes on OBFT node side.**

# Important Changes Introduced

- added validator of lexicographical order of checkpoint signatures
