### PR TITLE
[ETCM-173] Re-think the timestamp validation rule of checkpoint blocks

### DIFF
--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/BlockchainTestConfig.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.ets.blockchain
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.Protocol
 import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
-import io.iohk.ethereum.domain.{Address, UInt256}
+import io.iohk.ethereum.domain.{Address, Blockchain, UInt256}
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig, MonetaryPolicyConfig}
 import org.bouncycastle.util.encoders.Hex
 
@@ -291,40 +291,40 @@ object BlockchainTestConfig {
   )
 }
 
-object Validators {
+class Validators(blockchain: Blockchain) {
   import BlockchainTestConfig._
 
-  val frontierValidators = ValidatorsExecutor(FrontierConfig, Protocol.Ethash)
-  val homesteadValidators = ValidatorsExecutor(HomesteadConfig, Protocol.Ethash)
-  val eip150Validators = ValidatorsExecutor(Eip150Config, Protocol.Ethash)
-  val frontierToHomesteadValidators = ValidatorsExecutor(FrontierToHomesteadAt5, Protocol.Ethash)
-  val homesteadToEipValidators = ValidatorsExecutor(HomesteadToEIP150At5, Protocol.Ethash)
-  val homesteadToDaoValidators= ValidatorsExecutor(HomesteadToDaoAt5, Protocol.Ethash)
-  val eip158Validators = ValidatorsExecutor(Eip158Config, Protocol.Ethash)
-  val byzantiumValidators = ValidatorsExecutor(ByzantiumConfig, Protocol.Ethash)
-  val constantinopleValidators = ValidatorsExecutor(ConstantinopleConfig, Protocol.Ethash)
-  val constantinopleFixValidators = ValidatorsExecutor(ConstantinopleFixConfig, Protocol.Ethash)
-  val istanbulValidators = ValidatorsExecutor(IstanbulConfig, Protocol.Ethash)
-  val eip158ToByzantiumValidators = ValidatorsExecutor(Eip158ToByzantiumAt5Config, Protocol.Ethash)
-  val byzantiumToConstantinopleAt5 = ValidatorsExecutor(ByzantiumToConstantinopleAt5, Protocol.Ethash)
+  val frontierValidators = ValidatorsExecutor(FrontierConfig, blockchain, Protocol.Ethash)
+  val homesteadValidators = ValidatorsExecutor(HomesteadConfig, blockchain, Protocol.Ethash)
+  val eip150Validators = ValidatorsExecutor(Eip150Config, blockchain, Protocol.Ethash)
+  val frontierToHomesteadValidators = ValidatorsExecutor(FrontierToHomesteadAt5, blockchain, Protocol.Ethash)
+  val homesteadToEipValidators = ValidatorsExecutor(HomesteadToEIP150At5, blockchain, Protocol.Ethash)
+  val homesteadToDaoValidators= ValidatorsExecutor(HomesteadToDaoAt5, blockchain, Protocol.Ethash)
+  val eip158Validators = ValidatorsExecutor(Eip158Config, blockchain, Protocol.Ethash)
+  val byzantiumValidators = ValidatorsExecutor(ByzantiumConfig, blockchain, Protocol.Ethash)
+  val constantinopleValidators = ValidatorsExecutor(ConstantinopleConfig, blockchain, Protocol.Ethash)
+  val constantinopleFixValidators = ValidatorsExecutor(ConstantinopleFixConfig, blockchain, Protocol.Ethash)
+  val istanbulValidators = ValidatorsExecutor(IstanbulConfig, blockchain, Protocol.Ethash)
+  val eip158ToByzantiumValidators = ValidatorsExecutor(Eip158ToByzantiumAt5Config, blockchain, Protocol.Ethash)
+  val byzantiumToConstantinopleAt5 = ValidatorsExecutor(ByzantiumToConstantinopleAt5, blockchain, Protocol.Ethash)
 }
 
 // Connected with: https://github.com/ethereum/tests/issues/480
-object ValidatorsWithSkippedPoW {
+class ValidatorsWithSkippedPoW(blockchain: Blockchain) {
 
   import BlockchainTestConfig._
 
-  val frontierValidators =  ValidatorsExecutor(FrontierConfig, new EthashTestBlockHeaderValidator(FrontierConfig))
-  val homesteadValidators = ValidatorsExecutor(HomesteadConfig, new EthashTestBlockHeaderValidator(HomesteadConfig))
-  val eip150Validators = ValidatorsExecutor(Eip150Config, new EthashTestBlockHeaderValidator(Eip150Config))
-  val frontierToHomesteadValidators = ValidatorsExecutor(FrontierToHomesteadAt5, new EthashTestBlockHeaderValidator(FrontierToHomesteadAt5))
-  val homesteadToEipValidators = ValidatorsExecutor(HomesteadToEIP150At5, new EthashTestBlockHeaderValidator(HomesteadToEIP150At5))
-  val homesteadToDaoValidators= ValidatorsExecutor(HomesteadToDaoAt5, new EthashTestBlockHeaderValidator(HomesteadToDaoAt5))
-  val eip158Validators = ValidatorsExecutor(Eip158Config, new EthashTestBlockHeaderValidator(Eip158Config))
-  val byzantiumValidators = ValidatorsExecutor(ByzantiumConfig, new EthashTestBlockHeaderValidator(ByzantiumConfig))
-  val constantinopleValidators = ValidatorsExecutor(ConstantinopleConfig, new EthashTestBlockHeaderValidator(ConstantinopleConfig))
-  val constantinopleFixValidators = ValidatorsExecutor(ConstantinopleFixConfig, new EthashTestBlockHeaderValidator(ConstantinopleFixConfig))
-  val istanbulValidators = ValidatorsExecutor(IstanbulConfig, new EthashTestBlockHeaderValidator(IstanbulConfig))
-  val eip158ToByzantiumValidators = ValidatorsExecutor(Eip158ToByzantiumAt5Config, new EthashTestBlockHeaderValidator(Eip158ToByzantiumAt5Config))
-  val byzantiumToConstantinopleAt5 = ValidatorsExecutor(ByzantiumToConstantinopleAt5, new EthashTestBlockHeaderValidator(ByzantiumToConstantinopleAt5))
+  val frontierValidators =  ValidatorsExecutor(FrontierConfig, new EthashTestBlockHeaderValidator(FrontierConfig, blockchain))
+  val homesteadValidators = ValidatorsExecutor(HomesteadConfig, new EthashTestBlockHeaderValidator(HomesteadConfig, blockchain))
+  val eip150Validators = ValidatorsExecutor(Eip150Config, new EthashTestBlockHeaderValidator(Eip150Config, blockchain))
+  val frontierToHomesteadValidators = ValidatorsExecutor(FrontierToHomesteadAt5, new EthashTestBlockHeaderValidator(FrontierToHomesteadAt5, blockchain))
+  val homesteadToEipValidators = ValidatorsExecutor(HomesteadToEIP150At5, new EthashTestBlockHeaderValidator(HomesteadToEIP150At5, blockchain))
+  val homesteadToDaoValidators= ValidatorsExecutor(HomesteadToDaoAt5, new EthashTestBlockHeaderValidator(HomesteadToDaoAt5, blockchain))
+  val eip158Validators = ValidatorsExecutor(Eip158Config, new EthashTestBlockHeaderValidator(Eip158Config, blockchain))
+  val byzantiumValidators = ValidatorsExecutor(ByzantiumConfig, new EthashTestBlockHeaderValidator(ByzantiumConfig, blockchain))
+  val constantinopleValidators = ValidatorsExecutor(ConstantinopleConfig, new EthashTestBlockHeaderValidator(ConstantinopleConfig, blockchain))
+  val constantinopleFixValidators = ValidatorsExecutor(ConstantinopleFixConfig, new EthashTestBlockHeaderValidator(ConstantinopleFixConfig, blockchain))
+  val istanbulValidators = ValidatorsExecutor(IstanbulConfig, new EthashTestBlockHeaderValidator(IstanbulConfig, blockchain))
+  val eip158ToByzantiumValidators = ValidatorsExecutor(Eip158ToByzantiumAt5Config, new EthashTestBlockHeaderValidator(Eip158ToByzantiumAt5Config, blockchain))
+  val byzantiumToConstantinopleAt5 = ValidatorsExecutor(ByzantiumToConstantinopleAt5, new EthashTestBlockHeaderValidator(ByzantiumToConstantinopleAt5, blockchain))
 }

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/EthashTestBlockHeaderValidator.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/EthashTestBlockHeaderValidator.scala
@@ -3,18 +3,18 @@ package io.iohk.ethereum.ets.blockchain
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
 import io.iohk.ethereum.consensus.ethash.validators.EthashBlockHeaderValidator
-import io.iohk.ethereum.consensus.validators.{ BlockHeaderError, BlockHeaderValid, BlockHeaderValidatorSkeleton }
-import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, BlockHeaderValidatorSkeleton}
+import io.iohk.ethereum.domain.{BlockHeader, Blockchain}
 import io.iohk.ethereum.utils.BlockchainConfig
 
-class EthashTestBlockHeaderValidator(blockchainConfig: BlockchainConfig) extends BlockHeaderValidatorSkeleton(blockchainConfig) {
+class EthashTestBlockHeaderValidator(blockchainConfig: BlockchainConfig, blockchain: Blockchain) extends BlockHeaderValidatorSkeleton(blockchainConfig) {
   import EthashBlockHeaderValidator._
 
   // NOTE the below comment is from before PoW decoupling
   // we need concurrent map since validators can be used from multiple places
   protected val powCaches: java.util.concurrent.ConcurrentMap[Long, PowCacheData] = new java.util.concurrent.ConcurrentHashMap[Long, PowCacheData]()
 
-  protected def difficulty: DifficultyCalculator = new EthashDifficultyCalculator(blockchainConfig)
+  protected def difficulty: DifficultyCalculator = new EthashDifficultyCalculator(blockchainConfig, EthashDifficultyCalculator.grandparentsDataGetterFromBlockchain(blockchain))
 
   def validateEvenMore(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] =
     Right(BlockHeaderValid)

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -52,10 +52,13 @@ abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
   // according to: https://github.com/ethereum/tests/issues/480 only "NoProof" value should change our current implementation
   def shouldSkipPoW: Boolean = scenario.sealEngine.contains("NoProof")
 
-  val (blockchainConfig, validators) = buildBlockchainConfig(scenario.network, shouldSkipPoW)
-
-  //val validators = StdEthashValidators(blockchainConfig)
   val blockchain: BlockchainImpl = ScenarioSetup.getBlockchain
+
+  val validatorsWithPow = new Validators(blockchain)
+
+  val validatorsWithSkippedPoW = new ValidatorsWithSkippedPoW(blockchain)
+
+  val (blockchainConfig, validators) = buildBlockchainConfig(scenario.network, shouldSkipPoW)
 
   val consensus: TestConsensus = ScenarioSetup.loadEthashConsensus(_vm, blockchain, blockchainConfig, validators)
 
@@ -118,41 +121,41 @@ abstract class ScenarioSetup(_vm: VMImpl, scenario: BlockchainScenario) {
   }
 
   private def baseBlockchainConfig(network: String): (BlockchainConfig, ValidatorsExecutor) = network match {
-    case "EIP150" => (Eip150Config, Validators.eip150Validators)
-    case "Frontier" => (FrontierConfig, Validators.frontierValidators)
-    case "Homestead" => (HomesteadConfig, Validators.homesteadValidators)
-    case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, Validators.frontierToHomesteadValidators)
-    case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, Validators.homesteadToEipValidators)
-    case "EIP158" => (Eip158Config, Validators.eip158Validators)
-    case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, Validators.homesteadToDaoValidators)
-    case "Byzantium" => (ByzantiumConfig, Validators.byzantiumValidators)
-    case "Constantinople" => (ConstantinopleConfig, Validators.constantinopleValidators)
-    case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, Validators.eip158ToByzantiumValidators)
-    case "ByzantiumToConstantinopleFixAt5" => (ByzantiumToConstantinopleAt5, Validators.byzantiumToConstantinopleAt5)
-    case "ConstantinopleFix" => (ConstantinopleFixConfig, Validators.constantinopleValidators)
-    case "Istanbul" => (IstanbulConfig, Validators.istanbulValidators)
+    case "EIP150" => (Eip150Config, validatorsWithPow.eip150Validators)
+    case "Frontier" => (FrontierConfig, validatorsWithPow.frontierValidators)
+    case "Homestead" => (HomesteadConfig, validatorsWithPow.homesteadValidators)
+    case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, validatorsWithPow.frontierToHomesteadValidators)
+    case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, validatorsWithPow.homesteadToEipValidators)
+    case "EIP158" => (Eip158Config, validatorsWithPow.eip158Validators)
+    case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, validatorsWithPow.homesteadToDaoValidators)
+    case "Byzantium" => (ByzantiumConfig, validatorsWithPow.byzantiumValidators)
+    case "Constantinople" => (ConstantinopleConfig, validatorsWithPow.constantinopleValidators)
+    case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, validatorsWithPow.eip158ToByzantiumValidators)
+    case "ByzantiumToConstantinopleFixAt5" => (ByzantiumToConstantinopleAt5, validatorsWithPow.byzantiumToConstantinopleAt5)
+    case "ConstantinopleFix" => (ConstantinopleFixConfig, validatorsWithPow.constantinopleValidators)
+    case "Istanbul" => (IstanbulConfig, validatorsWithPow.istanbulValidators)
     // Some default config, test will fail or be canceled
