### PR TITLE
[Fix] Propagation improvements

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -119,13 +119,13 @@ mantis {
       max-mpt-components-per-message = 200
 
       # Maximum number of peers this node can connect to
-      max-outgoing-peers = 80
+      max-outgoing-peers = 45
 
       # Maximum number of peers that can connect to this node
-      max-incoming-peers = 5
+      max-incoming-peers = 15
 
       # Maximum number of peers that can be connecting to this node
-      max-pending-peers = 5
+      max-pending-peers = 20
 
       # Initial delay before connecting to nodes
       update-nodes-initial-delay = 5.seconds
@@ -343,9 +343,7 @@ mantis {
 
     # When we receive a branch that is not rooted in our chain (we don't have a parent for the first header), it means
     # we found a fork. To resolve it, we need to query the same peer for previous headers, to find a common ancestor.
-    # This setting determines how many additional headers we request. The default of 12 may be regarded as confirmation
-    # depth in ethereum (https://www.reddit.com/r/ethereum/comments/4eplsv/how_many_confirms_is_considered_safe_in_ethereum/)
-    branch-resolution-request-size = 12
+    branch-resolution-request-size = 30
 
     # TODO investigate proper value to handle ETC reorgs correctly
     # threshold for storing non-main-chain blocks in queue.

--- a/src/main/resources/chains/testnet-internal-genesis.json
+++ b/src/main/resources/chains/testnet-internal-genesis.json
@@ -2,9 +2,11 @@
   "extraData": "0x00",
   "nonce": "0x0000000000000042",
   "gasLimit": "0x2fefd8",
-  "difficulty": "0x400",
+  "_commentAboutDifficulty": "Set to 1000000",
+  "difficulty": "0xF4240",
   "ommersHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-  "timestamp": "0x00",
+  "_commentAboutTimestamp": "Set to 11/05/2020 @ 12:00am (UTC)",
+  "timestamp": "0x5FA34080",
   "coinbase": "0x0000000000000000000000000000000000000000",
   "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "alloc": {

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcher.scala
@@ -184,7 +184,7 @@ class BlockFetcher(
   private def handleNewBlockMessages(state: BlockFetcherState): Receive = {
     case MessageFromPeer(NewBlockHashes(hashes), _) =>
       log.debug("Received NewBlockHashes numbers {}", hashes.map(_.number).mkString(", "))
-      val newState = state.validatedHashes(hashes) match {
+      val newState = state.validateNewBlockHashes(hashes) match {
         case Left(_) => state
         case Right(validHashes) => state.withPossibleNewTopAt(validHashes.lastOption.map(_.number))
       }

--- a/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
+++ b/src/main/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherState.scala
@@ -90,11 +90,10 @@ case class BlockFetcherState(
         .ensure("Given headers should form a sequence without gaps")(HeadersSeq.areChain)
     }
 
-  def validatedHashes(hashes: Seq[BlockHash]): Either[String, Seq[BlockHash]] =
+  def validateNewBlockHashes(hashes: Seq[BlockHash]): Either[String, Seq[BlockHash]] =
     hashes
       .asRight[String]
       .ensure("Hashes are empty")(_.nonEmpty)
-      .ensure("Hashes are too new")(_.head.number == nextToLastBlock)
       .ensure("Hashes should form a chain")(hashes =>
         hashes.zip(hashes.tail).forall { case (a, b) =>
           a.number + 1 == b.number


### PR DESCRIPTION
# Description

Propagation improvements required for the testnet

# Proposed Solution

- Changed max-xxx-peers configurations to match the other project. Note that the effect of them might be a bit unreliable due to our bad usage of them, this will be improved a bit with #763 
- Increased branch-resolution-request-size to 30 to be more resilient to reorgs
- Increased timestamp of the genesis block and it's difficulty, for the testnet to be closer to the 15 second target time per blocks. Without this, the difficult moved toward that direction, but it would take quite a while to reach there.
- Removed validation of NewBlockHashes message so that know top is always updated when one is received, as is the case with NewBlock messages

