### PR TITLE
[FIX] Handle timeouts on BlockFetcher

### DIFF
--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/BlockFetcherSpec.scala
@@ -195,6 +195,24 @@ class BlockFetcherSpec extends TestKit(ActorSystem("BlockFetcherSpec_System")) w
         assert(HeadersSeq.areChain(headers))
       }
     }
+
+    "should properly handle a request timeout" in new TestSetup {
+      override lazy val syncConfig = defaultSyncConfig.copy(
+        // Small timeout on ask pattern for testing it here
+        peerResponseTimeout = 1.seconds
+      )
+
+      startFetcher()
+
+      val firstGetBlockHeadersRequest =
+        GetBlockHeaders(Left(1), syncConfig.blockHeadersPerRequest, skip = 0, reverse = false)
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
+
+      // Request should timeout without any response from the peer
+      Thread.sleep((syncConfig.peerResponseTimeout + 2.seconds).toMillis)
+
+      peersClient.expectMsgPF() { case PeersClient.Request(msg, _, _) if msg == firstGetBlockHeadersRequest => () }
+    }
   }
 
   trait TestSetup extends TestSyncConfig {


### PR DESCRIPTION
# Description

Address forking issue on the testnet

## Scenario

During the startup of the nomad cluster there were some connectivity problems and some connections got closed resulting in timeouts on the requests. However for mantis-5
1. He sent a request for a block header to a peer whose connection was closing (or soon to be closed)
2. The request eventually died due to a timeout (or at least that's my theory), we can see that it died as the requesters logging of PeersClient reached 0 at some moment.
3. But the BlockFetcher never received that timeout, so it was permanently stuck on `fetching headers == true`

# Proposed Solution

Recover from ask pattern timeout on the BlockFetcher by using the error fallback, which results in the request being cancelled and a new one triggered

# Testing

Added unit test

