### PR TITLE
Added some laziness to eliminate a risk of importing invalid blocks

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
@@ -24,8 +24,8 @@ class BlockImport(
       currentBestBlock: Block,
       currentTd: BigInt
   )(implicit blockExecutionContext: ExecutionContext): Future[BlockImportResult] = {
-    val validationResult = Future(blockValidation.validateBlockBeforeExecution(block))(validationContext)
-    val importResult = Future(importBlockToTop(block, currentBestBlock.header.number, currentTd))(blockExecutionContext)
+    lazy val validationResult = Future(blockValidation.validateBlockBeforeExecution(block))(validationContext)
+    lazy val importResult = Future(importBlockToTop(block, currentBestBlock.header.number, currentTd))(blockExecutionContext)
 
     for {
       validationResult <- validationResult


### PR DESCRIPTION
# Description

There's a significant chance of adding blocks prior to any validtion completed on them.
It happens because scala `Future` is eagerly evaluated, so `validationResult` and `importResult` start simultaneously on different execution contexts! 

A simple testcase:

```
      import scala.concurrent.duration._
      implicit val ec = global

      /*lazy */ val slowFuture = Future { Thread.sleep(1000); println("hello") }
      /*lazy */ val fastFuture = Future( println("world"))

      val res = for {
        x <- slowFuture
        y <- fastFuture
      } yield println("!")

      Await.result(res, 2.seconds)
```

will end up printing:

```
world
hello
!
```

Read more here:
https://stackoverflow.com/questions/57403756/regarding-scala-futures-being-eager

And here:
https://svejcar.dev/posts/2019/11/14/troubles-with-future/

# Proposed Solution

Transform `val` to a `def` 
Or add `lazy` modifier.
Or inline values into for comprehension.