### PR TITLE
[ETCM-284] Pay no money to coinbase address when processing checkpoint blocks

### DIFF
--- a/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ContractTest.scala
@@ -26,7 +26,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
     //block only with ether transfers
     val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
     val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
-    blockExecution.executeBlock(fixtures.blockByNumber(1)) shouldBe noErrors
+    blockExecution.executeAndValidateBlock(fixtures.blockByNumber(1)) shouldBe noErrors
   }
 
   it should "deploy contract" in new ScenarioSetup {
@@ -37,7 +37,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
     //contract creation
     val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
     val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
-    blockExecution.executeBlock(fixtures.blockByNumber(2)) shouldBe noErrors
+    blockExecution.executeAndValidateBlock(fixtures.blockByNumber(2)) shouldBe noErrors
   }
 
   it should "execute contract call" in new ScenarioSetup {
@@ -48,7 +48,7 @@ class ContractTest extends AnyFlatSpec with Matchers {
     //block with ether transfers and contract call
     val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
     val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
-    blockExecution.executeBlock(fixtures.blockByNumber(3)) shouldBe noErrors
+    blockExecution.executeAndValidateBlock(fixtures.blockByNumber(3)) shouldBe noErrors
   }
 
   it should "execute contract that pays 2 accounts" in new ScenarioSetup {
@@ -59,6 +59,6 @@ class ContractTest extends AnyFlatSpec with Matchers {
     //block contains contract paying 2 accounts
     val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
     val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
-    blockExecution.executeBlock(fixtures.blockByNumber(3)) shouldBe noErrors
+    blockExecution.executeAndValidateBlock(fixtures.blockByNumber(3)) shouldBe noErrors
   }
 }

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ECIP1017Test.scala
@@ -76,7 +76,7 @@ class ECIP1017Test extends AnyFlatSpec with Matchers {
       val blockchain = BlockchainImpl(storages)
       val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
       val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
-      blockExecution.executeBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
+      blockExecution.executeAndValidateBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
     }
   }
 

