### PR TITLE
[ETCM-135] Tx history improvements for wallet

### DIFF
--- a/insomnia_workspace.json
+++ b/insomnia_workspace.json
@@ -1,9 +1,63 @@
 {
   "_type": "export",
   "__export_format": 4,
-  "__export_date": "2020-11-02T20:39:43.839Z",
+  "__export_date": "2020-11-20T21:57:27.426Z",
   "__export_source": "insomnia.desktop.app:v2020.4.2",
   "resources": [
+    {
+      "_id": "req_3a0f1537c235444ea8f4b9dac488e14c",
+      "parentId": "fld_69840c51732b4213b880c2d1c48a212b",
+      "modified": 1605909416772,
+      "created": 1605907827178,
+      "url": "{{node_url}}",
+      "name": "mantis_getAccountTransactions",
+      "description": "",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 1,\n\t\"method\": \"mantis_getAccountTransactions\",\n\t\"params\": [\"$address\", 1 , 999]\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json",
+          "id": "pair_0a140acca58a4c679d227d29955f741e"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1605907827178,
+      "isPrivate": false,
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "fld_69840c51732b4213b880c2d1c48a212b",
+      "parentId": "wrk_097d43914a4d4aea8b6f73f647921182",
+      "modified": 1605907810643,
+      "created": 1605907810643,
+      "name": "mantis",
+      "description": "",
+      "environment": {},
+      "environmentPropertyOrder": null,
+      "metaSortKey": -1605907810643,
+      "_type": "request_group"
+    },
+    {
+      "_id": "wrk_097d43914a4d4aea8b6f73f647921182",
+      "parentId": null,
+      "modified": 1599825617921,
+      "created": 1552662762769,
+      "name": "Mantis",
+      "description": "",
+      "scope": null,
+      "_type": "workspace"
+    },
     {
       "_id": "req_4222a4d54ba24fa7813429bdcdb732df",
       "parentId": "fld_a7212a5b96194230a7e0abc76ee2bf26",
@@ -49,16 +103,6 @@
       "_type": "request_group"
     },
     {
-      "_id": "wrk_097d43914a4d4aea8b6f73f647921182",
-      "parentId": null,
-      "modified": 1599825617921,
-      "created": 1552662762769,
-      "name": "Mantis",
-      "description": "",
-      "scope": null,
-      "_type": "workspace"
-    },
-    {
       "_id": "req_da1e409360394849b673ec4e27f542b6",
       "parentId": "fld_a7212a5b96194230a7e0abc76ee2bf26",
       "modified": 1601637193229,
@@ -91,32 +135,28 @@
       "_type": "request"
     },
     {
-      "_id": "req_5c84aeff984d41e4aca173ac56a0b113",
-      "parentId": "fld_9f9137459d5c429d83901f5c682be0f9",
-      "modified": 1604346888565,
-      "created": 1603997152827,
-      "url": "{{ faucet_url }}",
-      "name": "send_funds",
+      "_id": "req_f2986c964bf74360878144213ca342a7",
+      "parentId": "fld_2b54cbb84e244284b3ef752c5f805376",
+      "modified": 1573042783130,
+      "created": 1573042743181,
+      "url": "{{ node_url }}",
+      "name": "qa_getFederationMembersInfo",
       "description": "",
       "method": "POST",
-      "body":
-      {
+      "body": {
         "mimeType": "application/json",
-        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"faucet_sendFunds\", \n  \"params\": [\"$address\"],\n  \"id\": 1\n}"
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 1,\n\t\"method\": \"qa_getFederationMembersInfo\",\n\t\"params\": []\n}"
       },
       "parameters": [],
-      "headers":
-      [
+      "headers": [
         {
+          "id": "pair_ba5a5914f02a4b27b86a330054582828",
           "name": "Content-Type",
-          "value": "application/json",
-          "description": "",
-          "id": "pair_b080d7c5b5194ad09efdd6926ed108c5",
-          "disabled": false
+          "value": "application/json"
         }
       ],
       "authentication": {},
-      "metaSortKey": -1603997152827,
+      "metaSortKey": -1568046037126,
       "isPrivate": false,
       "settingStoreCookies": true,
       "settingSendCookies": true,
@@ -127,42 +167,72 @@
       "_type": "request"
     },
     {
-      "_id": "fld_9f9137459d5c429d83901f5c682be0f9",
+      "_id": "fld_2b54cbb84e244284b3ef752c5f805376",
       "parentId": "wrk_097d43914a4d4aea8b6f73f647921182",
-      "modified": 1604349428103,
-      "created": 1603918083216,
-      "name": "faucet",
+      "modified": 1600249374160,
+      "created": 1600249374160,
+      "name": "QA",
       "description": "",
       "environment": {},
       "environmentPropertyOrder": null,
-      "metaSortKey": -1552939140242,
+      "metaSortKey": -1600249374160,
       "_type": "request_group"
     },
     {
-      "_id": "req_48316ba9ba834bcc94fdeae41d966eb9",
-      "parentId": "fld_9f9137459d5c429d83901f5c682be0f9",
-      "modified": 1604346774105,
-      "created": 1604338553808,
-      "url": "{{ faucet_url }}",
-      "name": "status",
+      "_id": "req_3ae9151dec5b4046b06fdb3408e9ab1f",
+      "parentId": "fld_2b54cbb84e244284b3ef752c5f805376",
+      "modified": 1572263390995,
+      "created": 1572007151716,
+      "url": "{{ node_url }}",
+      "name": "qa_generateCheckpoint",
       "description": "",
       "method": "POST",
-      "body":
-      {
+      "body": {
         "mimeType": "application/json",
-        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"faucet_status\", \n  \"params\": [],\n  \"id\": 1\n}"
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 1,\n\t\"method\": \"qa_generateCheckpoint\",\n\t\"params\": [\t\t[\"0x926db397ed35bedee660fe5bf6879679fa71f1fe8c27823f7f6a1e5d96a49b94\"], \"0xe160bdd7664e1b921612a4ed225321bdf3b8f70beb6b968c7a423d6022e39e16\"\n\t]\n}"
       },
       "parameters": [],
-      "headers":
-      [
+      "headers": [
         {
+          "id": "pair_6f2ea2de85ee4eabbbd25bde888e9dc1",
           "name": "Content-Type",
-          "value": "application/json",
-          "id": "pair_bce95e5eaba54223bb10210f4563af71"
+          "value": "application/json"
         }
       ],
       "authentication": {},
-      "metaSortKey": -1604338553809,
+      "metaSortKey": -1566535778023.25,
+      "isPrivate": false,
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "req_e1287e4fcba348eea9d326bb208092c3",
+      "parentId": "fld_2b54cbb84e244284b3ef752c5f805376",
+      "modified": 1573216279799,
+      "created": 1573216065706,
+      "url": "{{ node_url }}",
+      "name": "qa_generateCheckpoint (for latest block)",
+      "description": "",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 1,\n\t\"method\": \"qa_generateCheckpoint\",\n\t\"params\": [\t\t[\"0x926db397ed35bedee660fe5bf6879679fa71f1fe8c27823f7f6a1e5d96a49b94\"]\n\t]\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {
+          "id": "pair_6f2ea2de85ee4eabbbd25bde888e9dc1",
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1566394039140.875,
       "isPrivate": false,
       "settingStoreCookies": true,
       "settingSendCookies": true,
@@ -207,114 +277,6 @@
       "settingEncodeUrl": true,
       "settingRebuildPath": true,
       "settingFollowRedirects": "global",
-      "_type": "request"
-    },
-    {
-      "_id": "fld_2b54cbb84e244284b3ef752c5f805376",
-      "parentId": "wrk_097d43914a4d4aea8b6f73f647921182",
-      "modified": 1600249374160,
-      "created": 1600249374160,
-      "name": "QA",
-      "description": "",
-      "environment": {},
-      "environmentPropertyOrder": null,
-      "metaSortKey": -1600249374160,
-      "_type": "request_group"
-    },
-    {
-      "_id": "req_3ae9151dec5b4046b06fdb3408e9ab1f",
-      "authentication": {},
-      "body": {
-        "mimeType": "application/json",
-        "text": "{\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 1,\n\t\"method\": \"qa_generateCheckpoint\",\n\t\"params\": [\t\t[\"0x926db397ed35bedee660fe5bf6879679fa71f1fe8c27823f7f6a1e5d96a49b94\"], \"0xe160bdd7664e1b921612a4ed225321bdf3b8f70beb6b968c7a423d6022e39e16\"\n\t]\n}"
-      },
-      "created": 1572007151716,
-      "description": "",
-      "headers": [
-        {
-          "id": "pair_6f2ea2de85ee4eabbbd25bde888e9dc1",
-          "name": "Content-Type",
-          "value": "application/json"
-        }
-      ],
-      "isPrivate": false,
-      "metaSortKey": -1566535778023.25,
-      "method": "POST",
-      "modified": 1572263390995,
-      "name": "qa_generateCheckpoint",
-      "parameters": [],
-      "parentId": "fld_2b54cbb84e244284b3ef752c5f805376",
-      "settingDisableRenderRequestBody": false,
-      "settingEncodeUrl": true,
-      "settingFollowRedirects": "global",
-      "settingRebuildPath": true,
-      "settingSendCookies": true,
-      "settingStoreCookies": true,
-      "url": "{{ node_url }}",
-      "_type": "request"
-    },
-    {
-      "_id": "req_e1287e4fcba348eea9d326bb208092c3",
-      "authentication": {},
-      "body": {
-        "mimeType": "application/json",
-        "text": "{\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 1,\n\t\"method\": \"qa_generateCheckpoint\",\n\t\"params\": [\t\t[\"0x926db397ed35bedee660fe5bf6879679fa71f1fe8c27823f7f6a1e5d96a49b94\"]\n\t]\n}"
-      },
-      "created": 1573216065706,
-      "description": "",
-      "headers": [
-        {
-          "id": "pair_6f2ea2de85ee4eabbbd25bde888e9dc1",
-          "name": "Content-Type",
-          "value": "application/json"
-        }
-      ],
-      "isPrivate": false,
-      "metaSortKey": -1566394039140.875,
-      "method": "POST",
-      "modified": 1573216279799,
-      "name": "qa_generateCheckpoint (for latest block)",
-      "parameters": [],
-      "parentId": "fld_2b54cbb84e244284b3ef752c5f805376",
-      "settingDisableRenderRequestBody": false,
-      "settingEncodeUrl": true,
-      "settingFollowRedirects": "global",
-      "settingRebuildPath": true,
-      "settingSendCookies": true,
-      "settingStoreCookies": true,
-      "url": "{{ node_url }}",
-      "_type": "request"
-    },
-    {
-      "_id": "req_f2986c964bf74360878144213ca342a7",
-      "authentication": {},
-      "body": {
-        "mimeType": "application/json",
-        "text": "{\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 1,\n\t\"method\": \"qa_getFederationMembersInfo\",\n\t\"params\": []\n}"
-      },
-      "created": 1573042743181,
-      "description": "",
-      "headers": [
-        {
-          "id": "pair_ba5a5914f02a4b27b86a330054582828",
-          "name": "Content-Type",
-          "value": "application/json"
-        }
-      ],
-      "isPrivate": false,
-      "metaSortKey": -1568046037126,
-      "method": "POST",
-      "modified": 1573042783130,
-      "name": "qa_getFederationMembersInfo",
-      "parameters": [],
-      "parentId": "fld_2b54cbb84e244284b3ef752c5f805376",
-      "settingDisableRenderRequestBody": false,
-      "settingEncodeUrl": true,
-      "settingFollowRedirects": "global",
-      "settingRebuildPath": true,
-      "settingSendCookies": true,
-      "settingStoreCookies": true,
-      "url": "{{ node_url }}",
       "_type": "request"
     },
     {
@@ -883,7 +845,7 @@
     {
       "_id": "req_7770f112c5cb4fc4a0f2d7fea4f6166e",
       "parentId": "fld_a06eb77e183c4727800eb7dc43ceabe1",
-      "modified": 1599825954655,
+      "modified": 1605909042772,
       "created": 1554490202940,
       "url": "{{ node_url }}",
       "name": "eth_getTransactionByHash",
@@ -891,7 +853,7 @@
       "method": "POST",
       "body": {
         "mimeType": "application/json",
-        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"eth_getTransactionByHash\", \n\t\"params\": [\"0x926db397ed35bedee660fe5bf6879679fa71f1fe8c27823f7f6a1e5d96a49b94\"],\n  \"id\": 1\n}"
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"eth_getTransactionByHash\", \n\t\"params\": [\"$tx_hash\"],\n  \"id\": 1\n}"
       },
       "parameters": [],
       "headers": [
@@ -1066,43 +1028,6 @@
       "_type": "request"
     },
     {
-      "_id": "req_71950018809a482da79fc927070de862",
-      "parentId": "fld_a06eb77e183c4727800eb7dc43ceabe1",
-      "modified": 1599825973333,
-      "created": 1576585718979,
-      "url": "{{ node_url }}",
-      "name": "eth_getBalance",
-      "description": "",
-      "method": "POST",
-      "body": {
-        "mimeType": "application/json",
-        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"eth_getBalance\", \n\t\"params\": [\n\t\t\"$address\", \"$hexBlockNumber\"\n\t],\n  \"id\": 1\n}"
-      },
-      "parameters": [],
-      "headers": [
-        {
-          "id": "pair_9f4d6a9dde554cd384487e04fa3b21aa",
-          "name": "Content-Type",
-          "value": "application/json"
-        },
-        {
-          "id": "pair_088edc31f5e04f20a16b465a673871bb",
-          "name": "Cache-Control",
-          "value": "no-cache"
-        }
-      ],
-      "authentication": {},
-      "metaSortKey": -1552732410716.25,
-      "isPrivate": false,
-      "settingStoreCookies": true,
-      "settingSendCookies": true,
-      "settingDisableRenderRequestBody": false,
-      "settingEncodeUrl": true,
-      "settingRebuildPath": true,
-      "settingFollowRedirects": "global",
-      "_type": "request"
-    },
-    {
       "_id": "req_4c1135a4a69644fe9850292131197b47",
       "parentId": "fld_a06eb77e183c4727800eb7dc43ceabe1",
       "modified": 1602234543563,
@@ -1130,6 +1055,43 @@
       ],
       "authentication": {},
       "metaSortKey": -1552732410719.375,
+      "isPrivate": false,
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "req_71950018809a482da79fc927070de862",
+      "parentId": "fld_a06eb77e183c4727800eb7dc43ceabe1",
+      "modified": 1599825973333,
+      "created": 1576585718979,
+      "url": "{{ node_url }}",
+      "name": "eth_getBalance",
+      "description": "",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"eth_getBalance\", \n\t\"params\": [\n\t\t\"$address\", \"$hexBlockNumber\"\n\t],\n  \"id\": 1\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {
+          "id": "pair_9f4d6a9dde554cd384487e04fa3b21aa",
+          "name": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "id": "pair_088edc31f5e04f20a16b465a673871bb",
+          "name": "Cache-Control",
+          "value": "no-cache"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1552732410716.25,
       "isPrivate": false,
       "settingStoreCookies": true,
       "settingSendCookies": true,
@@ -1251,6 +1213,84 @@
       "_type": "request"
     },
     {
+      "_id": "req_48316ba9ba834bcc94fdeae41d966eb9",
+      "parentId": "fld_9f9137459d5c429d83901f5c682be0f9",
+      "modified": 1604346774105,
+      "created": 1604338553808,
+      "url": "{{ faucet_url }}",
+      "name": "status",
+      "description": "",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"faucet_status\", \n  \"params\": [],\n  \"id\": 1\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json",
+          "id": "pair_bce95e5eaba54223bb10210f4563af71"
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1604338553809,
+      "isPrivate": false,
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "fld_9f9137459d5c429d83901f5c682be0f9",
+      "parentId": "wrk_097d43914a4d4aea8b6f73f647921182",
+      "modified": 1604349428103,
+      "created": 1603918083216,
+      "name": "faucet",
+      "description": "",
+      "environment": {},
+      "environmentPropertyOrder": null,
+      "metaSortKey": -1552939140242,
+      "_type": "request_group"
+    },
+    {
+      "_id": "req_5c84aeff984d41e4aca173ac56a0b113",
+      "parentId": "fld_9f9137459d5c429d83901f5c682be0f9",
+      "modified": 1604346888565,
+      "created": 1603997152827,
+      "url": "{{ faucet_url }}",
+      "name": "send_funds",
+      "description": "",
+      "method": "POST",
+      "body": {
+        "mimeType": "application/json",
+        "text": "{\n\t\"jsonrpc\": \"2.0\",\n  \"method\": \"faucet_sendFunds\", \n  \"params\": [\"$address\"],\n  \"id\": 1\n}"
+      },
+      "parameters": [],
+      "headers": [
+        {
+          "name": "Content-Type",
+          "value": "application/json",
+          "description": "",
+          "id": "pair_b080d7c5b5194ad09efdd6926ed108c5",
+          "disabled": false
+        }
+      ],
+      "authentication": {},
+      "metaSortKey": -1603997152827,
+      "isPrivate": false,
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
       "_id": "env_ee4c8118750744559d3b1020845fe5d4",
       "parentId": "wrk_097d43914a4d4aea8b6f73f647921182",
       "modified": 1552663132622,
@@ -1288,15 +1328,12 @@
       "modified": 1604347516298,
       "created": 1552663140073,
       "name": "Develop",
-      "data":
-      {
+      "data": {
         "node_url": "http://127.0.0.1:8546",
         "faucet_url": "http://127.0.0.1:8099"
       },
-      "dataPropertyOrder":
-      {
-        "&":
-        [
+      "dataPropertyOrder": {
+        "&": [
           "node_url",
           "faucet_url"
         ]

--- a/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
+++ b/src/it/scala/io/iohk/ethereum/sync/util/CommonFakePeer.scala
@@ -25,7 +25,14 @@ import io.iohk.ethereum.network.p2p.EthereumMessageDecoder
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.NewBlock
 import io.iohk.ethereum.network.rlpx.AuthHandshaker
 import io.iohk.ethereum.network.rlpx.RLPxConnectionHandler.RLPxConfiguration
-import io.iohk.ethereum.network.{EtcPeerManagerActor, ForkResolver, KnownNodesManager, PeerEventBusActor, PeerManagerActor, ServerActor}
+import io.iohk.ethereum.network.{
+  EtcPeerManagerActor,
+  ForkResolver,
+  KnownNodesManager,
+  PeerEventBusActor,
+  PeerManagerActor,
+  ServerActor
+}
 import io.iohk.ethereum.nodebuilder.{PruningConfigBuilder, SecureRandomBuilder}
 import io.iohk.ethereum.sync.util.SyncCommonItSpec._
 import io.iohk.ethereum.sync.util.SyncCommonItSpecUtils._

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -207,11 +207,11 @@ mantis {
       }
 
       # Enabled JSON-RPC APIs over the JSON-RPC endpoint
-      # Available choices are: web3, eth, net, personal, daedalus, test, iele, debug, qa, checkpointing
-      apis = "eth,web3,net,personal,daedalus,debug,qa,checkpointing"
+      # Available choices are: web3, eth, net, personal, mantis, test, iele, debug, qa, checkpointing
+      apis = "eth,web3,net,personal,mantis,debug,qa,checkpointing"
 
-      # Maximum number of blocks for daedalus_getAccountTransactions
-      account-transactions-max-blocks = 50000
+      # Maximum number of blocks for mantis_getAccountTransactions
+      account-transactions-max-blocks = 1000
 
       net {
         peer-manager-timeout = 5.seconds

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthJsonMethodsImplicits.scala
@@ -584,7 +584,7 @@ object EthJsonMethodsImplicits extends JsonMethodsImplicits {
               addr <- extractAddress(addrJson)
               fromBlock <- extractQuantity(fromBlockJson)
               toBlock <- extractQuantity(toBlockJson)
-            } yield GetAccountTransactionsRequest(addr, fromBlock, toBlock)
+            } yield GetAccountTransactionsRequest(addr, fromBlock to toBlock)
           case _ => Left(InvalidParams())
         }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.jsonrpc
 import java.time.Duration
 import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
+
 import akka.actor.ActorRef
 import akka.util.{ByteString, Timeout}
 import cats.syntax.either._
@@ -15,8 +16,10 @@ import io.iohk.ethereum.consensus.ethash.EthashUtils
 import io.iohk.ethereum.crypto._
 import io.iohk.ethereum.db.storage.TransactionMappingStorage.TransactionLocation
 import io.iohk.ethereum.domain.{BlockHeader, SignedTransaction, UInt256, _}
+import io.iohk.ethereum.jsonrpc.AkkaTaskOps._
 import io.iohk.ethereum.jsonrpc.FilterManager.{FilterChanges, FilterLogs, LogFilterLogs, TxLog}
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
+import io.iohk.ethereum.jsonrpc.{FilterManager => FM}
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{InMemoryWorldStateProxy, Ledger, StxLedger}
 import io.iohk.ethereum.mpt.MerklePatriciaTrie.MissingNodeException
@@ -26,14 +29,14 @@ import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.rlp.UInt256RLPImplicits._
-import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{PendingTransaction, PendingTransactionsResponse}
+import io.iohk.ethereum.transactions.{PendingTransactionsManager, TransactionHistoryService}
 import io.iohk.ethereum.utils._
-import io.iohk.ethereum.jsonrpc.AkkaTaskOps._
-import io.iohk.ethereum.jsonrpc.{FilterManager => FM}
 import monix.eval.Task
 import org.bouncycastle.util.encoders.Hex
+
 import scala.collection.concurrent.{TrieMap, Map => ConcurrentMap}
+import scala.collection.immutable.NumericRange
 import scala.concurrent.duration.FiniteDuration
 import scala.language.existentials
 import scala.reflect.ClassTag
@@ -78,7 +81,7 @@ object EthService {
   case class GetTransactionByHashRequest(txHash: ByteString)
   case class GetTransactionByHashResponse(txResponse: Option[TransactionResponse])
 
-  case class GetAccountTransactionsRequest(address: Address, fromBlock: BigInt, toBlock: BigInt)
+  case class GetAccountTransactionsRequest(address: Address, blocksRange: NumericRange[BigInt])
   case class GetAccountTransactionsResponse(transactions: Seq[TransactionResponse])
 
   case class GetTransactionReceiptRequest(txHash: ByteString)
@@ -216,6 +219,7 @@ class EthService(
     syncingController: ActorRef,
     ommersPool: ActorRef,
     filterManager: ActorRef,
+    transactionHistoryService: TransactionHistoryService,
     filterConfig: FilterConfig,
     blockchainConfig: BlockchainConfig,
     protocolVersion: Int,
@@ -325,7 +329,7 @@ class EthService(
   }
 
   def getTransactionDataByHash(txHash: ByteString): Task[Option[TransactionData]] = {
-    val maybeTxPendingResponse: Task[Option[TransactionData]] = getTransactionsFromPool().map {
+    val maybeTxPendingResponse: Task[Option[TransactionData]] = getTransactionsFromPool.map {
       _.pendingTransactions.map(_.stx.tx).find(_.hash == txHash).map(TransactionData(_))
     }
 
@@ -541,7 +545,7 @@ class EthService(
       reportActive()
       val bestBlock = blockchain.getBestBlock()
       val response: ServiceResponse[GetWorkResponse] =
-        Task.parZip2(getOmmersFromPool(bestBlock.hash), getTransactionsFromPool()).map { case (ommers, pendingTxs) =>
+        Task.parZip2(getOmmersFromPool(bestBlock.hash), getTransactionsFromPool).map { case (ommers, pendingTxs) =>
           val blockGenerator = ethash.blockGenerator
           val PendingBlockAndState(pb, _) = blockGenerator.generateBlock(
             bestBlock,
@@ -575,13 +579,13 @@ class EthService(
     })(Task.now(OmmersPool.Ommers(Nil))) // NOTE If not Ethash consensus, ommers do not make sense, so => Nil
 
   // TODO This seems to be re-implemented in TransactionPicker, probably move to a better place? Also generalize the error message.
-  private[jsonrpc] def getTransactionsFromPool(): Task[PendingTransactionsResponse] = {
+  private[jsonrpc] val getTransactionsFromPool: Task[PendingTransactionsResponse] = {
     implicit val timeout: Timeout = Timeout(getTransactionFromPoolTimeout)
 
     pendingTransactionsManager
       .askFor[PendingTransactionsResponse](PendingTransactionsManager.GetPendingTransactions)
       .onErrorRecoverWith { case ex: Throwable =>
-        log.error("failed to get transactions, mining block with empty transactions list", ex)
+        log.error("Failed to get pending transactions, passing empty transactions list", ex)
         Task.now(PendingTransactionsResponse(Nil))
       }
   }
@@ -930,41 +934,19 @@ class EthService(
   def getAccountTransactions(
       request: GetAccountTransactionsRequest
   ): ServiceResponse[GetAccountTransactionsResponse] = {
-    val numBlocksToSearch = request.toBlock - request.fromBlock
-    if (numBlocksToSearch > jsonRpcConfig.accountTransactionsMaxBlocks) {
+    if (request.blocksRange.length > jsonRpcConfig.accountTransactionsMaxBlocks) {
       Task.now(
         Left(
           JsonRpcError.InvalidParams(
-            s"""Maximum number of blocks to search is ${jsonRpcConfig.accountTransactionsMaxBlocks}, requested: $numBlocksToSearch.
-           |See: 'network.rpc.account-transactions-max-blocks' config.""".stripMargin
+            s"""Maximum number of blocks to search is ${jsonRpcConfig.accountTransactionsMaxBlocks}, requested: ${request.blocksRange.length}.
+           |See: 'mantis.network.rpc.account-transactions-max-blocks' config.""".stripMargin
           )
         )
       )
     } else {
-
-      def collectTxs(
-          blockHeader: Option[BlockHeader],
-          pending: Boolean
-      ): PartialFunction[SignedTransaction, TransactionResponse] = {
-        case stx if stx.safeSenderIsEqualTo(request.address) =>
-          TransactionResponse(stx, blockHeader, pending = Some(pending), isOutgoing = Some(true))
-        case stx if stx.tx.receivingAddress.contains(request.address) =>
-          TransactionResponse(stx, blockHeader, pending = Some(pending), isOutgoing = Some(false))
-      }
-
-      getTransactionsFromPool map { case PendingTransactionsResponse(pendingTransactions) =>
-        val pendingTxs = pendingTransactions
-          .map(_.stx.tx)
-          .collect(collectTxs(None, pending = true))
-
-        val txsFromBlocks = (request.toBlock to request.fromBlock by -1).toStream
-          .flatMap { n => blockchain.getBlockByNumber(n) }
-          .flatMap { block =>
-            block.body.transactionList.collect(collectTxs(Some(block.header), pending = false)).reverse
-          }
-
-        Right(GetAccountTransactionsResponse(pendingTxs ++ txsFromBlocks))
-      }
+      transactionHistoryService
+        .getAccountTransactions(request.address, request.blocksRange)
+        .map(GetAccountTransactionsResponse(_).asRight)
     }
   }
 
@@ -980,7 +962,7 @@ class EthService(
     * @return pending transactions
     */
   def ethPendingTransactions(req: EthPendingTransactionsRequest): ServiceResponse[EthPendingTransactionsResponse] =
-    getTransactionsFromPool().map { resp =>
+    getTransactionsFromPool.map { resp =>
       Right(EthPendingTransactionsResponse(resp.pendingTransactions))
     }
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -621,8 +621,8 @@ class EthService(
                 startingBlock = startingBlockNumber,
                 currentBlock = blocksProgress.current,
                 highestBlock = blocksProgress.target,
-                knownStates = stateNodesProgress.current,
-                pulledStates = stateNodesProgress.target
+                knownStates = stateNodesProgress.target,
+                pulledStates = stateNodesProgress.current
               )
             )
           )

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/EthService.scala
@@ -3,7 +3,6 @@ package io.iohk.ethereum.jsonrpc
 import java.time.Duration
 import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.ActorRef
 import akka.util.{ByteString, Timeout}
 import cats.syntax.either._
@@ -30,6 +29,7 @@ import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.RLPList
 import io.iohk.ethereum.rlp.UInt256RLPImplicits._
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{PendingTransaction, PendingTransactionsResponse}
+import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
 import io.iohk.ethereum.transactions.{PendingTransactionsManager, TransactionHistoryService}
 import io.iohk.ethereum.utils._
 import monix.eval.Task
@@ -82,7 +82,7 @@ object EthService {
   case class GetTransactionByHashResponse(txResponse: Option[TransactionResponse])
 
   case class GetAccountTransactionsRequest(address: Address, blocksRange: NumericRange[BigInt])
-  case class GetAccountTransactionsResponse(transactions: Seq[TransactionResponse])
+  case class GetAccountTransactionsResponse(transactions: List[ExtendedTransactionData])
 
   case class GetTransactionReceiptRequest(txHash: ByteString)
   case class GetTransactionReceiptResponse(txResponse: Option[TransactionReceiptResponse])

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonMethodsImplicits.scala
@@ -22,13 +22,13 @@ import scala.util.Try
 trait JsonMethodsImplicits {
   implicit val formats = JsonSerializers.formats
 
-  protected def encodeAsHex(input: ByteString): JString =
+  def encodeAsHex(input: ByteString): JString =
     JString(s"0x${Hex.toHexString(input.toArray[Byte])}")
 
-  protected def encodeAsHex(input: Byte): JString =
+  def encodeAsHex(input: Byte): JString =
     JString(s"0x${Hex.toHexString(Array(input))}")
 
-  protected def encodeAsHex(input: BigInt): JString =
+  def encodeAsHex(input: BigInt): JString =
     JString(s"0x${input.toString(16)}")
 
   protected def decode(s: String): Array[Byte] = {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/JsonRpcController.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.jsonrpc
 import io.iohk.ethereum.jsonrpc.CheckpointingService._
 import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInfoResponse}
 import io.iohk.ethereum.jsonrpc.EthService._
+import io.iohk.ethereum.jsonrpc.MantisService.{GetAccountTransactionsRequest, GetAccountTransactionsResponse}
 import io.iohk.ethereum.jsonrpc.NetService._
 import io.iohk.ethereum.jsonrpc.PersonalService._
 import io.iohk.ethereum.jsonrpc.QAService.{
@@ -29,6 +30,7 @@ class JsonRpcController(
     debugService: DebugService,
     qaService: QAService,
     checkpointingService: CheckpointingService,
+    mantisService: MantisService,
     override val config: JsonRpcConfig
 ) extends ApisBuilder
     with Logger
@@ -41,13 +43,14 @@ class JsonRpcController(
   import JsonMethodsImplicits._
   import QAJsonMethodsImplicits._
   import TestJsonMethodsImplicits._
+  import MantisJsonMethodImplicits._
 
   override def apisHandleFns: Map[String, PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]]] = Map(
     Apis.Eth -> handleEthRequest,
     Apis.Web3 -> handleWeb3Request,
     Apis.Net -> handleNetRequest,
     Apis.Personal -> handlePersonalRequest,
-    Apis.Daedalus -> handleDaedalusRequest,
+    Apis.Mantis -> handleMantisRequest,
     Apis.Rpc -> handleRpcRequest,
     Apis.Debug -> handleDebugRequest,
     Apis.Test -> handleTestRequest,
@@ -259,9 +262,9 @@ class JsonRpcController(
       handle[EcRecoverRequest, EcRecoverResponse](personalService.ecRecover, req)
   }
 
-  private def handleDaedalusRequest: PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]] = {
-    case req @ JsonRpcRequest(_, "daedalus_getAccountTransactions", _, _) =>
-      handle[GetAccountTransactionsRequest, GetAccountTransactionsResponse](ethService.getAccountTransactions, req)
+  private def handleMantisRequest: PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]] = {
+    case req @ JsonRpcRequest(_, "mantis_getAccountTransactions", _, _) =>
+      handle[GetAccountTransactionsRequest, GetAccountTransactionsResponse](mantisService.getAccountTransactions, req)
   }
 
   private def handleQARequest: PartialFunction[JsonRpcRequest, Task[JsonRpcResponse]] = {

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/MantisJsonMethodImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/MantisJsonMethodImplicits.scala
@@ -1,0 +1,45 @@
+package io.iohk.ethereum.jsonrpc
+
+import io.iohk.ethereum.jsonrpc.EthJsonMethodsImplicits.transactionResponseJsonEncoder
+import io.iohk.ethereum.jsonrpc.JsonRpcError.InvalidParams
+import io.iohk.ethereum.jsonrpc.MantisService.{GetAccountTransactionsRequest, GetAccountTransactionsResponse}
+import io.iohk.ethereum.jsonrpc.serialization.{JsonEncoder, JsonMethodCodec, JsonMethodDecoder}
+import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
+import org.json4s.JsonAST._
+import org.json4s.Merge
+
+object MantisJsonMethodImplicits extends JsonMethodsImplicits {
+  implicit val extendedTransactionDataJsonEncoder: JsonEncoder[ExtendedTransactionData] = extendedTxData => {
+    val asTxResponse = TransactionResponse(
+      extendedTxData.stx,
+      extendedTxData.minedTransactionData.map(_._1),
+      extendedTxData.minedTransactionData.map(_._2)
+    )
+
+    val encodedTxResponse = JsonEncoder.encode(asTxResponse)
+    val encodedExtension = JObject(
+      "isOutgoing" -> JBool(extendedTxData.isOutgoing),
+      "isPending" -> JBool(extendedTxData.isPending)
+    )
+
+    Merge.merge(encodedTxResponse, encodedExtension)
+  }
+
+  implicit val mantis_getAccountTransactions
+      : JsonMethodCodec[GetAccountTransactionsRequest, GetAccountTransactionsResponse] =
+    new JsonMethodDecoder[GetAccountTransactionsRequest] with JsonEncoder[GetAccountTransactionsResponse] {
+      def decodeJson(params: Option[JArray]): Either[JsonRpcError, GetAccountTransactionsRequest] =
+        params match {
+          case Some(JArray(JString(addrJson) :: fromBlockJson :: toBlockJson :: Nil)) =>
+            for {
+              addr <- extractAddress(addrJson)
+              fromBlock <- extractQuantity(fromBlockJson)
+              toBlock <- extractQuantity(toBlockJson)
+            } yield GetAccountTransactionsRequest(addr, fromBlock to toBlock)
+          case _ => Left(InvalidParams())
+        }
+
+      override def encodeJson(t: GetAccountTransactionsResponse): JValue =
+        JObject("transactions" -> JsonEncoder.encode(t.transactions))
+    }
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/MantisService.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/MantisService.scala
@@ -1,0 +1,35 @@
+package io.iohk.ethereum.jsonrpc
+import io.iohk.ethereum.domain.Address
+import io.iohk.ethereum.jsonrpc.MantisService.{GetAccountTransactionsRequest, GetAccountTransactionsResponse}
+import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
+import io.iohk.ethereum.transactions.TransactionHistoryService
+import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
+import monix.eval.Task
+import cats.implicits._
+
+import scala.collection.immutable.NumericRange
+
+object MantisService {
+  case class GetAccountTransactionsRequest(address: Address, blocksRange: NumericRange[BigInt])
+  case class GetAccountTransactionsResponse(transactions: List[ExtendedTransactionData])
+}
+class MantisService(transactionHistoryService: TransactionHistoryService, jsonRpcConfig: JsonRpcConfig) {
+  def getAccountTransactions(
+      request: GetAccountTransactionsRequest
+  ): ServiceResponse[GetAccountTransactionsResponse] = {
+    if (request.blocksRange.length > jsonRpcConfig.accountTransactionsMaxBlocks) {
+      Task.now(
+        Left(
+          JsonRpcError.InvalidParams(
+            s"""Maximum number of blocks to search is ${jsonRpcConfig.accountTransactionsMaxBlocks}, requested: ${request.blocksRange.length}.
+               |See: 'mantis.network.rpc.account-transactions-max-blocks' config.""".stripMargin
+          )
+        )
+      )
+    } else {
+      transactionHistoryService
+        .getAccountTransactions(request.address, request.blocksRange)
+        .map(GetAccountTransactionsResponse(_).asRight)
+    }
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/TransactionResponse.scala
@@ -14,30 +14,24 @@ final case class TransactionResponse(
     value: BigInt,
     gasPrice: BigInt,
     gas: BigInt,
-    input: ByteString,
-    pending: Option[Boolean],
-    isOutgoing: Option[Boolean]
+    input: ByteString
 )
 
 final case class TransactionData(
     stx: SignedTransaction,
     blockHeader: Option[BlockHeader] = None,
-    transactionIndex: Option[Int] = None,
-    pending: Option[Boolean] = None,
-    isOutgoing: Option[Boolean] = None
+    transactionIndex: Option[Int] = None
 )
 
 object TransactionResponse {
 
   def apply(tx: TransactionData): TransactionResponse =
-    TransactionResponse(tx.stx, tx.blockHeader, tx.transactionIndex, tx.pending, tx.isOutgoing)
+    TransactionResponse(tx.stx, tx.blockHeader, tx.transactionIndex)
 
   def apply(
       stx: SignedTransaction,
       blockHeader: Option[BlockHeader] = None,
-      transactionIndex: Option[Int] = None,
-      pending: Option[Boolean] = None,
-      isOutgoing: Option[Boolean] = None
+      transactionIndex: Option[Int] = None
   ): TransactionResponse =
     TransactionResponse(
       hash = stx.hash,
@@ -50,9 +44,7 @@ object TransactionResponse {
       value = stx.tx.value,
       gasPrice = stx.tx.gasPrice,
       gas = stx.tx.gasLimit,
-      input = stx.tx.payload,
-      pending = pending,
-      isOutgoing = isOutgoing
+      input = stx.tx.payload
     )
 
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonEncoder.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonEncoder.scala
@@ -18,8 +18,11 @@ object JsonEncoder {
   implicit def listEncoder[T](implicit itemEncoder: JsonEncoder[T]): JsonEncoder[List[T]] = list =>
     JArray(list.map(itemEncoder.encodeJson))
 
-  def optionToNullEncoder[T](implicit valueEncoder: JsonEncoder[T]): JsonEncoder[Option[T]] = {
-    case Some(value) => valueEncoder.encodeJson(value)
-    case None => JNull
+  trait OptionToNull {
+    implicit def optionToNullEncoder[T](implicit valueEncoder: JsonEncoder[T]): JsonEncoder[Option[T]] = {
+      case Some(value) => valueEncoder.encodeJson(value)
+      case None => JNull
+    }
   }
+  object OptionToNull extends OptionToNull
 }

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonEncoder.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/serialization/JsonEncoder.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.jsonrpc.serialization
 
-import org.json4s.{JArray, JBool, JInt, JNull, JString, JValue}
+import io.iohk.ethereum.jsonrpc.JsonMethodsImplicits
+import org.json4s.{JArray, JBool, JInt, JLong, JNull, JString, JValue}
 
 trait JsonEncoder[T] {
   def encodeJson(t: T): JValue
@@ -10,10 +11,18 @@ object JsonEncoder {
 
   def encode[T](value: T)(implicit encoder: JsonEncoder[T]): JValue = encoder.encodeJson(value)
 
+  object Ops {
+    implicit class JsonEncoderOps[T](val item: T) extends AnyVal {
+      def jsonEncoded(implicit encoder: JsonEncoder[T]): JValue = encoder.encodeJson(item)
+    }
+  }
+
   implicit val stringEncoder: JsonEncoder[String] = JString(_)
   implicit val intEncoder: JsonEncoder[Int] = JInt(_)
+  implicit val longEncoder: JsonEncoder[Long] = JLong(_)
   implicit val booleanEncoder: JsonEncoder[Boolean] = JBool(_)
   implicit val jvalueEncoder: JsonEncoder[JValue] = identity
+  implicit val bigIntEncoder: JsonEncoder[BigInt] = JsonMethodsImplicits.encodeAsHex(_)
 
   implicit def listEncoder[T](implicit itemEncoder: JsonEncoder[T]): JsonEncoder[List[T]] = list =>
     JArray(list.map(itemEncoder.encodeJson))

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -280,9 +280,14 @@ object PendingTransactionsManagerBuilder {
 }
 
 trait TransactionHistoryServiceBuilder {
-  self: BlockchainBuilder with PendingTransactionsManagerBuilder with TxPoolConfigBuilder =>
-  lazy val transactionHistoryService =
-    new TransactionHistoryService(blockchain, pendingTransactionsManager, txPoolConfig.getTransactionFromPoolTimeout)
+  def transactionHistoryService: TransactionHistoryService
+}
+object TransactionHistoryServiceBuilder {
+  trait Default extends TransactionHistoryServiceBuilder {
+    self: BlockchainBuilder with PendingTransactionsManagerBuilder with TxPoolConfigBuilder =>
+    val transactionHistoryService =
+      new TransactionHistoryService(blockchain, pendingTransactionsManager, txPoolConfig.getTransactionFromPoolTimeout)
+  }
 }
 
 trait FilterManagerBuilder {
@@ -346,7 +351,7 @@ trait EthServiceBuilder {
     with JSONRpcConfigBuilder
     with AsyncConfigBuilder =>
 
-  lazy val ethService = new EthService(
+  val ethService = new EthService(
     blockchain,
     ledger,
     stxLedger,
@@ -685,4 +690,4 @@ trait Node
     with KeyStoreConfigBuilder
     with AsyncConfigBuilder
     with CheckpointBlockGeneratorBuilder
-    with TransactionHistoryServiceBuilder
+    with TransactionHistoryServiceBuilder.Default

--- a/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
@@ -1,0 +1,104 @@
+package io.iohk.ethereum.transactions
+
+import akka.actor.ActorRef
+import akka.util.Timeout
+import io.iohk.ethereum.domain.{Address, BlockHeader, Blockchain, SignedTransaction}
+import io.iohk.ethereum.jsonrpc.AkkaTaskOps.TaskActorOps
+import io.iohk.ethereum.jsonrpc.TransactionResponse
+import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
+import io.iohk.ethereum.transactions.TransactionHistoryService.TxChecker
+import io.iohk.ethereum.utils.Logger
+import monix.eval.Task
+import monix.reactive.{Observable, OverflowStrategy}
+
+import scala.collection.immutable.NumericRange
+import scala.concurrent.duration.FiniteDuration
+
+class TransactionHistoryService(
+    blockchain: Blockchain,
+    pendingTransactionsManager: ActorRef,
+    getTransactionFromPoolTimeout: FiniteDuration
+) extends Logger {
+  def getAccountTransactions(account: Address, fromBlocks: NumericRange[BigInt]): Task[Seq[TransactionResponse]] = {
+    val txnsFromBlocks = Observable
+      .from(fromBlocks.reverse)
+      .mapParallelOrdered(10)(blockNr => Task { blockchain.getBlockByNumber(blockNr) })(OverflowStrategy.Unbounded)
+      .collect { case Some(block) => block }
+      .concatMapIterable { block =>
+        val checker = TxChecker.forSigned(block.header)
+        block.body.transactionList.toVector
+          .collect(Function.unlift(checker.checkTx(_, account)))
+          .reverse
+      }
+      .toListL
+
+    val txnsFromMempool = getTransactionsFromPool map { pendingTransactions =>
+      pendingTransactions
+        .collect(Function.unlift(TxChecker.forPending.checkTx(_, account)))
+    }
+
+    Task.parMap2(txnsFromBlocks, txnsFromMempool)((pending, fromBlocks) => (pending ++ fromBlocks))
+  }
+
+  private val getTransactionsFromPool: Task[Vector[PendingTransaction]] = {
+    implicit val timeout: Timeout = getTransactionFromPoolTimeout
+    pendingTransactionsManager
+      .askFor[PendingTransactionsManager.PendingTransactionsResponse](PendingTransactionsManager.GetPendingTransactions)
+      .map(_.pendingTransactions.toVector)
+      .onErrorRecoverWith { case ex: Throwable =>
+        log.error("Failed to get pending transactions, passing empty transactions list", ex)
+        Task.now(Vector.empty)
+      }
+  }
+}
+object TransactionHistoryService {
+  trait TxChecker[T] {
+    def isTxPending: Boolean
+    def maybeBlockHeader: Option[BlockHeader]
+    def isSender(tx: T, address: Address): Boolean
+    def isReceiver(tx: T, address: Address): Boolean
+    def asSigned(tx: T): SignedTransaction
+
+    def checkTx(tx: T, address: Address): Option[TransactionResponse] = {
+      if (isSender(tx, address)) {
+        Some(
+          TransactionResponse(
+            asSigned(tx),
+            maybeBlockHeader,
+            pending = Some(isTxPending),
+            isOutgoing = Some(true)
+          )
+        )
+      } else if (isReceiver(tx, address)) {
+        Some(
+          TransactionResponse(
+            asSigned(tx),
+            maybeBlockHeader,
+            pending = Some(isTxPending),
+            isOutgoing = Some(false)
+          )
+        )
+      } else {
+        None
+      }
+    }
+  }
+  object TxChecker {
+    val forPending: TxChecker[PendingTransaction] = new TxChecker[PendingTransaction] {
+      val isTxPending = true
+      val maybeBlockHeader = None
+      def isSender(tx: PendingTransaction, maybeSender: Address) = tx.stx.senderAddress == maybeSender
+      def isReceiver(tx: PendingTransaction, maybeReceiver: Address) =
+        tx.stx.tx.tx.receivingAddress.contains(maybeReceiver)
+      def asSigned(tx: PendingTransaction) = tx.stx.tx
+    }
+
+    def forSigned(blockHeader: BlockHeader): TxChecker[SignedTransaction] = new TxChecker[SignedTransaction] {
+      val isTxPending = false
+      val maybeBlockHeader = Some(blockHeader)
+      def isSender(tx: SignedTransaction, maybeSender: Address) = tx.safeSenderIsEqualTo(maybeSender)
+      def isReceiver(tx: SignedTransaction, maybeReceiver: Address) = tx.tx.receivingAddress.contains(maybeReceiver)
+      def asSigned(tx: SignedTransaction) = tx
+    }
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
@@ -1,12 +1,12 @@
 package io.iohk.ethereum.transactions
 
 import akka.actor.ActorRef
+import cats.implicits._
 import akka.util.Timeout
-import io.iohk.ethereum.domain.{Address, BlockHeader, Blockchain, SignedTransaction}
+import io.iohk.ethereum.domain.{Address, Block, BlockHeader, Blockchain, SignedTransaction}
 import io.iohk.ethereum.jsonrpc.AkkaTaskOps.TaskActorOps
-import io.iohk.ethereum.jsonrpc.TransactionResponse
 import io.iohk.ethereum.transactions.PendingTransactionsManager.PendingTransaction
-import io.iohk.ethereum.transactions.TransactionHistoryService.TxChecker
+import io.iohk.ethereum.transactions.TransactionHistoryService.{ExtendedTransactionData, TxChecker}
 import io.iohk.ethereum.utils.Logger
 import monix.eval.Task
 import monix.reactive.{Observable, OverflowStrategy}
@@ -19,14 +19,17 @@ class TransactionHistoryService(
     pendingTransactionsManager: ActorRef,
     getTransactionFromPoolTimeout: FiniteDuration
 ) extends Logger {
-  def getAccountTransactions(account: Address, fromBlocks: NumericRange[BigInt]): Task[Seq[TransactionResponse]] = {
+  def getAccountTransactions(
+      account: Address,
+      fromBlocks: NumericRange[BigInt]
+  ): Task[List[ExtendedTransactionData]] = {
     val txnsFromBlocks = Observable
       .from(fromBlocks.reverse)
       .mapParallelOrdered(10)(blockNr => Task { blockchain.getBlockByNumber(blockNr) })(OverflowStrategy.Unbounded)
       .collect { case Some(block) => block }
       .concatMapIterable { block =>
-        val checker = TxChecker.forSigned(block.header)
-        block.body.transactionList.toVector
+        val checker = TxChecker.forSigned(block)
+        block.body.transactionList.toList
           .collect(Function.unlift(checker.checkTx(_, account)))
           .reverse
       }
@@ -37,68 +40,73 @@ class TransactionHistoryService(
         .collect(Function.unlift(TxChecker.forPending.checkTx(_, account)))
     }
 
-    Task.parMap2(txnsFromBlocks, txnsFromMempool)((pending, fromBlocks) => (pending ++ fromBlocks))
+    Task.parMap2(txnsFromBlocks, txnsFromMempool)(_ ++ _)
   }
 
-  private val getTransactionsFromPool: Task[Vector[PendingTransaction]] = {
+  private val getTransactionsFromPool: Task[List[PendingTransaction]] = {
     implicit val timeout: Timeout = getTransactionFromPoolTimeout
     pendingTransactionsManager
       .askFor[PendingTransactionsManager.PendingTransactionsResponse](PendingTransactionsManager.GetPendingTransactions)
-      .map(_.pendingTransactions.toVector)
+      .map(_.pendingTransactions.toList)
       .onErrorRecoverWith { case ex: Throwable =>
         log.error("Failed to get pending transactions, passing empty transactions list", ex)
-        Task.now(Vector.empty)
+        Task.now(List.empty)
       }
   }
 }
 object TransactionHistoryService {
-  trait TxChecker[T] {
-    def isTxPending: Boolean
-    def maybeBlockHeader: Option[BlockHeader]
-    def isSender(tx: T, address: Address): Boolean
-    def isReceiver(tx: T, address: Address): Boolean
-    def asSigned(tx: T): SignedTransaction
+  case class ExtendedTransactionData(
+      stx: SignedTransaction,
+      isOutgoing: Boolean,
+      //block header and transaction index
+      minedTransactionData: Option[(BlockHeader, Int)]
+  ) {
+    val isPending: Boolean = minedTransactionData.isEmpty
+  }
 
-    def checkTx(tx: T, address: Address): Option[TransactionResponse] = {
-      if (isSender(tx, address)) {
-        Some(
-          TransactionResponse(
-            asSigned(tx),
-            maybeBlockHeader,
-            pending = Some(isTxPending),
-            isOutgoing = Some(true)
-          )
-        )
-      } else if (isReceiver(tx, address)) {
-        Some(
-          TransactionResponse(
-            asSigned(tx),
-            maybeBlockHeader,
-            pending = Some(isTxPending),
-            isOutgoing = Some(false)
-          )
-        )
-      } else {
-        None
-      }
-    }
+  trait TxChecker[T] {
+    def checkTx(tx: T, address: Address): Option[ExtendedTransactionData]
   }
   object TxChecker {
     val forPending: TxChecker[PendingTransaction] = new TxChecker[PendingTransaction] {
-      val isTxPending = true
-      val maybeBlockHeader = None
       def isSender(tx: PendingTransaction, maybeSender: Address) = tx.stx.senderAddress == maybeSender
       def isReceiver(tx: PendingTransaction, maybeReceiver: Address) =
         tx.stx.tx.tx.receivingAddress.contains(maybeReceiver)
       def asSigned(tx: PendingTransaction) = tx.stx.tx
+
+      def checkTx(tx: PendingTransaction, address: Address): Option[ExtendedTransactionData] = {
+        if (isSender(tx, address)) {
+          Some(ExtendedTransactionData(asSigned(tx), isOutgoing = true, None))
+        } else if (isReceiver(tx, address)) {
+          Some(ExtendedTransactionData(asSigned(tx), isOutgoing = false, None))
+        } else {
+          None
+        }
+      }
     }
 
-    def forSigned(blockHeader: BlockHeader): TxChecker[SignedTransaction] = new TxChecker[SignedTransaction] {
-      val isTxPending = false
-      val maybeBlockHeader = Some(blockHeader)
+    def forSigned(block: Block): TxChecker[SignedTransaction] = new TxChecker[SignedTransaction] {
       def isSender(tx: SignedTransaction, maybeSender: Address) = tx.safeSenderIsEqualTo(maybeSender)
       def isReceiver(tx: SignedTransaction, maybeReceiver: Address) = tx.tx.receivingAddress.contains(maybeReceiver)
       def asSigned(tx: SignedTransaction) = tx
+
+      def getMinedTxData(tx: SignedTransaction): Option[(BlockHeader, Int)] = {
+        val maybeIndex = block.body.transactionList.zipWithIndex.collectFirst {
+          case (someTx, index) if someTx.hash == tx.hash => index
+        }
+
+        (Some(block.header), maybeIndex).tupled
+      }
+
+      def checkTx(tx: SignedTransaction, address: Address): Option[ExtendedTransactionData] = {
+        if (isSender(tx, address)) {
+          Some(ExtendedTransactionData(asSigned(tx), isOutgoing = true, getMinedTxData(tx)))
+        } else if (isReceiver(tx, address)) {
+          Some(ExtendedTransactionData(asSigned(tx), isOutgoing = false, getMinedTxData(tx)))
+        } else {
+          None
+        }
+      }
     }
   }
 }

--- a/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
+++ b/src/main/scala/io/iohk/ethereum/transactions/TransactionHistoryService.scala
@@ -17,7 +17,6 @@ import monix.reactive.{Observable, OverflowStrategy}
 
 import scala.collection.immutable.NumericRange
 import scala.concurrent.duration.FiniteDuration
-import scala.language.higherKinds
 
 class TransactionHistoryService(
     blockchain: Blockchain,

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -14,7 +14,7 @@ mantis {
 
   network.peer.max-pending-peers = 1
 
-  network.rpc.apis = "eth,web3,net,personal,daedalus,debug,qa,checkpointing"
+  network.rpc.apis = "eth,web3,net,personal,mantis,debug,qa,checkpointing"
 
   blockchains {
     network = "test"

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/EphemBlockchainTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/EphemBlockchainTestSetup.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.blockchain.sync
 import io.iohk.ethereum.db.components.{EphemDataSourceComponent, Storages}
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
-import io.iohk.ethereum.nodebuilder.PruningConfigBuilder
+import io.iohk.ethereum.nodebuilder.{BlockchainBuilder, PruningConfigBuilder}
 
 trait EphemBlockchainTestSetup extends ScenarioSetup {
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/EphemBlockchainTestSetup.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/EphemBlockchainTestSetup.scala
@@ -3,7 +3,7 @@ package io.iohk.ethereum.blockchain.sync
 import io.iohk.ethereum.db.components.{EphemDataSourceComponent, Storages}
 import io.iohk.ethereum.db.storage.pruning.{ArchivePruning, PruningMode}
 import io.iohk.ethereum.ledger.Ledger.VMImpl
-import io.iohk.ethereum.nodebuilder.{BlockchainBuilder, PruningConfigBuilder}
+import io.iohk.ethereum.nodebuilder.PruningConfigBuilder
 
 trait EphemBlockchainTestSetup extends ScenarioSetup {
 

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/StateSyncSpec.scala
@@ -9,7 +9,13 @@ import akka.testkit.{TestKit, TestProbe}
 import akka.util.ByteString
 import io.iohk.ethereum.blockchain.sync.StateSyncUtils.{MptNodeData, TrieProvider}
 import io.iohk.ethereum.blockchain.sync.fast.{SyncStateScheduler, SyncStateSchedulerActor}
-import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.{RestartRequested, StartSyncingTo, StateSyncFinished, StateSyncStats, WaitingForNewTargetBlock}
+import io.iohk.ethereum.blockchain.sync.fast.SyncStateSchedulerActor.{
+  RestartRequested,
+  StartSyncingTo,
+  StateSyncFinished,
+  StateSyncStats,
+  WaitingForNewTargetBlock
+}
 import io.iohk.ethereum.db.dataSource.RocksDbDataSource.IterationError
 import io.iohk.ethereum.domain.{Address, BlockchainImpl, ChainWeight}
 import io.iohk.ethereum.network.EtcPeerManagerActor.{GetHandshakedPeers, HandshakedPeers, PeerInfo, SendMessage}

--- a/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/BlockchainSpec.scala
@@ -154,15 +154,17 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
       }
 
       blockchainWithStubPersisting.getBestBlockNumber() shouldBe blocksToImport.last.number
-      blockchainStoragesWithStubPersisting.appStateStorage.getBestBlockNumber() shouldBe blockImportToPersist.fold(0: BigInt)(_.number)
-
+      blockchainStoragesWithStubPersisting.appStateStorage.getBestBlockNumber() shouldBe blockImportToPersist.fold(
+        0: BigInt
+      )(_.number)
 
       // Rollback blocks
       val numberBlocksToRollback = intGen(0, numberBlocksToImport).sample.get
       val (blocksNotRollbacked, blocksToRollback) = blocksToImport.splitAt(numberBlocksToRollback)
 
       // Randomly select the block rollback to persist (empty means no persistance)
-      val blockRollbackToPersist = if (blocksToRollback.isEmpty) None else Gen.option(Gen.oneOf(blocksToRollback)).sample.get
+      val blockRollbackToPersist =
+        if (blocksToRollback.isEmpty) None else Gen.option(Gen.oneOf(blocksToRollback)).sample.get
       (stubStateStorage
         .onBlockRollback(_: BigInt, _: BigInt)(_: () => Unit))
         .when(*, *, *)
@@ -188,14 +190,18 @@ class BlockchainSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
   trait TestSetup extends MockFactory {
     val maxNumberBlocksToImport: Int = 30
 
-    def calculatePersistedBestBlock(blockImportPersisted: Option[BigInt], blockRollbackPersisted: Option[BigInt], blocksRollbacked: Seq[BigInt]): BigInt = {
+    def calculatePersistedBestBlock(
+        blockImportPersisted: Option[BigInt],
+        blockRollbackPersisted: Option[BigInt],
+        blocksRollbacked: Seq[BigInt]
+    ): BigInt = {
       (blocksRollbacked, blockImportPersisted) match {
         case (Nil, Some(bi)) =>
           // No blocks rollbacked, last persist was the persist during import
           bi
         case (nonEmptyRollbackedBlocks, Some(bi)) =>
           // Last forced persist during apply/rollback
-          val maxForcedPersist = blockRollbackPersisted.fold(bi){ br => (br - 1).max(bi)}
+          val maxForcedPersist = blockRollbackPersisted.fold(bi) { br => (br - 1).max(bi) }
 
           // The above number would have been decreased by any rollbacked blocks
           (nonEmptyRollbackedBlocks.head - 1).min(maxForcedPersist)

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingJRCSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/CheckpointingJRCSpec.scala
@@ -209,6 +209,8 @@ class CheckpointingJRCSpec
     val ethService = mock[EthService]
     val qaService = mock[QAService]
     val checkpointingService = mock[CheckpointingService]
+    val mantisService = mock[MantisService]
+
     val jsonRpcController =
       new JsonRpcController(
         web3Service,
@@ -219,6 +221,7 @@ class CheckpointingJRCSpec
         debugService,
         qaService,
         checkpointingService,
+        mantisService,
         config
       )
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -1,6 +1,5 @@
 package io.iohk.ethereum.jsonrpc
 
-import java.security.SecureRandom
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.ByteString
@@ -25,17 +24,14 @@ import io.iohk.ethereum.mpt.{ByteArrayEncoder, ByteArraySerializable, MerklePatr
 import io.iohk.ethereum.nodebuilder.ApisBuilder
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.testing.ActorsTesting.simpleAutoPilot
-import io.iohk.ethereum.transactions.{PendingTransactionsManager, TransactionHistoryService}
+import io.iohk.ethereum.transactions.PendingTransactionsManager
 import io.iohk.ethereum.transactions.PendingTransactionsManager.{
   GetPendingTransactions,
   PendingTransaction,
   PendingTransactionsResponse
 }
-import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
-import io.iohk.ethereum.utils.ByteStringUtils.hash2string
 import io.iohk.ethereum.utils._
-import io.iohk.ethereum.{BlockHelpers, Fixtures, NormalPatience, Timeouts, WithActorSystemShutDown, crypto}
-import monix.eval.Task
+import io.iohk.ethereum._
 import monix.execution.Scheduler.Implicits.global
 import org.bouncycastle.util.encoders.Hex
 import org.scalactic.TypeCheckedTripleEquals
@@ -45,7 +41,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.immutable.NumericRange
 import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 
 // scalastyle:off file.size.limit

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/EthServiceSpec.scala
@@ -509,8 +509,8 @@ class EthServiceSpec
           startingBlock = 999,
           currentBlock = 200,
           highestBlock = 10000,
-          knownStates = 100,
-          pulledStates = 144
+          knownStates = 144,
+          pulledStates = 100
         )
       )
     )

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthSpec.scala
@@ -85,8 +85,8 @@ class JsonRpcControllerEthSpec
       "startingBlock" -> "0x3e7",
       "currentBlock" -> "0xc8",
       "highestBlock" -> "0x2710",
-      "knownStates" -> "0x64",
-      "pulledStates" -> "0x90"
+      "knownStates" -> "0x90",
+      "pulledStates" -> "0x64"
     )
   }
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerEthTransactionSpec.scala
@@ -430,6 +430,7 @@ class JsonRpcControllerEthTransactionSpec
         debugService,
         qaService,
         checkpointingService,
+        mantisService,
         config
       )
 
@@ -480,6 +481,7 @@ class JsonRpcControllerEthTransactionSpec
         debugService,
         qaService,
         checkpointingService,
+        mantisService,
         config
       )
     val request = JsonRpcRequest(

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -16,11 +16,13 @@ import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpc
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{BloomFilter, Ledger, StxLedger}
 import io.iohk.ethereum.nodebuilder.ApisBuilder
+import io.iohk.ethereum.transactions.TransactionHistoryService
 import io.iohk.ethereum.utils.{Config, FilterConfig}
 import io.iohk.ethereum.{Fixtures, ObjectGenerators, Timeouts}
 import org.bouncycastle.util.encoders.Hex
 import org.json4s.JsonAST.{JArray, JInt, JString, JValue}
 import org.scalamock.scalatest.MockFactory
+
 import scala.concurrent.duration._
 
 class JsonRpcControllerFixture(implicit system: ActorSystem)
@@ -74,6 +76,8 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
   val debugService = mock[DebugService]
   val qaService = mock[QAService]
   val checkpointingService = mock[CheckpointingService]
+  val transactionHistoryService =
+    new TransactionHistoryService(blockchain, pendingTransactionsManager.ref, getTransactionFromPoolTimeout)
 
   val ethService = new EthService(
     blockchain,
@@ -84,6 +88,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
     syncingController.ref,
     ommersPool.ref,
     filterManager.ref,
+    transactionHistoryService,
     filterConfig,
     blockchainConfig,
     currentProtocolVersion,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -16,7 +16,6 @@ import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpc
 import io.iohk.ethereum.keystore.KeyStore
 import io.iohk.ethereum.ledger.{BloomFilter, Ledger, StxLedger}
 import io.iohk.ethereum.nodebuilder.ApisBuilder
-import io.iohk.ethereum.transactions.TransactionHistoryService
 import io.iohk.ethereum.utils.{Config, FilterConfig}
 import io.iohk.ethereum.{Fixtures, ObjectGenerators, Timeouts}
 import org.bouncycastle.util.encoders.Hex

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerFixture.scala
@@ -76,8 +76,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
   val debugService = mock[DebugService]
   val qaService = mock[QAService]
   val checkpointingService = mock[CheckpointingService]
-  val transactionHistoryService =
-    new TransactionHistoryService(blockchain, pendingTransactionsManager.ref, getTransactionFromPoolTimeout)
+  val mantisService = mock[MantisService]
 
   val ethService = new EthService(
     blockchain,
@@ -88,7 +87,6 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
     syncingController.ref,
     ommersPool.ref,
     filterManager.ref,
-    transactionHistoryService,
     filterConfig,
     blockchainConfig,
     currentProtocolVersion,
@@ -107,6 +105,7 @@ class JsonRpcControllerFixture(implicit system: ActorSystem)
       debugService,
       qaService,
       checkpointingService,
+      mantisService,
       config
     )
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -4,25 +4,22 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInfoResponse}
-import io.iohk.ethereum.jsonrpc.EthService._
-import io.iohk.ethereum.jsonrpc.MantisService.GetAccountTransactionsResponse
-import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
+import io.iohk.ethereum.jsonrpc.NetService.{ListeningResponse, PeerCountResponse, VersionResponse}
 import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.{
   OptionNoneToJNullSerializer,
   QuantitiesSerializer,
   UnformattedDataJsonSerializer
 }
-import io.iohk.ethereum.jsonrpc.NetService.{ListeningResponse, PeerCountResponse, VersionResponse}
+import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer
 import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer
 import io.iohk.ethereum.network.EtcPeerManagerActor.PeerInfo
 import io.iohk.ethereum.network.p2p.messages.CommonMessages.Status
 import io.iohk.ethereum.network.p2p.messages.Versions
-import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
 import io.iohk.ethereum.{Fixtures, LongPatience, WithActorSystemShutDown}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.json4s.{DefaultFormats, Extraction, Formats, JArray, JBool, JInt, JObject, JString}
+import org.json4s.{DefaultFormats, Formats, JArray, JObject, JString}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisJRCSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisJRCSpec.scala
@@ -1,0 +1,108 @@
+package io.iohk.ethereum.jsonrpc
+
+import io.iohk.ethereum.jsonrpc.MantisService.GetAccountTransactionsResponse
+import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
+import io.iohk.ethereum.nodebuilder.ApisBuilder
+import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
+import io.iohk.ethereum.utils.Config
+import io.iohk.ethereum.{Fixtures, FreeSpecBase, SpecFixtures}
+import monix.eval.Task
+import org.json4s.{Extraction, JArray, JBool, JInt, JObject, JString}
+import org.scalamock.scalatest.AsyncMockFactory
+
+class MantisJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory with JRCMatchers {
+  import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.formats
+
+  class Fixture extends ApisBuilder {
+    def config: JsonRpcConfig = JsonRpcConfig(Config.config, available)
+
+    val web3Service = mock[Web3Service]
+    val netService = mock[NetService]
+    val personalService = mock[PersonalService]
+    val debugService = mock[DebugService]
+    val ethService = mock[EthService]
+    val qaService = mock[QAService]
+    val checkpointingService = mock[CheckpointingService]
+    val mantisService = mock[MantisService]
+
+    val jsonRpcController =
+      new JsonRpcController(
+        web3Service,
+        netService,
+        ethService,
+        personalService,
+        None,
+        debugService,
+        qaService,
+        checkpointingService,
+        mantisService,
+        config
+      )
+
+  }
+  def createFixture() = new Fixture
+
+  "Mantis JRC" - {
+    "should handle mantis_getAccountTransactions" in testCaseM { fixture =>
+      import fixture._
+      val block = Fixtures.Blocks.Block3125369
+      val sentTx = block.body.transactionList.head
+      val receivedTx = block.body.transactionList.last
+
+      (mantisService.getAccountTransactions _)
+        .expects(*)
+        .returning(
+          Task.now(
+            Right(
+              GetAccountTransactionsResponse(
+                List(
+                  ExtendedTransactionData(sentTx, isOutgoing = true, Some((block.header, 0))),
+                  ExtendedTransactionData(receivedTx, isOutgoing = false, Some((block.header, 1)))
+                )
+              )
+            )
+          )
+        )
+
+      val request: JsonRpcRequest = JsonRpcRequest(
+        "2.0",
+        "mantis_getAccountTransactions",
+        Some(
+          JArray(
+            List(
+              JString(s"0x7B9Bc474667Db2fFE5b08d000F1Acc285B2Ae47D"),
+              JInt(100),
+              JInt(200)
+            )
+          )
+        ),
+        Some(JInt(1))
+      )
+
+      val expectedTxs = Seq(
+        JObject(
+          Extraction
+            .decompose(TransactionResponse(sentTx, Some(block.header), Some(0)))
+            .asInstanceOf[JObject]
+            .obj ++ List(
+            "isPending" -> JBool(false),
+            "isOutgoing" -> JBool(true)
+          )
+        ),
+        JObject(
+          Extraction
+            .decompose(TransactionResponse(receivedTx, Some(block.header), Some(1)))
+            .asInstanceOf[JObject]
+            .obj ++ List(
+            "isPending" -> JBool(false),
+            "isOutgoing" -> JBool(false)
+          )
+        )
+      )
+
+      for {
+        response <- jsonRpcController.handleRequest(request)
+      } yield response should haveObjectResult("transactions" -> JArray(expectedTxs.toList))
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -1,0 +1,100 @@
+package io.iohk.ethereum.jsonrpc
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{TestKit, TestProbe}
+import akka.util.ByteString
+import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.crypto.ECDSASignature
+import io.iohk.ethereum.domain.{Address, BlockBody, SignedTransactionWithSender, Transaction}
+import io.iohk.ethereum.jsonrpc.MantisService.{GetAccountTransactionsRequest, GetAccountTransactionsResponse}
+import io.iohk.ethereum.nodebuilder.{
+  ApisBuilder,
+  JSONRpcConfigBuilder,
+  MantisServiceBuilder,
+  PendingTransactionsManagerBuilder,
+  TransactionHistoryServiceBuilder,
+  TxPoolConfigBuilder
+}
+import io.iohk.ethereum.transactions.TransactionHistoryService
+import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
+import io.iohk.ethereum.{BlockHelpers, FreeSpecBase, SpecFixtures, WithActorSystemShutDown}
+import monix.eval.Task
+
+import scala.collection.immutable.NumericRange
+
+class MantisServiceSpec
+    extends TestKit(ActorSystem("MantisServiceSpec"))
+    with FreeSpecBase
+    with SpecFixtures
+    with WithActorSystemShutDown {
+  class Fixture
+      extends TransactionHistoryServiceBuilder
+      with EphemBlockchainTestSetup
+      with PendingTransactionsManagerBuilder
+      with TxPoolConfigBuilder
+      with MantisServiceBuilder
+      with JSONRpcConfigBuilder
+      with ApisBuilder {
+    lazy val pendingTransactionsManagerProbe = TestProbe()
+    override lazy val pendingTransactionsManager: ActorRef = pendingTransactionsManagerProbe.ref
+  }
+  def createFixture() = new Fixture
+
+  "Mantis Service" - {
+    "should get account's transaction history" in {
+      class TxHistoryFixture extends Fixture {
+        val fakeTransaction = SignedTransactionWithSender(
+          Transaction(
+            nonce = 0,
+            gasPrice = 123,
+            gasLimit = 123,
+            receivingAddress = Address("0x1234"),
+            value = 0,
+            payload = ByteString()
+          ),
+          signature = ECDSASignature(0, 0, 0.toByte),
+          sender = Address("0x1234")
+        )
+
+        val block =
+          BlockHelpers.generateBlock(BlockHelpers.genesis).copy(body = BlockBody(List(fakeTransaction.tx), Nil))
+
+        val expectedResponse = List(
+          ExtendedTransactionData(
+            fakeTransaction.tx,
+            isOutgoing = true,
+            Some((block.header, 0))
+          )
+        )
+
+        override lazy val transactionHistoryService: TransactionHistoryService =
+          new TransactionHistoryService(
+            blockchain,
+            pendingTransactionsManager,
+            txPoolConfig.getTransactionFromPoolTimeout
+          ) {
+            override def getAccountTransactions(account: Address, fromBlocks: NumericRange[BigInt]) =
+              Task.pure(expectedResponse)
+          }
+      }
+
+      customTestCaseM(new TxHistoryFixture) { fixture =>
+        import fixture._
+
+        mantisService
+          .getAccountTransactions(GetAccountTransactionsRequest(fakeTransaction.senderAddress, BigInt(0) to BigInt(1)))
+          .map(result => assert(result === Right(GetAccountTransactionsResponse(expectedResponse))))
+      }
+    }
+
+    "should validate range size against configuration" in testCaseM { fixture =>
+      import fixture._
+
+      mantisService
+        .getAccountTransactions(
+          GetAccountTransactionsRequest(Address(1), BigInt(0) to BigInt(jsonRpcConfig.accountTransactionsMaxBlocks + 1))
+        )
+        .map(result => assert(result.isLeft))
+    }
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -28,7 +28,7 @@ class MantisServiceSpec
     with SpecFixtures
     with WithActorSystemShutDown {
   class Fixture
-      extends TransactionHistoryServiceBuilder
+      extends TransactionHistoryServiceBuilder.Default
       with EphemBlockchainTestSetup
       with PendingTransactionsManagerBuilder
       with TxPoolConfigBuilder
@@ -67,7 +67,7 @@ class MantisServiceSpec
           )
         )
 
-        override lazy val transactionHistoryService: TransactionHistoryService =
+        override val transactionHistoryService: TransactionHistoryService =
           new TransactionHistoryService(
             blockchain,
             pendingTransactionsManager,

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -16,7 +16,7 @@ import io.iohk.ethereum.nodebuilder.{
   TxPoolConfigBuilder
 }
 import io.iohk.ethereum.transactions.TransactionHistoryService
-import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
+import io.iohk.ethereum.transactions.TransactionHistoryService.{ExtendedTransactionData, MinedTransactionData}
 import io.iohk.ethereum.{BlockHelpers, FreeSpecBase, SpecFixtures, WithActorSystemShutDown}
 import monix.eval.Task
 
@@ -63,7 +63,7 @@ class MantisServiceSpec
           ExtendedTransactionData(
             fakeTransaction.tx,
             isOutgoing = true,
-            Some((block.header, 0))
+            Some(MinedTransactionData(block.header, 0, 42))
           )
         )
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/QaJRCSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/QaJRCSpec.scala
@@ -245,8 +245,9 @@ class QaJRCSpec
     val debugService = mock[DebugService]
     val ethService = mock[EthService]
     val checkpointingService = mock[CheckpointingService]
-
+    val mantisService = mock[MantisService]
     val qaService = mock[QAService]
+
     val jsonRpcController =
       new JsonRpcController(
         web3Service,
@@ -257,6 +258,7 @@ class QaJRCSpec
         debugService,
         qaService,
         checkpointingService,
+        mantisService,
         config
       )
 

--- a/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
@@ -1,0 +1,95 @@
+package io.iohk.ethereum.transactions
+
+import akka.actor.ActorSystem
+import akka.testkit.{TestKit, TestProbe}
+import akka.util.ByteString
+import io.iohk.ethereum._
+import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
+import io.iohk.ethereum.domain.{Address, Block, SignedTransaction, Transaction}
+import io.iohk.ethereum.transactions.TransactionHistoryService.ExtendedTransactionData
+import io.iohk.ethereum.transactions.testing.PendingTransactionsManagerAutoPilot
+import monix.eval.Task
+
+import java.security.SecureRandom
+
+class TransactionHistoryServiceSpec
+    extends TestKit(ActorSystem("TransactionHistoryServiceSpec-system"))
+    with FreeSpecBase
+    with SpecFixtures
+    with WithActorSystemShutDown {
+  class Fixture extends EphemBlockchainTestSetup {
+    val pendingTransactionManager = TestProbe()
+    pendingTransactionManager.setAutoPilot(PendingTransactionsManagerAutoPilot())
+    val transactionHistoryService =
+      new TransactionHistoryService(blockchain, pendingTransactionManager.ref, Timeouts.normalTimeout)
+  }
+
+  def createFixture() = new Fixture
+
+  "returns account recent transactions in newest -> oldest order" in testCaseM { fixture =>
+    import fixture._
+
+    val address = Address("0xee4439beb5c71513b080bbf9393441697a29f478")
+
+    val keyPair = crypto.generateKeyPair(new SecureRandom)
+
+    val tx1 = SignedTransaction.sign(Transaction(0, 123, 456, Some(address), 1, ByteString()), keyPair, None).tx
+    val tx2 = SignedTransaction.sign(Transaction(0, 123, 456, Some(address), 2, ByteString()), keyPair, None).tx
+    val tx3 = SignedTransaction.sign(Transaction(0, 123, 456, Some(address), 3, ByteString()), keyPair, None).tx
+
+    val blockWithTx1 =
+      Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body.copy(transactionList = Seq(tx1)))
+
+    val blockWithTxs2and3 = Block(
+      Fixtures.Blocks.Block3125369.header.copy(number = 3125370),
+      Fixtures.Blocks.Block3125369.body.copy(transactionList = Seq(tx2, tx3))
+    )
+
+    val expectedTxs = Seq(
+      ExtendedTransactionData(
+        tx3,
+        isOutgoing = false,
+        Some(blockWithTxs2and3.header -> 1)
+      ),
+      ExtendedTransactionData(
+        tx2,
+        isOutgoing = false,
+        Some(blockWithTxs2and3.header -> 0)
+      ),
+      ExtendedTransactionData(tx1, isOutgoing = false, Some(blockWithTx1.header -> 0))
+    )
+
+    for {
+      _ <- Task {
+        blockchain
+          .storeBlock(blockWithTx1)
+          .and(blockchain.storeBlock(blockWithTxs2and3))
+          .commit()
+      }
+      response <- transactionHistoryService.getAccountTransactions(address, BigInt(3125360) to BigInt(3125370))
+    } yield assert(response === expectedTxs)
+  }
+
+  "does not return account recent transactions from older blocks and return pending txs" in testCaseM { fixture =>
+    import fixture._
+
+    val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+
+    val keyPair = crypto.generateKeyPair(new SecureRandom)
+
+    val tx = Transaction(0, 123, 456, None, 99, ByteString())
+    val signedTx = SignedTransaction.sign(tx, keyPair, None)
+
+    val expectedSent =
+      Seq(ExtendedTransactionData(signedTx.tx, isOutgoing = true, None))
+
+    for {
+      _ <- Task { blockchain.storeBlock(blockWithTx).commit() }
+      _ <- Task { pendingTransactionManager.ref ! PendingTransactionsManager.AddTransactions(signedTx) }
+      response <- transactionHistoryService.getAccountTransactions(
+        signedTx.senderAddress,
+        BigInt(3125371) to BigInt(3125381)
+      )
+    } yield assert(response === expectedSent)
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/transactions/testing/PendingTransactionsManagerAutoPilot.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/testing/PendingTransactionsManagerAutoPilot.scala
@@ -1,0 +1,55 @@
+package io.iohk.ethereum.transactions.testing
+import akka.actor.ActorRef
+import akka.testkit.TestActor.AutoPilot
+import akka.util.ByteString
+import io.iohk.ethereum.domain.{SignedTransaction, SignedTransactionWithSender}
+import io.iohk.ethereum.transactions.PendingTransactionsManager._
+import io.iohk.ethereum.transactions.SignedTransactionsFilterActor.ProperSignedTransactions
+
+case class PendingTransactionsManagerAutoPilot(pendingTransactions: Set[PendingTransaction] = Set.empty)
+    extends AutoPilot {
+  def run(sender: ActorRef, msg: Any) = {
+    msg match {
+      case AddUncheckedTransactions(transactions) =>
+        val validTxs = SignedTransactionWithSender.getSignedTransactions(transactions)
+        this.addTransactions(validTxs.toSet)
+
+      case AddTransactions(signedTransactions) =>
+        this.addTransactions(signedTransactions)
+
+      case AddOrOverrideTransaction(newStx) =>
+        // Only validated transactions are added this way, it is safe to call get
+        val newStxSender = SignedTransaction.getSender(newStx).get
+        val obsoleteTxs = pendingTransactions
+          .filter(ptx => ptx.stx.senderAddress == newStxSender && ptx.stx.tx.tx.nonce == newStx.tx.nonce)
+          .map(_.stx.tx.hash)
+
+        removeTransactions(obsoleteTxs).addTransactions(Set(SignedTransactionWithSender(newStx, newStxSender)))
+
+      case GetPendingTransactions =>
+        sender ! PendingTransactionsResponse(pendingTransactions.toSeq)
+        this
+
+      case RemoveTransactions(signedTransactions) =>
+        this.removeTransactions(signedTransactions.map(_.hash).toSet)
+
+      case ProperSignedTransactions(transactions, peerId) =>
+        this.addTransactions(transactions)
+
+      case ClearPendingTransactions =>
+        copy(pendingTransactions = Set.empty)
+    }
+  }
+
+  def addTransactions(signedTransactions: Set[SignedTransactionWithSender]) = {
+    val timestamp = System.currentTimeMillis()
+    val stxs = pendingTransactions.map(_.stx)
+    val transactionsToAdd = signedTransactions.diff(stxs).map(tx => PendingTransaction(tx, timestamp))
+
+    copy(pendingTransactions ++ transactionsToAdd)
+  }
+
+  def removeTransactions(hashes: Set[ByteString]) = {
+    copy(pendingTransactions.filterNot(ptx => hashes.contains(ptx.stx.tx.hash)))
+  }
+}

--- a/src/test/scala/io/iohk/ethereum/utils/VersionInfoSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/utils/VersionInfoSpec.scala
@@ -7,7 +7,8 @@ class VersionInfoSpec extends AnyFlatSpec with Matchers {
   behavior of "nodeName"
 
   it should "match ethstats expected structure and preserve major and minor Java version" in {
-    VersionInfo.nodeName() should fullyMatch regex """mantis/v\d(\.\d+)*-[a-z0-9]{7}/[^/]+-[^/]+/[^/]+-.[^/]+-java-\d+\.\d+[._0-9]*"""
+    VersionInfo
+      .nodeName() should fullyMatch regex """mantis/v\d(\.\d+)*-[a-z0-9]{7}/[^/]+-[^/]+/[^/]+-.[^/]+-java-\d+\.\d+[._0-9]*"""
   }
 
   it should "augment the name with an identity" in {

--- a/src/universal/conf/testmode.conf
+++ b/src/universal/conf/testmode.conf
@@ -17,7 +17,7 @@ mantis {
   }
 
   network.rpc {
-    apis = "eth,web3,net,personal,daedalus,test,iele,debug,qa,checkpointing"
+    apis = "eth,web3,net,personal,mantis,test,iele,debug,qa,checkpointing"
   }
 
 }


### PR DESCRIPTION
# Description

Move transaction history method to `mantis_` namespace, and add couple of additional informations a requested by Mantis Wallet devs.

It's a high priority because it's quite important from wallet perspective.

# Testing

1. all unit tests should pass
2. check if method complains about too large number of blocks within range
3. check whether method finds transactions sent or received by given address (only direct sender or direct receiver is supported so far), example tx on mordor: https://blockscout.com/etc/mordor/tx/0x6249ce7bae7e6c57b08f4a9333bd335a9c001b648e2b62b30c4cea8e80fa9842/internal-transactions, it's a tx from faucet to my testing address