-    case _ => (FrontierConfig, Validators.frontierValidators)
+    case _ => (FrontierConfig, validatorsWithPow.frontierValidators)
   }
 
   private def withSkippedPoWValidationBlockchainConfig(network: String): (BlockchainConfig, ValidatorsExecutor) =
     network match {
-      case "EIP150" => (Eip150Config, ValidatorsWithSkippedPoW.eip150Validators)
-      case "Frontier" => (FrontierConfig, ValidatorsWithSkippedPoW.frontierValidators)
-      case "Homestead" => (HomesteadConfig, ValidatorsWithSkippedPoW.homesteadValidators)
-      case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, ValidatorsWithSkippedPoW.frontierToHomesteadValidators)
-      case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, ValidatorsWithSkippedPoW.homesteadToEipValidators)
-      case "EIP158" => (Eip158Config, ValidatorsWithSkippedPoW.eip158Validators)
-      case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, ValidatorsWithSkippedPoW.homesteadToDaoValidators)
-      case "Byzantium" => (ByzantiumConfig, ValidatorsWithSkippedPoW.byzantiumValidators)
-      case "Constantinople" => (ConstantinopleConfig, ValidatorsWithSkippedPoW.constantinopleValidators)
-      case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, ValidatorsWithSkippedPoW.eip158ToByzantiumValidators)
+      case "EIP150" => (Eip150Config, validatorsWithSkippedPoW.eip150Validators)
+      case "Frontier" => (FrontierConfig, validatorsWithSkippedPoW.frontierValidators)
+      case "Homestead" => (HomesteadConfig, validatorsWithSkippedPoW.homesteadValidators)
+      case "FrontierToHomesteadAt5" => (FrontierToHomesteadAt5, validatorsWithSkippedPoW.frontierToHomesteadValidators)
+      case "HomesteadToEIP150At5" => (HomesteadToEIP150At5, validatorsWithSkippedPoW.homesteadToEipValidators)
+      case "EIP158" => (Eip158Config, validatorsWithSkippedPoW.eip158Validators)
+      case "HomesteadToDaoAt5" => (HomesteadToDaoAt5, validatorsWithSkippedPoW.homesteadToDaoValidators)
+      case "Byzantium" => (ByzantiumConfig, validatorsWithSkippedPoW.byzantiumValidators)
+      case "Constantinople" => (ConstantinopleConfig, validatorsWithSkippedPoW.constantinopleValidators)
+      case "EIP158ToByzantiumAt5" => (Eip158ToByzantiumAt5Config, validatorsWithSkippedPoW.eip158ToByzantiumValidators)
       case "ByzantiumToConstantinopleFixAt5" =>
