### PR TITLE
[ETCM-341] faucet - revert configs

### DIFF
--- a/insomnia_workspace.json
+++ b/insomnia_workspace.json
@@ -1291,7 +1291,7 @@
       "data":
       {
         "node_url": "http://127.0.0.1:8546",
-        "faucet_url": "http://127.0.0.1:8547"
+        "faucet_url": "http://127.0.0.1:8099"
       },
       "dataPropertyOrder":
       {

--- a/src/universal/conf/faucet.conf
+++ b/src/universal/conf/faucet.conf
@@ -21,9 +21,6 @@ faucet {
   # Transaction value
   tx-value = 1000000000000000000
 
-  # Faucet cors config
-  cors-allowed-origins = "*"
-
   # Address of Ethereum node used to send the transaction
   rpc-address = "http://127.0.0.1:8546/"
 
@@ -63,7 +60,7 @@ mantis {
         interface = "localhost"
 
         # Listening port of JSON-RPC HTTP(S) endpoint
-        port = 8547
+        port = 8099
 
         # Path to the keystore storing the certificates (used only for https)
         # null value indicates HTTPS is not being used


### PR DESCRIPTION
# Description

- Revert Faucet's port from 8547 to default 8099. 
- Remove legacy cors, used in the httpserver removed. Today the current cors used is “mantis.network.http.cors-allowed-origins” into the faucet config

