### PR TITLE
[FIX] Return executed blocks sorted on execution error

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockExecution.scala
@@ -139,7 +139,7 @@ class BlockExecution(
       if (remainingBlocks.isEmpty) {
         (executedBlocks.reverse, None)
       } else if (error.isDefined) {
-        (executedBlocks, error)
+        (executedBlocks.reverse, error)
       } else {
         val blockToExecute = remainingBlocks.head
         executeAndValidateBlock(blockToExecute, alreadyValidated = true) match {

--- a/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
+++ b/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
@@ -7,7 +7,6 @@ import io.iohk.ethereum.nodebuilder.SecureRandomBuilder
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import mouse.all._
 
-import scala.math.BigInt
 import scala.util.Random
 
 object BlockHelpers extends SecureRandomBuilder {
@@ -37,16 +36,16 @@ object BlockHelpers extends SecureRandomBuilder {
   def randomHash(): ByteString =
     ObjectGenerators.byteStringOfLengthNGen(32).sample.get
 
-  def generateChain(amount: Int, parent: Block, adjustBlock: Block => Block = identity): List[Block] =
-    (1 to amount).toList.foldLeft[List[Block]](Nil)((generated, _) => {
-      val theParent = generated.lastOption.getOrElse(parent)
-      generated :+ (theParent |> generateBlock |> adjustBlock)
-    })
+  def generateChain(amount: Int, branchParent: Block, adjustBlock: Block => Block = identity): List[Block] =
+    (1 to amount).toList.foldLeft[List[Block]](Nil){ (generated, _) =>
+      val parent = generated.lastOption.getOrElse(branchParent)
+      generated :+ (parent |> generateBlock |> adjustBlock)
+    }
 
-  def generateBlock(nr: BigInt, parent: Block): Block = {
-    val header = defaultHeader.copy(
+  def generateBlock(parent: Block): Block = {
+    val header = parent.header.copy(
       extraData = randomHash(),
-      number = nr,
+      number = parent.number + 1,
       parentHash = parent.hash,
       nonce = ByteString(Random.nextLong())
     )
@@ -56,7 +55,5 @@ object BlockHelpers extends SecureRandomBuilder {
 
     Block(header, BlockBody(List(stx.tx), List(ommer)))
   }
-
-  def generateBlock(parent: Block): Block = generateBlock(parent.number + 1, parent)
 
 }

--- a/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/ledger/LedgerTestSetup.scala
@@ -157,6 +157,7 @@ trait BlockchainSetup extends TestSetup {
   val blockchainStorages: storagesInstance.Storages = storagesInstance.storages
 
   val validBlockParentHeader: BlockHeader = defaultBlockHeader.copy(stateRoot = initialWorld.stateRootHash)
+  val validBlockParentBlock: Block = Block(validBlockParentHeader, BlockBody.empty)
   val validBlockHeader: BlockHeader = defaultBlockHeader.copy(
     stateRoot = initialWorld.stateRootHash,
     parentHash = validBlockParentHeader.hash,


### PR DESCRIPTION
# Description

Fixes missing blocks on testnet, caused by:

1. An invalid block (1505: 0b) was generated by the miner of the node (due to https://jira.iohk.io/browse/ETCM-301), probably caused by an expected race condition between the miner and the importing process
2. The above block import required a reorg of more than one block. From [1502: 8c, 1503: 87, 1504: 6c] to [1502: 8a, 1503: 5a, 1504: 0b, 1505: 0b] (the list are: [block number: first two bytes of the hash])
3. Failure in executing it caused the reorg to be reverted and `BlockImport.revertChainReorganisation` to be called with the `executedBlocks=[1505: 0b, 1504: 0b, 1503: 5a, 1502: 8a]`
4. This caused the call: `removeBlocksUntil(0b, 1502)`, meaning that all blocks from the db were deleted
5. Eventually block 1506 had an ommer whose parent was deleted in the last step, meaning that it was marked as invalid by this node with reason `OmmersNotValidError`. As this was the chain followed by the two other miners, the testnet irrevocably forked

## Simple scenario to reproduce:

Pre-requisites:
- Due to https://jira.iohk.io/browse/ETCM-329 the mocked miner generates invalid blocks in some occasions, the `ValidationAfterExecError(s"Block has invalid state root hash, expected ${Hex.toHexString(header.stateRoot.toArray)} but got ${Hex.toHexString(stateRootHash.toArray)}")` validation has to be disabled
- Patch Mantis to consider a block to be invalid, I did so by changing `BlockExecution.executeAndValidateBlock` so that all blocks with number 13 are considered invalid

Reproducing it
1. Start a node and mine 12 blocks in a mocked way
2. Mine 5 blocks having the block 8 as it's parent
3. As the last mined block has number 13 it will be detected as invalid
4. Query the blocks by number (through JSON RPC) and check that blocks 1-7 were deleted

# Proposed Solution

Return the executedBlocks in proper order

# Testing

- Run the scenario to reproduce and see that it no longer causes any issues
- No test was added due to the complexity of producing this exact scenario
