### PR TITLE
[Chore] Configure the future address of the treasury contract (nomad testnet)

### DIFF
--- a/src/main/resources/chains/testnet-internal-nomad-chain.conf
+++ b/src/main/resources/chains/testnet-internal-nomad-chain.conf
@@ -84,7 +84,7 @@
 
     # Proto-treasury fork block number (ETC only, but deactivated for now)
     # https://ecips.ethereumclassic.org/ECIPs/ecip-1098
-    treasury-address = "0011223344556677889900112233445566778899"
+    treasury-address = "0358e65dfe67b350eb827ffa17a82e7bb5f4c0c6"
     ecip1098-block-number = "0"
 
     # Checkpointing fork block number


### PR DESCRIPTION
# Description

Prepare our nomad testnet for deploying the treasury contract


# Proposed Solution

Due to our check of account existance on the block execution, the treasury contract can be deployed on an testnet with ECIP 1098 already enabled by:

1. @KonradStaniec created the contract deploying account (`0xfca4134ea4203dbfeffbe55f8568ac2ff41f5f7f`) and derivated the expected treasury address (`0x0358e65dfe67b350eb827ffa17a82e7bb5f4c0c6`)
2. This PR, add it to our configurations (it's a requirement that the treasury address before it to never be used)
3. Deploy the treasury contract

# Testing

Connect to the nomad testnet and execute blocks without any issues
