### PR TITLE
Add signature validation tool + fix checkpointing padding.

### DIFF
--- a/src/main/scala/io/iohk/ethereum/App.scala
+++ b/src/main/scala/io/iohk/ethereum/App.scala
@@ -1,7 +1,7 @@
 package io.iohk.ethereum
 
 import io.iohk.ethereum.cli.CliLauncher
-import io.iohk.ethereum.crypto.EcKeyGen
+import io.iohk.ethereum.crypto.{EcKeyGen, SignatureValidator}
 import io.iohk.ethereum.extvm.VmServerApp
 import io.iohk.ethereum.faucet.Faucet
 import io.iohk.ethereum.mallet.main.Mallet
@@ -19,6 +19,7 @@ object App extends Logger {
     val faucet = "faucet"
     val ecKeyGen = "eckeygen"
     val cli = "cli"
+    val sigValidator = "signature-validator"
 
     args.headOption match {
       case None => Mantis.main(args)
@@ -33,12 +34,13 @@ object App extends Logger {
       case Some(`mallet`) => Mallet.main(args.tail)
       case Some(`faucet`) => Faucet.main(args.tail)
       case Some(`ecKeyGen`) => EcKeyGen.main(args.tail)
+      case Some(`sigValidator`) => SignatureValidator.main(args.tail)
       case Some(`cli`) => CliLauncher.main(args.tail)
       case Some(unknown) =>
         log.error(
           s"Unrecognised launcher option, " +
             s"first parameter must be $launchKeytool, $downloadBootstrap, $launchMantis, " +
-            s"$mallet, $faucet, $vmServer, $ecKeyGen or $cli"
+            s"$mallet, $faucet, $vmServer, $ecKeyGen, $sigValidator or $cli"
         )
     }
 

--- a/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
+++ b/src/main/scala/io/iohk/ethereum/crypto/ECDSASignature.scala
@@ -174,7 +174,7 @@ case class ECDSASignature(r: BigInt, s: BigInt, v: Byte) {
     import ECDSASignature.RLength
 
     def bigInt2Bytes(b: BigInt) =
-      ByteString(ByteUtils.bigIntToBytes(b, RLength))
+      ByteUtils.padLeft(ByteString(b.toByteArray).takeRight(RLength), RLength, 0)
 
     bigInt2Bytes(r) ++ bigInt2Bytes(s) :+ v
   }

--- a/src/main/scala/io/iohk/ethereum/crypto/SignatureValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/crypto/SignatureValidator.scala
@@ -1,0 +1,57 @@
+package io.iohk.ethereum.crypto
+
+import akka.util.ByteString
+import io.iohk.ethereum.crypto
+import io.iohk.ethereum.jsonrpc.JsonMethodsImplicits
+import io.iohk.ethereum.security.SecureRandomBuilder
+import io.iohk.ethereum.utils.ByteStringUtils
+
+import scala.util.{Failure, Success, Try}
+
+// scalastyle:off regex
+object SignatureValidator extends App with SecureRandomBuilder with JsonMethodsImplicits {
+
+  args match {
+    case Array(pk, sig, msgHash) =>
+      Try {
+        val signature = ECDSASignature.fromBytes(ByteStringUtils.string2hash(sig))
+        val msg = ByteStringUtils.string2hash(msgHash)
+
+        signature.flatMap(_.publicKey(msg))
+      } match {
+        case Failure(exception) =>
+          System.err.println(
+            s"Can't recover public key from signature [$sig] and msg [$msgHash]: ERROR: ${exception.getMessage}"
+          )
+          sys.exit(1)
+        case Success(recoveredPk) =>
+          val publicKey = ByteStringUtils.string2hash(pk)
+          recoveredPk match {
+            case Some(pk) =>
+              if (pk == publicKey) {
+                System.err.println(
+                  s"Recovered public key [${ByteStringUtils.hash2string(pk)}] is the same as given one"
+                )
+              } else {
+                System.err.println(s"Recovered public key [${ByteStringUtils
+                  .hash2string(pk)}] is different than given [${ByteStringUtils.hash2string(publicKey)}]")
+                sys.exit(1)
+              }
+            case None =>
+              System.err.println(s"Can't recover public key from signature [$sig] and msg [$msgHash]")
+              sys.exit(1)
+          }
+      }
+    case _ =>
+      val keyPair = crypto.generateKeyPair(secureRandom)
+      val pkStr = ByteStringUtils.hash2string(ByteString(crypto.pubKeyFromKeyPair(keyPair)))
+      val hash = kec256(Array(1.toByte))
+      val hashStr = ByteStringUtils.hash2string(ByteString(hash))
+      val signature = ECDSASignature.sign(hash, keyPair)
+      val sigStr = ByteStringUtils.hash2string(signature.toBytes)
+      System.err.println(
+        s"Bad Input. Example usage: [signature-validator publicKey signature message_hash]. Example: [signature-validator $pkStr $sigStr $hashStr]"
+      )
+      sys.exit(1)
+  }
+}

--- a/src/universal/bin/signatureValidator
+++ b/src/universal/bin/signatureValidator
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/..
+./bin/mantis -- signature-validator "$@"


### PR DESCRIPTION
# Description

We add a signature validation tool allowing the OBFT team to create a automated integration test checking the signatures issued by Morpho.

We also pad the ECDSA Signature `bigInt2Bytes` output.

Note: this has been tested using the Morpho integration test suite:

https://hydra.project42.iohkdev.io/log/lak4pp2cy1ych2kzzm5d7lr4dx7jnmv4-checkpointing-node-mantis-integration-tests.drv
```
unpacking sources
unpacking source archive /nix/store/0zyf6r2rlypf8la9prn6ks1105cz9hww-source
source root is source
patching sources
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
installing
Mantis Integration Tests
  mantis-integration
    Test the keygen against the actual Mantis parser: OK (136.19s)
      +++ OK, passed 100 tests.

All 1 tests passed (136.19s)
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/7aliz8s7ipfzmbhsssrlhbhvrcpjg45v-checkpointing-node-mantis-integration-tests
patching script interpreter paths in /nix/store/7aliz8s7ipfzmbhsssrlhbhvrcpjg45v-checkpointing-node-mantis-integration-tests
checking for references to /build/ in /nix/store/7aliz8s7ipfzmbhsssrlhbhvrcpjg45v-checkpointing-node-mantis-integration-tests...
```