### PR TITLE
[FIX] Fix the way AsyncConfig is built

### DIFF
--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -217,7 +217,7 @@ object Config {
 case class AsyncConfig(askTimeout: Timeout)
 object AsyncConfig {
   def apply(mantisConfig: TypesafeConfig): AsyncConfig =
-    AsyncConfig(mantisConfig.atKey("async").getDuration("ask-timeout").toMillis.millis)
+    AsyncConfig(mantisConfig.getConfig("async").getDuration("ask-timeout").toMillis.millis)
 }
 
 trait KeyStoreConfig {


### PR DESCRIPTION
# Description

Async config was built improperly causing to node to fail

# Testing

Run the node - it should not break now.