-        (ByzantiumToConstantinopleAt5, ValidatorsWithSkippedPoW.byzantiumToConstantinopleAt5)
-      case "ConstantinopleFix" => (ConstantinopleFixConfig, ValidatorsWithSkippedPoW.constantinopleFixValidators)
-      case "Istanbul" => (IstanbulConfig, ValidatorsWithSkippedPoW.istanbulValidators)
+        (ByzantiumToConstantinopleAt5, validatorsWithSkippedPoW.byzantiumToConstantinopleAt5)
+      case "ConstantinopleFix" => (ConstantinopleFixConfig, validatorsWithSkippedPoW.constantinopleFixValidators)
+      case "Istanbul" => (IstanbulConfig, validatorsWithSkippedPoW.istanbulValidators)
       // Some default config, test will fail or be canceled
-      case _ => (FrontierConfig, ValidatorsWithSkippedPoW.frontierValidators)
+      case _ => (FrontierConfig, validatorsWithSkippedPoW.frontierValidators)
     }
 
   private def decode(s: String): Array[Byte] = {

--- a/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ConsensusBuilder.scala
@@ -27,7 +27,7 @@ trait StdConsensusBuilder extends ConsensusBuilder {
   protected def buildEthashConsensus(): ethash.EthashConsensus = {
     val specificConfig = ethash.EthashConfig(mantisConfig)
     val fullConfig = newConfig(specificConfig)
-    val validators = ValidatorsExecutor(blockchainConfig, consensusConfig.protocol)
+    val validators = ValidatorsExecutor(blockchainConfig, blockchain, consensusConfig.protocol)
     val consensus = EthashConsensus(vm, blockchain, blockchainConfig, fullConfig, validators)
     consensus
   }

--- a/src/main/scala/io/iohk/ethereum/consensus/blocks/CheckpointBlockGenerator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/blocks/CheckpointBlockGenerator.scala
@@ -10,14 +10,14 @@ class CheckpointBlockGenerator {
   def generate(parent: Block, checkpoint: Checkpoint): Block = {
     val blockNumber = parent.number + 1
     // we are using a predictable value for timestamp so that each federation node generates identical block
-    // see ETCM-173
     val timestamp = parent.header.unixTimestamp + 1
 
     val header = BlockHeader(
       parentHash = parent.hash,
       ommersHash = BlockHeader.EmptyOmmers,
       beneficiary = BlockHeader.EmptyBeneficiary,
-      difficulty = parent.header.difficulty,
+      // there is no PoW here
+      difficulty = BlockHeader.EmptyDifficulty,
       number = blockNumber,
       gasLimit = parent.header.gasLimit,
       unixTimestamp = timestamp,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/EthashConsensus.scala
@@ -178,7 +178,10 @@ object EthashConsensus {
       validators: ValidatorsExecutor
   ): EthashConsensus = {
 
-    val difficultyCalculator = new EthashDifficultyCalculator(blockchainConfig)
+    val difficultyCalculator = new EthashDifficultyCalculator(
+      blockchainConfig,
+      EthashDifficultyCalculator.grandparentsDataGetterFromBlockchain(blockchain)
+    )
 
     val blockPreparator = new BlockPreparator(
       vm = vm,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/EthashBlockHeaderValidator.scala
@@ -6,13 +6,13 @@ import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
 import io.iohk.ethereum.consensus.validators.BlockHeaderError.HeaderPoWError
 import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, BlockHeaderValidatorSkeleton}
 import io.iohk.ethereum.crypto
-import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.domain.{BlockHeader, Blockchain}
 import io.iohk.ethereum.utils.BlockchainConfig
 
 /**
   * A block header validator for Ethash.
   */
-class EthashBlockHeaderValidator(blockchainConfig: BlockchainConfig)
+class EthashBlockHeaderValidator(blockchainConfig: BlockchainConfig, blockchain: Blockchain)
     extends BlockHeaderValidatorSkeleton(blockchainConfig) {
   import EthashBlockHeaderValidator._
 
@@ -21,7 +21,11 @@ class EthashBlockHeaderValidator(blockchainConfig: BlockchainConfig)
   protected val powCaches: java.util.concurrent.ConcurrentMap[Long, PowCacheData] =
     new java.util.concurrent.ConcurrentHashMap[Long, PowCacheData]()
 
-  protected def difficulty: DifficultyCalculator = new EthashDifficultyCalculator(blockchainConfig)
+  protected def difficulty: DifficultyCalculator =
+    new EthashDifficultyCalculator(
+      blockchainConfig,
+      EthashDifficultyCalculator.grandparentsDataGetterFromBlockchain(blockchain)
+    )
 
   def validateEvenMore(
       blockHeader: BlockHeader,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/MockedPowBlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/MockedPowBlockHeaderValidator.scala
@@ -4,13 +4,17 @@ package validators
 import io.iohk.ethereum.consensus.difficulty.DifficultyCalculator
 import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator
 import io.iohk.ethereum.consensus.validators.{BlockHeaderError, BlockHeaderValid, BlockHeaderValidatorSkeleton}
-import io.iohk.ethereum.domain.BlockHeader
+import io.iohk.ethereum.domain.{BlockHeader, Blockchain}
 import io.iohk.ethereum.utils.BlockchainConfig
 
-class MockedPowBlockHeaderValidator(blockchainConfig: BlockchainConfig)
+class MockedPowBlockHeaderValidator(blockchainConfig: BlockchainConfig, blockchain: Blockchain)
     extends BlockHeaderValidatorSkeleton(blockchainConfig) {
 
-  protected def difficulty: DifficultyCalculator = new EthashDifficultyCalculator(blockchainConfig)
+  protected def difficulty: DifficultyCalculator =
+    new EthashDifficultyCalculator(
+      blockchainConfig,
+      EthashDifficultyCalculator.grandparentsDataGetterFromBlockchain(blockchain)
+    )
 
   def validateEvenMore(
       blockHeader: BlockHeader,

--- a/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/ValidatorsExecutor.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/ethash/validators/ValidatorsExecutor.scala
@@ -4,7 +4,7 @@ package ethash.validators
 import akka.util.ByteString
 import io.iohk.ethereum.consensus.validators.std.{StdBlockValidator, StdSignedTransactionValidator, StdValidators}
 import io.iohk.ethereum.consensus.validators.{BlockHeaderValidator, Validators}
-import io.iohk.ethereum.domain.{Block, Receipt}
+import io.iohk.ethereum.domain.{Block, Blockchain, Receipt}
 import io.iohk.ethereum.ledger.BlockExecutionError.ValidationBeforeExecError
 import io.iohk.ethereum.ledger.{BlockExecutionError, BlockExecutionSuccess}
 import io.iohk.ethereum.utils.BlockchainConfig
@@ -44,10 +44,10 @@ trait ValidatorsExecutor extends Validators {
 }
 
 object ValidatorsExecutor {
-  def apply(blockchainConfig: BlockchainConfig, protocol: Protocol): ValidatorsExecutor = {
+  def apply(blockchainConfig: BlockchainConfig, blockchain: Blockchain, protocol: Protocol): ValidatorsExecutor = {
     val blockHeaderValidator: BlockHeaderValidator = protocol match {
-      case Protocol.MockedPow => new MockedPowBlockHeaderValidator(blockchainConfig)
-      case Protocol.Ethash => new EthashBlockHeaderValidator(blockchainConfig)
+      case Protocol.MockedPow => new MockedPowBlockHeaderValidator(blockchainConfig, blockchain)
+      case Protocol.Ethash => new EthashBlockHeaderValidator(blockchainConfig, blockchain)
     }
 
     new StdValidatorsExecutor(

--- a/src/main/scala/io/iohk/ethereum/consensus/validators/BlockWithCheckpointHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/consensus/validators/BlockWithCheckpointHeaderValidator.scala
@@ -70,6 +70,7 @@ class BlockWithCheckpointHeaderValidator(blockchainConfig: BlockchainConfig) {
   /**
     * Validates emptiness of:
     * - beneficiary
+    * - difficulty
     * - extraData
     * - treasuryOptOut
     * - ommersHash
@@ -85,6 +86,8 @@ class BlockWithCheckpointHeaderValidator(blockchainConfig: BlockchainConfig) {
   private def validateEmptyFields(blockHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] = {
     if (blockHeader.beneficiary != BlockHeader.EmptyBeneficiary)
       notEmptyFieldError("beneficiary")
+    else if (blockHeader.difficulty != BlockHeader.EmptyDifficulty)
+      notEmptyFieldError("difficulty")
     else if (blockHeader.ommersHash != BlockHeader.EmptyOmmers)
       notEmptyFieldError("ommersHash")
     else if (blockHeader.transactionsRoot != BlockHeader.EmptyMpt)
@@ -107,6 +110,7 @@ class BlockWithCheckpointHeaderValidator(blockchainConfig: BlockchainConfig) {
   /**
     * Validates fields which should be equal to parent equivalents:
     * - stateRoot
+    * - gasLimit
     *
     * @param blockHeader BlockHeader to validate.
     * @param parentHeader BlockHeader of the parent of the block to validate.
@@ -120,8 +124,6 @@ class BlockWithCheckpointHeaderValidator(blockchainConfig: BlockchainConfig) {
       fieldNotMatchedParentFieldError("stateRoot")
     else if (blockHeader.gasLimit != parentHeader.gasLimit)
       fieldNotMatchedParentFieldError("gasLimit")
-    else if (blockHeader.difficulty != parentHeader.difficulty)
-      fieldNotMatchedParentFieldError("difficulty")
     else Right(BlockHeaderValid)
   }
 

--- a/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/BlockHeader.scala
@@ -104,6 +104,8 @@ object BlockHeader {
 
   val EmptyOmmers: ByteString = ByteString(crypto.kec256(rlp.encode(RLPList())))
 
+  val EmptyDifficulty: BigInt = BigInt(0)
+
   /**
     * Given a block header, returns it's rlp encoded bytes without nonce and mix hash
     *

--- a/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
+++ b/src/main/scala/io/iohk/ethereum/testmode/TestmodeConsensus.scala
@@ -79,7 +79,6 @@ class TestmodeConsensus(
       }
     ) {
       override def withBlockTimestampProvider(blockTimestampProvider: BlockTimestampProvider): TestBlockGenerator = this
-
     }
 
   override def startProtocol(node: Node): Unit = {}
@@ -99,6 +98,9 @@ trait TestmodeConsensusBuilder extends ConsensusBuilder {
     blockchain,
     blockchainConfig,
     consensusConfig,
-    new EthashDifficultyCalculator(blockchainConfig)
+    new EthashDifficultyCalculator(
+      blockchainConfig,
+      EthashDifficultyCalculator.grandparentsDataGetterFromBlockchain(blockchain)
+    )
   )
 }

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/ScenarioSetup.scala
@@ -25,7 +25,7 @@ trait ScenarioSetup extends StdTestConsensusBuilder with SyncConfigBuilder with 
   protected lazy val executionContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
   protected lazy val successValidators: Validators = Mocks.MockValidatorsAlwaysSucceed
   protected lazy val failureValidators: Validators = Mocks.MockValidatorsAlwaysFail
-  protected lazy val ethashValidators: ValidatorsExecutor = ValidatorsExecutor(blockchainConfig, Protocol.Ethash)
+  protected lazy val ethashValidators: ValidatorsExecutor = ValidatorsExecutor(blockchainConfig, blockchain, Protocol.Ethash)
 
   /**
     * The default validators for the test cases.

--- a/src/test/scala/io/iohk/ethereum/consensus/blocks/CheckpointBlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/blocks/CheckpointBlockGeneratorSpec.scala
@@ -27,7 +27,7 @@ class CheckpointBlockGeneratorSpec extends AnyFlatSpec with Matchers {
         transactionsRoot = BlockHeader.EmptyMpt,
         receiptsRoot = BlockHeader.EmptyMpt,
         logsBloom = BloomFilter.EmptyBloomFilter,
-        difficulty = parentBlock.header.difficulty,
+        difficulty = BlockHeader.EmptyDifficulty,
         number = parentBlock.number + 1,
         gasLimit = parentBlock.header.gasLimit,
         gasUsed = UInt256.Zero,

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/EthashMinerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/EthashMinerSpec.scala
@@ -72,7 +72,7 @@ class EthashMinerSpec extends TestKit(ActorSystem("EthashMinerSpec_System")) wit
       Fixtures.Blocks.ValidBlock.body
     )
 
-    val blockHeaderValidator = new EthashBlockHeaderValidator(blockchainConfig)
+    val blockHeaderValidator = new EthashBlockHeaderValidator(blockchainConfig, blockchain)
 
     val ommersPool = TestProbe()
     val pendingTransactionsManager = TestProbe()

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/MinerSpecSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/MinerSpecSetup.scala
@@ -50,7 +50,7 @@ abstract class MinerSpecSetup(implicit system: ActorSystem) extends ScenarioSetu
 
   val blockCreator = mock[EthashBlockCreator]
 
-  val difficultyCalc = new EthashDifficultyCalculator(blockchainConfig)
+  val difficultyCalc = new EthashDifficultyCalculator(blockchainConfig, EthashDifficultyCalculator.grandparentsDataGetterFromBlockchain(blockchain))
 
   val blockForMiningTimestamp = System.currentTimeMillis()
 

--- a/src/test/scala/io/iohk/ethereum/consensus/ethash/difficulty/EthashDifficultyCalculatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/ethash/difficulty/EthashDifficultyCalculatorSpec.scala
@@ -1,0 +1,99 @@
+package io.iohk.ethereum.consensus.ethash.difficulty
+
+import io.iohk.ethereum.Fixtures
+import io.iohk.ethereum.consensus.ethash.difficulty.EthashDifficultyCalculator.{GrandparentsData, GrandparentsDataGetter}
+import io.iohk.ethereum.domain.{BlockHeader, Checkpoint}
+import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1097
+import io.iohk.ethereum.nodebuilder.BlockchainConfigBuilder
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class EthashDifficultyCalculatorSpec extends AnyFlatSpec with Matchers with BlockchainConfigBuilder {
+
+  "EthashDifficultyCalculator" should "properly calculate the difficulty for block whose parent has checkpoint" in new TestSetup {
+    val diff = 6
+    val parentHeader: BlockHeader = validParentHeader.copy(
+      extraFields = HefPostEcip1097(treasuryOptOut = false, Some(Checkpoint(Nil)))
+    )
+    val parentHeaderWithoutCheckpoint: BlockHeader = validParentHeader
+    val grandparentHeader =
+      Fixtures.Blocks.ValidBlock.header.copy(
+        unixTimestamp = parentHeader.unixTimestamp - diff,
+        number = parentHeader.number - 1,
+        difficulty = parentHeader.difficulty - 100
+      )
+    val greatGrandparentHeader =
+      Fixtures.Blocks.ValidBlock.header.copy(
+        unixTimestamp = grandparentHeader.unixTimestamp - diff,
+        number = grandparentHeader.number - 1,
+        difficulty = grandparentHeader.difficulty - 100
+      )
+
+    override def grandparentsDataGetter: GrandparentsDataGetter = _ =>
+      GrandparentsData(grandparentHeader.difficulty, grandparentHeader.unixTimestamp - greatGrandparentHeader.unixTimestamp)
+
+    val blockNumber: BigInt = parentHeader.number + 1
+    val blockTimestamp: Long = parentHeader.unixTimestamp + 6
+
+    val difficultyWithCheckpoint: BigInt = difficultyCalculator.calculateDifficulty(blockNumber, blockTimestamp, parentHeader)
+    val difficultyWithoutCheckpoint: BigInt = difficultyCalculator.calculateDifficulty(blockNumber, blockTimestamp, parentHeaderWithoutCheckpoint)
+
+    difficultyWithCheckpoint should be < difficultyWithoutCheckpoint
+  }
+
+  it should "properly calculate the difficulty after difficulty bomb resume (with reward reduction)" in new TestSetup {
+    val parentHeader: BlockHeader =
+      validParentHeader.copy(number = 5000101, unixTimestamp = 1513175023, difficulty = BigInt("22627021745803"))
+
+    val blockNumber: BigInt = parentHeader.number + 1
+    val blockTimestamp: Long = parentHeader.unixTimestamp + 6
+
+    val difficulty: BigInt = difficultyCalculator.calculateDifficulty(blockNumber, blockTimestamp, parentHeader)
+    val expected = BigInt("22638070358408")
+
+    difficulty shouldBe expected
+  }
+
+  it should "properly calculate the difficulty after difficulty defuse" in new TestSetup {
+    val parentHeader: BlockHeader =
+      validParentHeader.copy(number = 5899999, unixTimestamp = 1525176000, difficulty = BigInt("22627021745803"))
+
+    val blockNumber: BigInt = parentHeader.number + 1
+    val blockTimestamp: Long = parentHeader.unixTimestamp + 6
+
+    val difficulty: BigInt = difficultyCalculator.calculateDifficulty(blockNumber, blockTimestamp, parentHeader)
+    val blockDifficultyWihtoutBomb = BigInt("22638070096264")
+
+    difficulty shouldBe blockDifficultyWihtoutBomb
+  }
+
+  it should "properly calculate a block after block reward reduction (without uncles)" in new TestSetup {
+    val parentHeader: BlockHeader =
+      validParentHeader.copy(number = 5863374, unixTimestamp = 1530104893, difficulty = BigInt("3480699544328087"))
+
+    val blockNumber: BigInt = parentHeader.number + 1
+    val blockTimestamp: Long = parentHeader.unixTimestamp + 6
+
+    val difficulty: BigInt = difficultyCalculator.calculateDifficulty(blockNumber, blockTimestamp, parentHeader)
+
+    /** Expected calculations:
+      * blockNumber = 5863375 // < 5900000
+      * timestampDiff = 6
+      * x = 3480699544328087 / 2048 =
+      * c = (1 - (6 / 9)) = 0,33  // > -99
+      * fakeBlockNumber = 5863375 - 3000000 = 2863375
+      * extraDifficulty = 134217728
+      * difficultyWithoutBomb = 3480699544328087 + 1699560324378,95 * 0,33 = 3481260399235132
+      */
+    val blockDifficultyAfterRewardReduction = BigInt("3482399171761329")
+
+    difficulty shouldBe blockDifficultyAfterRewardReduction
+  }
+
+  trait TestSetup {
+    def grandparentsDataGetter: GrandparentsDataGetter = _ => GrandparentsData(0, 0)
+    val difficultyCalculator = new EthashDifficultyCalculator(blockchainConfig, grandparentsDataGetter)
+    val validParentHeader = Fixtures.Blocks.ValidBlock.header
+  }
+
+}

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/BlockWithCheckpointHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/BlockWithCheckpointHeaderValidatorSpec.scala
@@ -108,12 +108,12 @@ class BlockWithCheckpointHeaderValidatorSpec
     }
   }
 
-  it should "return failure if difficulty is different than parent difficulty" in new TestSetup {
-    forAll(bigIntGen suchThat (_ != validBlockParentHeader.difficulty)) { difficulty =>
+  it should "return failure if difficulty is not zero" in new TestSetup {
+    forAll(bigIntGen suchThat (_ != BlockHeader.EmptyDifficulty)) { difficulty =>
       val blockHeader = validBlockHeaderWithCheckpoint.copy(difficulty = difficulty)
       val validateResult = blockHeaderValidator.validate(blockHeader, validBlockParentHeader)
       assert(
-        validateResult == Left(HeaderNotMatchParentError("difficulty has different value that similar parent field"))
+        validateResult == Left(HeaderFieldNotEmptyError("difficulty is not empty"))
       )
     }
   }

--- a/src/test/scala/io/iohk/ethereum/consensus/validators/OmmersValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/validators/OmmersValidatorSpec.scala
@@ -77,7 +77,7 @@ class OmmersValidatorSpec extends AnyFlatSpec with Matchers with ScalaCheckPrope
   // scalastyle:off magic.number
   trait BlockUtils extends EphemBlockchainTestSetup {
 
-    val ommersValidator = new StdOmmersValidator(blockchainConfig, new EthashBlockHeaderValidator(blockchainConfig))
+    val ommersValidator = new StdOmmersValidator(blockchainConfig, new EthashBlockHeaderValidator(blockchainConfig, blockchain))
 
     //Ommers from block 0xe9fb121a7ee5cb03b33adbf59e95321a2453f09db98068e1f31f0da79860c50c (of number 97)
     val ommer1 = BlockHeader(


### PR DESCRIPTION
# Description

The goal was to make blocks with checkpoint not included in computing PoW difficulty.

# Proposed Solution

Set block with checkpoint difficulty to zero and in case of having a block with checkpoint as a parent use grandparent difficulty and timestamp gap between grandparent and great grandparent

# Important Changes Introduced

- block with checkpoint has zero difficulty now
- the difficulty and timestamp gap used for computing new difficulty is taken from grandparents when the parent is a block with checkpoint

# Testing

Unit tests