--- a/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
+++ b/src/it/scala/io/iohk/ethereum/txExecTest/ForksTest.scala
@@ -67,7 +67,7 @@ class ForksTest extends AnyFlatSpec with Matchers {
       val blockchain = BlockchainImpl(storages)
       val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
       val blockExecution = new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
-      blockExecution.executeBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
+      blockExecution.executeAndValidateBlock(fixtures.blockByNumber(blockToExecute)) shouldBe noErrors
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -1,7 +1,10 @@
 package io.iohk.ethereum.jsonrpc
 
 import akka.util.ByteString
-import io.iohk.ethereum.domain.{Block, BlockHeader, BlockBody}
+import io.iohk.ethereum.crypto.ECDSASignature
+import io.iohk.ethereum.domain.{Block, BlockBody, BlockHeader}
+
+case class CheckpointResponse(signatures: Seq[ECDSASignature], signers: Seq[ByteString])
 
 case class BlockResponse(
     number: BigInt,
@@ -21,6 +24,8 @@ case class BlockResponse(
     gasLimit: BigInt,
     gasUsed: BigInt,
     timestamp: BigInt,
+    checkpoint: Option[CheckpointResponse],
+    treasuryOptOut: Option[Boolean],
     transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
     uncles: Seq[ByteString]
 )
@@ -41,6 +46,12 @@ object BlockResponse {
       else
         Left(block.body.transactionList.map(_.hash))
 
+    val checkpoint = block.header.checkpoint.map { checkpoint =>
+      val signers = checkpoint.signatures.flatMap(_.publicKey(block.header.parentHash))
+
+      CheckpointResponse(checkpoint.signatures, signers)
+    }
+
     BlockResponse(
       number = block.header.number,
       hash = if (pendingBlock) None else Some(block.header.hash),
@@ -59,6 +70,8 @@ object BlockResponse {
       gasLimit = block.header.gasLimit,
       gasUsed = block.header.gasUsed,
       timestamp = block.header.unixTimestamp,
+      checkpoint = checkpoint,
+      treasuryOptOut = block.header.treasuryOptOut,
       transactions = transactions,
       uncles = block.body.uncleNodesList.map(_.hash)
     )

--- a/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
@@ -42,7 +42,7 @@ class BlockImport(
     val executionResult = for {
       topBlock <- blockQueue.enqueueBlock(block, bestBlockNumber)
       topBlocks = blockQueue.getBranch(topBlock.hash, dequeue = true)
-      (executed, errors) = blockExecution.executeBlocks(topBlocks, currentTd)
+      (executed, errors) = blockExecution.executeAndValidateBlocks(topBlocks, currentTd)
     } yield (executed, errors, topBlocks)
 
     executionResult match {
@@ -190,7 +190,7 @@ class BlockImport(
       parentTd: BigInt,
       oldBlocksData: List[BlockData]
   ): Either[BlockExecutionError, (List[Block], List[Block])] = {
-    val (executedBlocks, maybeError) = blockExecution.executeBlocks(newBranch, parentTd)
+    val (executedBlocks, maybeError) = blockExecution.executeAndValidateBlocks(newBranch, parentTd)
     maybeError match {
       case None =>
         Right(oldBlocksData.map(_.block), executedBlocks.map(_.block))

--- a/src/snappy/scala/io/iohk/ethereum/snappy/SnappyTest.scala
+++ b/src/snappy/scala/io/iohk/ethereum/snappy/SnappyTest.scala
@@ -64,7 +64,7 @@ class SnappyTest extends AnyFreeSpec with Matchers with Logger {
         val blockValidation = new BlockValidation(consensus, blockchain, BlockQueue(blockchain, syncConfig))
         val blockExecution =
           new BlockExecution(blockchain, blockchainConfig, consensus.blockPreparator, blockValidation)
-        blockExecution.executeBlock(block)
+        blockExecution.executeAndValidateBlock(block)
 
       case None =>
         // this seems to discard failures, for better errors messages we might want to implement a different method (simulateBlock?)

--- a/src/test/scala/io/iohk/ethereum/checkpointing/CheckpointingTestHelpers.scala
+++ b/src/test/scala/io/iohk/ethereum/checkpointing/CheckpointingTestHelpers.scala
@@ -2,43 +2,10 @@ package io.iohk.ethereum.checkpointing
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.ECDSASignature
-import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1097
-import io.iohk.ethereum.domain._
-import io.iohk.ethereum.ledger.BloomFilter
-import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import io.iohk.ethereum.crypto.ECDSASignatureImplicits.ECDSASignatureOrdering
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 
 object CheckpointingTestHelpers {
-  def createBlockWithCheckpoint(
-      parentHeader: BlockHeader,
-      checkpoint: Checkpoint
-  ): Block = {
-    Block(createBlockHeaderWithCheckpoint(parentHeader, checkpoint), BlockBody(Nil, Nil))
-  }
-
-  def createBlockHeaderWithCheckpoint(
-      parentHeader: BlockHeader,
-      checkpoint: Checkpoint
-  ): BlockHeader = {
-    BlockHeader(
-      parentHash = parentHeader.hash,
-      beneficiary = BlockHeader.EmptyBeneficiary,
-      stateRoot = parentHeader.stateRoot,
-      ommersHash = BlockHeader.EmptyOmmers,
-      transactionsRoot = BlockHeader.EmptyMpt,
-      receiptsRoot = BlockHeader.EmptyMpt,
-      logsBloom = BloomFilter.EmptyBloomFilter,
-      difficulty = parentHeader.difficulty,
-      number = parentHeader.number + 1,
-      gasLimit = parentHeader.gasLimit,
-      gasUsed = UInt256.Zero,
-      unixTimestamp = parentHeader.unixTimestamp + 1,
-      extraData = ByteString.empty,
-      mixHash = ByteString.empty,
-      nonce = ByteString.empty,
-      extraFields = HefPostEcip1097(treasuryOptOut = false, checkpoint = Some(checkpoint))
-    )
-  }
 
   def createCheckpointSignatures(
       keys: Seq[AsymmetricCipherKeyPair],

--- a/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
@@ -47,7 +47,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchain.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.header.extraData shouldBe headerExtraData
   }
 
@@ -67,7 +67,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchain.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.header.extraData shouldBe headerExtraData
   }
 
@@ -135,7 +135,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       blockchain.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
 
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -166,7 +166,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchain.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -231,7 +231,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
       fullBlock.header,
       blockchain.getBlockHeaderByHash
     ) shouldBe Right(BlockHeaderValid)
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(generalTx)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -289,7 +289,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val generatedBlock =
       blockGenerator.generateBlock(bestBlock, Seq(generalTx), Address(testAddress), blockGenerator.emptyX)
 
-    blockExecution.executeBlock(generatedBlock.block, true) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(generatedBlock.block, true) shouldBe a[Right[_, Seq[Receipt]]]
   }
 
   it should "generate block after eip155 and allow both chain specific and general transactions" in new TestSetup {
@@ -315,7 +315,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx, generalTx)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -344,7 +344,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx, nextTransaction)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -386,7 +386,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx, nextTransaction)
     fullBlock.header.extraData shouldBe headerExtraData
   }
@@ -415,7 +415,7 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
     )
-    blockExecution.executeBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
+    blockExecution.executeAndValidateBlock(fullBlock) shouldBe a[Right[_, Seq[Receipt]]]
     fullBlock.body.transactionList shouldBe Seq(signedTransaction.tx)
     fullBlock.header.extraData shouldBe headerExtraData
   }

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -1,14 +1,13 @@
 package io.iohk.ethereum.domain
 
 import akka.util.ByteString
-import io.iohk.ethereum.{Fixtures, ObjectGenerators}
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.checkpointing.CheckpointingTestHelpers
 import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.db.dataSource.EphemDataSource
 import io.iohk.ethereum.db.storage.StateStorage
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1097
 import io.iohk.ethereum.mpt.MerklePatriciaTrie
+import io.iohk.ethereum.{Fixtures, ObjectGenerators}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -56,7 +55,7 @@ class BlockchainSpec extends AnyFlatSpec with Matchers {
     val parent = Fixtures.Blocks.Genesis.block
     blockchain.storeBlock(parent)
 
-    val validBlock = CheckpointingTestHelpers.createBlockWithCheckpoint(parent.header, checkpoint)
+    val validBlock = new CheckpointBlockGenerator().generate(parent, checkpoint)
 
     blockchain.save(validBlock, Seq.empty, BigInt(0), saveAsBestBlock = true)
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -12,12 +12,8 @@ import io.iohk.ethereum.crypto.kec256
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.jsonrpc.EthService._
 import io.iohk.ethereum.jsonrpc.FilterManager.LogFilterLogs
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.{
-  OptionNoneToJNullSerializer,
-  QuantitiesSerializer,
-  UnformattedDataJsonSerializer
-}
 import io.iohk.ethereum.jsonrpc.PersonalService._
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.{OptionNoneToJNullSerializer, QuantitiesSerializer, UnformattedDataJsonSerializer}
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.ommers.OmmersPool.Ommers
 import io.iohk.ethereum.testing.ActorsTesting.simpleAutoPilot
@@ -110,8 +106,92 @@ class JsonRpcControllerEthSpec
     response should haveResult(expectedBlockResponse)
   }
 
+  it should "handle eth_getBlockByHash request (block with checkpoint)" in new JsonRpcControllerFixture {
+    val blockToRequest = blockWithCheckpoint
+    val blockTd = blockToRequest.header.difficulty
+
+    blockchain
+      .storeBlock(blockToRequest)
+      .and(blockchain.storeTotalDifficulty(blockToRequest.header.hash, blockTd))
+      .commit()
+
+    val request = newJsonRpcRequest(
+      "eth_getBlockByHash",
+      List(JString(s"0x${blockToRequest.header.hashAsHexString}"), JBool(false))
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    val expectedBlockResponse =
+      Extraction.decompose(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+
+    response should haveResult(expectedBlockResponse)
+  }
+
+  it should "handle eth_getBlockByHash request (block with treasuryOptOut)" in new JsonRpcControllerFixture {
+    val blockToRequest = blockWithTreasuryOptOut
+    val blockTd = blockToRequest.header.difficulty
+
+    blockchain
+      .storeBlock(blockToRequest)
+      .and(blockchain.storeTotalDifficulty(blockToRequest.header.hash, blockTd))
+      .commit()
+
+    val request = newJsonRpcRequest(
+      "eth_getBlockByHash",
+      List(JString(s"0x${blockToRequest.header.hashAsHexString}"), JBool(false))
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    val expectedBlockResponse =
+      Extraction.decompose(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+
+    response should haveResult(expectedBlockResponse)
+  }
+
   it should "handle eth_getBlockByNumber request" in new JsonRpcControllerFixture {
     val blockToRequest = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+    val blockTd = blockToRequest.header.difficulty
+
+    blockchain
+      .storeBlock(blockToRequest)
+      .and(blockchain.storeTotalDifficulty(blockToRequest.header.hash, blockTd))
+      .commit()
+
+    val request = newJsonRpcRequest(
+      "eth_getBlockByNumber",
+      List(JString(s"0x${Hex.toHexString(blockToRequest.header.number.toByteArray)}"), JBool(false))
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    val expectedBlockResponse =
+      Extraction.decompose(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+
+    response should haveResult(expectedBlockResponse)
+  }
+
+  it should "handle eth_getBlockByNumber request (block with treasuryOptOut)" in new JsonRpcControllerFixture {
+    val blockToRequest = blockWithTreasuryOptOut
+    val blockTd = blockToRequest.header.difficulty
+
+    blockchain
+      .storeBlock(blockToRequest)
+      .and(blockchain.storeTotalDifficulty(blockToRequest.header.hash, blockTd))
+      .commit()
+
+    val request = newJsonRpcRequest(
+      "eth_getBlockByNumber",
+      List(JString(s"0x${Hex.toHexString(blockToRequest.header.number.toByteArray)}"), JBool(false))
+    )
+    val response = jsonRpcController.handleRequest(request).futureValue
+
+    val expectedBlockResponse =
+      Extraction.decompose(BlockResponse(blockToRequest, fullTxs = false, totalDifficulty = Some(blockTd)))
+
+    response should haveResult(expectedBlockResponse)
+  }
+
+  it should "handle eth_getBlockByNumber request (block with checkpoint)" in new JsonRpcControllerFixture {
+    val blockToRequest = blockWithCheckpoint
     val blockTd = blockToRequest.header.difficulty
 
     blockchain

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -3,18 +3,20 @@ package io.iohk.ethereum.jsonrpc
 import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import akka.util.ByteString
-import io.iohk.ethereum.{Fixtures, Timeouts}
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.consensus.{ConsensusConfigs, TestConsensus}
+import io.iohk.ethereum.consensus.blocks.CheckpointBlockGenerator
 import io.iohk.ethereum.consensus.ethash.blocks.EthashBlockGenerator
 import io.iohk.ethereum.consensus.ethash.validators.ValidatorsExecutor
+import io.iohk.ethereum.consensus.{ConsensusConfigs, TestConsensus}
 import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.db.storage.AppStateStorage
+import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1098
 import io.iohk.ethereum.domain.{Block, BlockBody, SignedTransaction}
 import io.iohk.ethereum.jsonrpc.JsonRpcController.JsonRpcConfig
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{BloomFilter, Ledger, StxLedger}
 import io.iohk.ethereum.utils.{Config, FilterConfig}
+import io.iohk.ethereum.{Fixtures, ObjectGenerators, Timeouts}
 import org.bouncycastle.util.encoders.Hex
 import org.json4s.JsonAST.{JArray, JInt, JString, JValue}
 import org.scalamock.scalatest.MockFactory
@@ -112,6 +114,12 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
     gasUsed = 0,
     unixTimestamp = 0
   )
+
+  val checkpoint = ObjectGenerators.fakeCheckpointGen(2, 5).sample.get
+  val checkpointBlockGenerator = new CheckpointBlockGenerator()
+  val blockWithCheckpoint = checkpointBlockGenerator.generate(Fixtures.Blocks.Block3125369.block, checkpoint)
+  val blockWithTreasuryOptOut =
+    Block(Fixtures.Blocks.Block3125369.header.copy(extraFields = HefPostEcip1098(true)), Fixtures.Blocks.Block3125369.body)
 
   val parentBlock = Block(blockHeader.copy(number = 1), BlockBody.empty)
 

--- a/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/BlockImportSpec.scala
@@ -112,7 +112,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newTd2)
     val blockData3 = BlockData(newBlock3, Seq.empty[Receipt], newTd3)
 
-    (ledgerWithMockedBlockExecution.blockExecution.executeBlocks _)
+    (ledgerWithMockedBlockExecution.blockExecution.executeAndValidateBlocks _)
       .expects(newBranch, *)
       .returning((List(blockData2, blockData3), None))
 
@@ -157,7 +157,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newTd2)
     val blockData3 = BlockData(newBlock3, Seq.empty[Receipt], newTd3)
 
-    (ledgerWithMockedBlockExecution.blockExecution.executeBlocks _)
+    (ledgerWithMockedBlockExecution.blockExecution.executeAndValidateBlocks _)
       .expects(newBranch, *)
       .returning((List(blockData2), Some(execError)))
 
@@ -260,7 +260,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     val blockData2 = BlockData(newBlock2, Seq.empty[Receipt], newTd2)
     val blockData3 = BlockData(newBlock3WithOmmer, Seq.empty[Receipt], newTd3)
 
-    (ledgerWithMockedBlockExecution.blockExecution.executeBlocks _)
+    (ledgerWithMockedBlockExecution.blockExecution.executeAndValidateBlocks _)
       .expects(newBranch, *)
       .returning((List(blockData2, blockData3), None))
 
@@ -288,7 +288,7 @@ class BlockImportSpec extends AnyFlatSpec with Matchers with ScalaFutures {
     blockchain.save(parentBlock, Nil, tdParent, saveAsBestBlock = true)
     blockchain.save(regularBlock, Nil, tdRegular, saveAsBestBlock = true)
 
-    (ledgerWithMockedBlockExecution.blockExecution.executeBlocks _)
+    (ledgerWithMockedBlockExecution.blockExecution.executeAndValidateBlocks _)
       .expects(List(checkpointBlock), *)
       .returning((List(BlockData(checkpointBlock, Nil, tdCheckpoint)), None))
 

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerSpec.scala
@@ -74,7 +74,7 @@ class LedgerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
       )
       val block = Block(blockHeader, blockBodyWithOmmers)
 
-      val blockExecResult = ledger.blockExecution.executeBlock(block)
+      val blockExecResult = ledger.blockExecution.executeAndValidateBlock(block)
       assert(blockExecResult.isRight)
     }
   }
@@ -121,7 +121,7 @@ class LedgerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
 
     assert(seqFailingValidators.forall { validators =>
       val ledger = newTestLedger(validators = validators)
-      val blockExecResult = ledger.blockExecution.executeBlock(block)
+      val blockExecResult = ledger.blockExecution.executeAndValidateBlock(block)
 
       blockExecResult.left.forall {
         case e: ValidationBeforeExecError => true
@@ -172,7 +172,7 @@ class LedgerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
       val blockHeader: BlockHeader = validBlockHeader.copy(gasUsed = cumulativeGasUsedBlock, stateRoot = stateRootHash)
       val block = Block(blockHeader, validBlockBodyWithNoTxs)
 
-      val blockExecResult = ledger.blockExecution.executeBlock(block)
+      val blockExecResult = ledger.blockExecution.executeAndValidateBlock(block)
 
       assert(blockExecResult match {
         case Left(_: ValidationAfterExecError) => true
@@ -271,7 +271,7 @@ class LedgerSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
       val blockWithCorrectStateAndGasUsed = block.copy(
         header = block.header.copy(stateRoot = blockExpectedStateRoot, gasUsed = gasUsedReceipt2)
       )
-      assert(ledger.blockExecution.executeBlock(blockWithCorrectStateAndGasUsed).isRight)
+      assert(ledger.blockExecution.executeAndValidateBlock(blockWithCorrectStateAndGasUsed).isRight)
     }
   }
 


### PR DESCRIPTION
# Description

All checkpoint blocks will currently be marked as invalid, as:

the block state root is set as the same as the parent
the resulting state root includes money provided to the coinbase address

# Proposed Solution

The solution is a small optimization - block with checkpoint is skipping execution of transactions and paying the reward

# Important Changes Introduced

- block with checkpoint is not executing transactions, rewards and after execution validation
- [bonus] added information about treasury and checkpoint to the json BlockResponse (I found it useful for testing)

# Testing

unit tests + local tests with mocked miner and QA endpoints

