### PR TITLE
[ETCM-205] Add information about checkpoints in tx history

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -54,7 +54,9 @@ object Dependencies {
     "org.scalatest" %% "scalatest" % "3.2.2" % "it,test",
     "org.scalamock" %% "scalamock" % "5.0.0" % "test",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.14.3" % "it,test"
+    "org.scalacheck" %% "scalacheck" % "1.14.3" % "it,test",
+    "com.softwaremill.diffx" %% "diffx-core" % "0.3.30" % "test",
+    "com.softwaremill.diffx" %% "diffx-scalatest" % "0.3.30" % "test"
   )
 
   val cats: Seq[ModuleID] = {

--- a/project/repo.nix
+++ b/project/repo.nix
@@ -2533,10 +2533,6 @@
       url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.thesamet/sbt-protoc/scala_2.12/sbt_1.0/0.99.25/srcs/sbt-protoc-sources.jar";
       sha256 = "699E08CF9863646BC67DD3330A620BA30EE0658C65D3106599F73BF2B640909F";
     };
-    "nix-sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/docs/sbt-updates-javadoc.jar" = {
-      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/docs/sbt-updates-javadoc.jar";
-      sha256 = "CB21980847CA86A0261DD0A44E7FFA408A083ECA8F485D35CEF0B8E49CCF05A9";
-    };
     "nix-sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/ivys/ivy.xml" = {
       url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/ivys/ivy.xml";
       sha256 = "C84F09F4CBBD2009245F8AA3FF3E8748B68768A6E7A932FA0D4DF9E9F01E049C";

--- a/project/repo.nix
+++ b/project/repo.nix
@@ -2533,6 +2533,10 @@
       url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.thesamet/sbt-protoc/scala_2.12/sbt_1.0/0.99.25/srcs/sbt-protoc-sources.jar";
       sha256 = "699E08CF9863646BC67DD3330A620BA30EE0658C65D3106599F73BF2B640909F";
     };
+    "nix-sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/docs/sbt-updates-javadoc.jar" = {
+      url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/docs/sbt-updates-javadoc.jar";
+      sha256 = "CB21980847CA86A0261DD0A44E7FFA408A083ECA8F485D35CEF0B8E49CCF05A9";
+    };
     "nix-sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/ivys/ivy.xml" = {
       url = "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.timushev.sbt/sbt-updates/scala_2.12/sbt_1.0/0.5.1/ivys/ivy.xml";
       sha256 = "C84F09F4CBBD2009245F8AA3FF3E8748B68768A6E7A932FA0D4DF9E9F01E049C";

--- a/repo.nix
+++ b/repo.nix
@@ -869,6 +869,70 @@
       url = "https://repo1.maven.org/maven2/com/monovore/decline_2.12/1.3.0/decline_2.12-1.3.0.pom";
       sha256 = "8806217334913555CE9E8F844EA4561767CD850457945E552838F1B2F85A9C86";
     };
+    "nix-public/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0-javadoc.jar";
+      sha256 = "71FABF98DEA887966534B972076E7CEF471081BEC54447E9CE99CD83693A147E";
+    };
+    "nix-public/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0-sources.jar";
+      sha256 = "6668CBFAE9263A2542F6AC78B0AA1DB0D4DA557614ADB4D03973BC44C7DA694C";
+    };
+    "nix-public/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0.jar" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0.jar";
+      sha256 = "7ACCC5F93399FBE99C9D6DC1F4A8A82263D63B7ECB5D98BD3E5C1D0ABB6F0450";
+    };
+    "nix-public/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0.pom" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/magnolia_2.12/0.17.0/magnolia_2.12-0.17.0.pom";
+      sha256 = "465823AEF5E9EB3C788790AF3899A4A3E59DD8B2D38718A42A679D6286F8905B";
+    };
+    "nix-public/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1-javadoc.jar";
+      sha256 = "A781EB938DAEFE7392F84B69246E5A337044DBED0C3AEDD8B1442847FFF70170";
+    };
+    "nix-public/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1-sources.jar";
+      sha256 = "E5DC8F9E19A9533C8F69AF24A4AC2AB91D09D9799A291E3AD10D55357B7CE9DF";
+    };
+    "nix-public/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1.jar" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1.jar";
+      sha256 = "1DEEF9A53201B3F05DEA6BDD6CD3D355720A7A8423F119C9993AD6A8E12BDA49";
+    };
+    "nix-public/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1.pom" = {
+      url = "https://repo1.maven.org/maven2/com/propensive/mercator_2.12/0.2.1/mercator_2.12-0.2.1.pom";
+      sha256 = "E4126D50DE1E89EB086787CB28047BC9CDC5136E16BBC8E4D7C72BC8AF028E60";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30-javadoc.jar";
+      sha256 = "B18F78BFE8970F9CCFD55C174979EFA5C87E0D462C4053B4577F7B7710506A48";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30-sources.jar";
+      sha256 = "1505A3FF3EAB930B7E4677D89D154FF2E77717759B3C1E4A3777AB7EF4DF21F0";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30.jar" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30.jar";
+      sha256 = "9A4FFF8A5FA811AB351B7254F85D0410D47B64B0AD975E7736B82BE05F9B51F7";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30.pom" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-core_2.12/0.3.30/diffx-core_2.12-0.3.30.pom";
+      sha256 = "DFB5DFA65BFA9B4B4762B4427D8905C5D9119D14E851D7C16859717361D1B4AB";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30-javadoc.jar";
+      sha256 = "CF0F66D18B3DDC84CB958B412FD7CA80CDD494D7BCACE4E34670DC524ABBDBDD";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30-sources.jar";
+      sha256 = "5F976B5E59C3C52D306DBBF84E6E3E1A739B6CF566B04E74ED9587F90C87AD6D";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30.jar" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30.jar";
+      sha256 = "8D8AC0AC4F0B51EEC09C6A1F745CEA5CCB70490A446FC2DDA91F5C05C06A59FF";
+    };
+    "nix-public/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30.pom" = {
+      url = "https://repo1.maven.org/maven2/com/softwaremill/diffx/diffx-scalatest_2.12/0.3.30/diffx-scalatest_2.12-0.3.30.pom";
+      sha256 = "2E03EF44FBB174C847896F073762145847ED458784B41C549033C97E22B5CE43";
+    };
     "nix-public/com/squareup/okhttp3/logging-interceptor/4.3.1/logging-interceptor-4.3.1-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/com/squareup/okhttp3/logging-interceptor/4.3.1/logging-interceptor-4.3.1-javadoc.jar";
       sha256 = "1FDD287ADDB6301F3D16274ADBDF55C7129E2C675DA61EF087A62740EAB49EAF";
@@ -2961,6 +3025,22 @@
       url = "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.2.2/scalactic_2.12-3.2.2.pom";
       sha256 = "E8996A85BA1225FEA69237DEA1ADBFC6A7B47E61BA717273A602F538DBE80191";
     };
+    "nix-public/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3-javadoc.jar";
+      sha256 = "390B5F46A0748DA214EBD337EE16BDC70866CC89CE0B0D670B6840A9DC61DE38";
+    };
+    "nix-public/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3-sources.jar";
+      sha256 = "E7AC7B33C26C6310CCCC162341E5FA0C09D32AB82387EF1C544A73259071A789";
+    };
+    "nix-public/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3.jar";
+      sha256 = "AE90B144DB41B2947F85C926F218E0F4821CB5C4E896050B05DBDC8D8976A8E9";
+    };
+    "nix-public/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3.pom" = {
+      url = "https://repo1.maven.org/maven2/org/scalactic/scalactic_2.12/3.2.3/scalactic_2.12-3.2.3.pom";
+      sha256 = "A7A9780707C5A8DA98A1E2874FEA5E6FEC72AE01C9AC9703B1C88C948B0C447A";
+    };
     "nix-public/org/scalameta/common_2.12/4.3.20/common_2.12-4.3.20-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/org/scalameta/common_2.12/4.3.20/common_2.12-4.3.20-javadoc.jar";
       sha256 = "44335923904E3547FEAFDEB1F0FC843159D0AED05769D9C98C78927E180118F4";
@@ -3089,6 +3169,22 @@
       url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.2/scalatest-compatible-3.2.2.pom";
       sha256 = "285E1C62310DF89E3D4EC4A3317812B25E673FA52BDC0E4655EA6940BF2BF4B5";
     };
+    "nix-public/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3-javadoc.jar";
+      sha256 = "C45E5CCEB24BC0C40D63FBA5B2D43622F376DB0D321C020C0910A64537751342";
+    };
+    "nix-public/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3-sources.jar";
+      sha256 = "0BC33A5EEB862128718005A7A46B29BECFB04D4D6E70E9A52D43E476F4027AF4";
+    };
+    "nix-public/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3.jar";
+      sha256 = "78D08EA4E51ECAF33B66DAEB10342F2794906F46EB0C5E1B0B26FA0F65A50A20";
+    };
+    "nix-public/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3.pom" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-compatible/3.2.3/scalatest-compatible-3.2.3.pom";
+      sha256 = "240C6F5134832ED099B9236CB5C832FA41AA2A82FC716EFB822D41D2C4211CCE";
+    };
     "nix-public/org/scalatest/scalatest-core_2.12/3.2.2/scalatest-core_2.12-3.2.2-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-core_2.12/3.2.2/scalatest-core_2.12-3.2.2-javadoc.jar";
       sha256 = "30ED32B545BE24F539576B4CEE444DD32C45AFAD0EEA5CD48338A5FD1C5891F7";
@@ -3104,6 +3200,22 @@
     "nix-public/org/scalatest/scalatest-core_2.12/3.2.2/scalatest-core_2.12-3.2.2.pom" = {
       url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-core_2.12/3.2.2/scalatest-core_2.12-3.2.2.pom";
       sha256 = "6E85AE78C7460DEFDFCD6904A0C9532417B0818165ABAAC701F9FAFBF19D1306";
+    };
+    "nix-public/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3-javadoc.jar";
+      sha256 = "330D9DA80AD89BED6E78B716278779103B5D6F0FFB62DFD0D22C2860AB61B14A";
+    };
+    "nix-public/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3-sources.jar";
+      sha256 = "48F2A735CF1EEC2B6DD0A01C5626398DACB41998D17BF1F6AE2D1A2699725EC9";
+    };
+    "nix-public/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3.jar";
+      sha256 = "DB7679D95C56922CC30BA86B06AF43BCD124AD5815E861F8D6BE6A456D9EF36C";
+    };
+    "nix-public/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3.pom" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-core_2.12/3.2.3/scalatest-core_2.12-3.2.3.pom";
+      sha256 = "40F996A790BF4DAEEA443957B70EDCF82B3A71012DE669474C7C303A4CC8CA51";
     };
     "nix-public/org/scalatest/scalatest-diagrams_2.12/3.2.2/scalatest-diagrams_2.12-3.2.2-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-diagrams_2.12/3.2.2/scalatest-diagrams_2.12-3.2.2-javadoc.jar";
@@ -3216,6 +3328,22 @@
     "nix-public/org/scalatest/scalatest-matchers-core_2.12/3.2.2/scalatest-matchers-core_2.12-3.2.2.pom" = {
       url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_2.12/3.2.2/scalatest-matchers-core_2.12-3.2.2.pom";
       sha256 = "1A63C3DF2A738BA37DDCAAC4122660C2B0E8254A0FD96E74BEAC8F576CDB5B48";
+    };
+    "nix-public/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3-javadoc.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3-javadoc.jar";
+      sha256 = "C279DC1F0FF83A83C0AACE46ED9AE325B72004C93066934A2455646FD2E9AECD";
+    };
+    "nix-public/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3-sources.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3-sources.jar";
+      sha256 = "0326FF5F28C075E6AA2337136EF3AC4E0D26BA824579E156DCBCB5276441BAAF";
+    };
+    "nix-public/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3.jar" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3.jar";
+      sha256 = "0F28CDC645FF00753880E684B017536E3207A5416ECE4AAE6BDCB82B37678182";
+    };
+    "nix-public/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3.pom" = {
+      url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-matchers-core_2.12/3.2.3/scalatest-matchers-core_2.12-3.2.3.pom";
+      sha256 = "061C2E466F362C5337EBA12E954BE5293F1AB8530F1930D97FCF40E6D9216566";
     };
     "nix-public/org/scalatest/scalatest-mustmatchers_2.12/3.2.2/scalatest-mustmatchers_2.12-3.2.2-javadoc.jar" = {
       url = "https://repo1.maven.org/maven2/org/scalatest/scalatest-mustmatchers_2.12/3.2.2/scalatest-mustmatchers_2.12-3.2.2-javadoc.jar";

--- a/src/main/scala/io/iohk/ethereum/domain/Address.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Address.scala
@@ -2,11 +2,9 @@ package io.iohk.ethereum.domain
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto
-import io.iohk.ethereum.domain.SignedTransaction.FirstByteOfAddress
 import io.iohk.ethereum.mpt.ByteArrayEncoder
 import io.iohk.ethereum.utils.ByteUtils.padLeft
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-import org.bouncycastle.crypto.params.ECPublicKeyParameters
 import org.bouncycastle.util.encoders.Hex
 
 object Address {
@@ -38,9 +36,8 @@ object Address {
   }
 
   def apply(keyPair: AsymmetricCipherKeyPair): Address = {
-    //byte 0 of encoded ECC point indicates that it is uncompressed point, it is part of bouncycastle encoding
-    val pub = keyPair.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false).tail
-    Address(crypto.kec256(pub).drop(FirstByteOfAddress))
+    val pub = crypto.pubKeyFromKeyPair(keyPair)
+    Address(crypto.kec256(pub))
   }
 }
 

--- a/src/main/scala/io/iohk/ethereum/domain/Address.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/Address.scala
@@ -2,8 +2,11 @@ package io.iohk.ethereum.domain
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto
+import io.iohk.ethereum.domain.SignedTransaction.FirstByteOfAddress
 import io.iohk.ethereum.mpt.ByteArrayEncoder
 import io.iohk.ethereum.utils.ByteUtils.padLeft
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
+import org.bouncycastle.crypto.params.ECPublicKeyParameters
 import org.bouncycastle.util.encoders.Hex
 
 object Address {
@@ -32,6 +35,12 @@ object Address {
     val bytes = Hex.decode(hexString.replaceFirst("^0x", ""))
     require(bytes.length <= Length, s"Invalid address: $hexString")
     Address(bytes)
+  }
+
+  def apply(keyPair: AsymmetricCipherKeyPair): Address = {
+    //byte 0 of encoded ECC point indicates that it is uncompressed point, it is part of bouncycastle encoding
+    val pub = keyPair.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false).tail
+    Address(crypto.kec256(pub).drop(FirstByteOfAddress))
   }
 }
 

--- a/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
+++ b/src/main/scala/io/iohk/ethereum/domain/SignedTransaction.scala
@@ -1,23 +1,20 @@
 package io.iohk.ethereum.domain
 
-import java.math.BigInteger
-import java.util.concurrent.Executors
-
 import akka.util.ByteString
 import com.google.common.cache.{Cache, CacheBuilder}
 import io.iohk.ethereum.crypto
 import io.iohk.ethereum.crypto.{ECDSASignature, kec256}
 import io.iohk.ethereum.mpt.ByteArraySerializable
+import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
 import io.iohk.ethereum.rlp.RLPImplicitConversions._
 import io.iohk.ethereum.rlp.RLPImplicits._
 import io.iohk.ethereum.rlp.{encode => rlpEncode, _}
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
-import org.bouncycastle.crypto.params.ECPublicKeyParameters
 import org.bouncycastle.util.encoders.Hex
-import io.iohk.ethereum.network.p2p.messages.CommonMessages.SignedTransactions._
 
+import java.math.BigInteger
+import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, Future}
-
 import scala.util.Try
 
 object SignedTransaction {
@@ -74,9 +71,7 @@ object SignedTransaction {
   def sign(tx: Transaction, keyPair: AsymmetricCipherKeyPair, chainId: Option[Byte]): SignedTransactionWithSender = {
     val bytes = bytesToSign(tx, chainId)
     val sig = ECDSASignature.sign(bytes, keyPair, chainId)
-    //byte 0 of encoded ECC point indicates that it is uncompressed point, it is part of bouncycastle encoding
-    val pub = keyPair.getPublic.asInstanceOf[ECPublicKeyParameters].getQ.getEncoded(false).tail
-    val address = Address(crypto.kec256(pub).drop(FirstByteOfAddress))
+    val address = Address(keyPair)
     SignedTransactionWithSender(tx, sig, address)
   }
 

--- a/src/main/scala/io/iohk/ethereum/jsonrpc/MantisJsonMethodImplicits.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/MantisJsonMethodImplicits.scala
@@ -21,6 +21,7 @@ object MantisJsonMethodImplicits extends JsonMethodsImplicits {
     val encodedTxResponse = JsonEncoder.encode(asTxResponse)
     val encodedExtension = JObject(
       "isOutgoing" -> extendedTxData.isOutgoing.jsonEncoded,
+      "isCheckpointed" -> extendedTxData.minedTransactionData.map(_.isCheckpointed).jsonEncoded,
       "isPending" -> extendedTxData.isPending.jsonEncoded,
       "gasUsed" -> extendedTxData.minedTransactionData.map(_.gasUsed).jsonEncoded,
       "timestamp" -> extendedTxData.minedTransactionData.map(_.timestamp).jsonEncoded

--- a/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
+++ b/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
@@ -3,11 +3,10 @@ package io.iohk.ethereum
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.generateKeyPair
 import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields
-import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefEmpty
-import io.iohk.ethereum.domain.{Address, Block, BlockBody, BlockHeader, SignedTransaction, Transaction}
+import io.iohk.ethereum.domain._
 import io.iohk.ethereum.security.SecureRandomBuilder
-import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import mouse.all._
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 
 import scala.util.Random
 

--- a/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
+++ b/src/test/scala/io/iohk/ethereum/BlockHelpers.scala
@@ -2,7 +2,9 @@ package io.iohk.ethereum
 
 import akka.util.ByteString
 import io.iohk.ethereum.crypto.generateKeyPair
-import io.iohk.ethereum.domain.{Address, Block, BlockBody, SignedTransaction, Transaction}
+import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields
+import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefEmpty
+import io.iohk.ethereum.domain.{Address, Block, BlockBody, BlockHeader, SignedTransaction, Transaction}
 import io.iohk.ethereum.security.SecureRandomBuilder
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair
 import mouse.all._
@@ -42,18 +44,33 @@ object BlockHelpers extends SecureRandomBuilder {
       generated :+ (parent |> generateBlock |> adjustBlock)
     }
 
+  def resetHeaderExtraFields(hef: BlockHeader.HeaderExtraFields): BlockHeader.HeaderExtraFields = hef match {
+    case HeaderExtraFields.HefEmpty => HeaderExtraFields.HefEmpty
+    case HeaderExtraFields.HefPostEcip1098(_) => HeaderExtraFields.HefPostEcip1098(treasuryOptOut = false)
+    case HeaderExtraFields.HefPostEcip1097(_, _) => HeaderExtraFields.HefPostEcip1097(treasuryOptOut = false, None)
+  }
+
   def generateBlock(parent: Block): Block = {
     val header = parent.header.copy(
       extraData = randomHash(),
       number = parent.number + 1,
       parentHash = parent.hash,
-      nonce = ByteString(Random.nextLong())
+      nonce = ByteString(Random.nextLong()),
+      extraFields = resetHeaderExtraFields(parent.header.extraFields)
     )
     val ommer = defaultHeader.copy(extraData = randomHash())
     val tx = defaultTx.copy(payload = randomHash())
     val stx = SignedTransaction.sign(tx, keyPair, None)
 
     Block(header, BlockBody(List(stx.tx), List(ommer)))
+  }
+
+  def updateHeader(block: Block, updater: BlockHeader => BlockHeader): Block = {
+    block.copy(header = updater(block.header))
+  }
+
+  def withTransactions(block: Block, transactions: List[SignedTransaction]): Block = {
+    block.copy(body = block.body.copy(transactionList = transactions))
   }
 
 }

--- a/src/test/scala/io/iohk/ethereum/Mocks.scala
+++ b/src/test/scala/io/iohk/ethereum/Mocks.scala
@@ -129,8 +129,11 @@ object Mocks {
     }
   }
 
-  case class MockHandshakerAlwaysSucceeds(initialStatus: RemoteStatus, currentMaxBlockNumber: BigInt, forkAccepted: Boolean)
-      extends Handshaker[PeerInfo] {
+  case class MockHandshakerAlwaysSucceeds(
+      initialStatus: RemoteStatus,
+      currentMaxBlockNumber: BigInt,
+      forkAccepted: Boolean
+  ) extends Handshaker[PeerInfo] {
     override val handshakerState: HandshakerState[PeerInfo] =
       ConnectedState(
         PeerInfo(

--- a/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
+++ b/src/test/scala/io/iohk/ethereum/ObjectGenerators.scala
@@ -163,7 +163,6 @@ trait ObjectGenerators {
     chainWeight <- chainWeightGen
   } yield PV64.NewBlock(Block(blockHeader, BlockBody(stxs, uncles)), chainWeight)
 
-
   def extraFieldsGen: Gen[HeaderExtraFields] = for {
     optOut <- Arbitrary.arbitrary[Option[Boolean]]
     checkpoint <- if (optOut.isDefined) Gen.option(fakeCheckpointOptGen(0, 5)) else Gen.const(None)

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/BlockBroadcastSpec.scala
@@ -44,13 +44,17 @@ class BlockBroadcastSpec
     //Block that should be sent as it's total difficulty is higher than known by peer
     val blockHeader: BlockHeader = baseBlockHeader.copy(number = initialPeerInfo.maxBlockNumber - 3)
     val newBlockNewHashes = NewBlockHashes(Seq(PV62.BlockHash(blockHeader.hash, blockHeader.number)))
-    val peerInfo = initialPeerInfo.copy(remoteStatus = peerStatus.copy(protocolVersion = ProtocolVersions.PV63))
+    val peerInfo = initialPeerInfo
+      .copy(remoteStatus = peerStatus.copy(protocolVersion = ProtocolVersions.PV63))
       .withChainWeight(ChainWeight.totalDifficultyOnly(initialPeerInfo.chainWeight.totalDifficulty))
     val newBlock =
       CommonMessages.NewBlock(Block(blockHeader, BlockBody(Nil, Nil)), peerInfo.chainWeight.totalDifficulty + 2)
 
     //when
-    blockBroadcast.broadcastBlock(BlockToBroadcast(newBlock.block, ChainWeight.totalDifficultyOnly(newBlock.totalDifficulty)), Map(peer -> peerInfo))
+    blockBroadcast.broadcastBlock(
+      BlockToBroadcast(newBlock.block, ChainWeight.totalDifficultyOnly(newBlock.totalDifficulty)),
+      Map(peer -> peerInfo)
+    )
 
     //then
     etcPeerManagerProbe.expectMsg(EtcPeerManagerActor.SendMessage(newBlock, peer.id))

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/PivotBlockSelectorSpec.scala
@@ -292,7 +292,9 @@ class PivotBlockSelectorSpec
       Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer1.id))),
       Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer2.id))),
       Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer3.id))),
-      Subscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer4.id))) // Next peer will be asked
+      Subscribe(
+        MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer4.id))
+      ) // Next peer will be asked
     )
 
     etcPeerManager.expectMsg(
@@ -340,7 +342,9 @@ class PivotBlockSelectorSpec
       Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer1.id))),
       Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer2.id))),
       Unsubscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer3.id))),
-      Subscribe(MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer4.id))) // Next peer will be asked
+      Subscribe(
+        MessageClassifier(Set(Codes.BlockHeadersCode), PeerSelector.WithId(peer4.id))
+      ) // Next peer will be asked
     )
 
     etcPeerManager.expectMsg(
@@ -492,7 +496,13 @@ class PivotBlockSelectorSpec
     val peer4 = Peer(new InetSocketAddress("127.0.0.4", 0), peer4TestProbe.ref, false)
 
     val peer1Status =
-      RemoteStatus(ProtocolVersions.PV64, 1, ChainWeight.totalDifficultyOnly(20), ByteString("peer1_bestHash"), ByteString("unused"))
+      RemoteStatus(
+        ProtocolVersions.PV64,
+        1,
+        ChainWeight.totalDifficultyOnly(20),
+        ByteString("peer1_bestHash"),
+        ByteString("unused")
+      )
     val peer2Status = peer1Status.copy(bestHash = ByteString("peer2_bestHash"))
     val peer3Status = peer1Status.copy(bestHash = ByteString("peer3_bestHash"))
     val peer4Status = peer1Status.copy(bestHash = ByteString("peer4_bestHash"))

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncSchedulerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/SyncSchedulerSpec.scala
@@ -29,7 +29,7 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
     val (missingNodes, newState) = scheduler.getMissingNodes(initialState, 1)
     val responses = prov.getNodes(missingNodes)
     val result = scheduler.processResponses(newState, responses)
-    val (newRequests, state) = scheduler.getMissingNodes(result.right.value._1, 1)
+    val (newRequests, state) = scheduler.getMissingNodes(result.value._1, 1)
     scheduler.persistBatch(state, 1)
 
     assert(missingNodes.size == 1)
@@ -47,9 +47,9 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
     )
     val (scheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
     val initState = scheduler.initState(worldHash).get
-    val state1 = exchangeSingleNode(initState, scheduler, prov).right.value
-    val state2 = exchangeSingleNode(state1, scheduler, prov).right.value
-    val state3 = exchangeSingleNode(state2, scheduler, prov).right.value
+    val state1 = exchangeSingleNode(initState, scheduler, prov).value
+    val state2 = exchangeSingleNode(state1, scheduler, prov).value
+    val state3 = exchangeSingleNode(state2, scheduler, prov).value
     scheduler.persistBatch(state3, 1)
 
     assert(state1.numberOfPendingRequests > 0)
@@ -85,7 +85,7 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
     val initState1 = scheduler.initState(worldHash1).get
 
     // received root branch node with 3 leaf nodes
-    val state1a = exchangeSingleNode(initState1, scheduler, prov).right.value
+    val state1a = exchangeSingleNode(initState1, scheduler, prov).value
 
     // branch got 3 leaf nodes, but we already known 2 of them, so there are pending requests only for: 1 branch + 1 unknown leaf
     assert(state1a.numberOfPendingRequests == 2)
@@ -103,16 +103,16 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
     val (scheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
     val initState = scheduler.initState(worldHash).get
     assert(schedulerDb.dataSource.storage.isEmpty)
-    val state1 = exchangeSingleNode(initState, scheduler, prov).right.value
-    val state2 = exchangeSingleNode(state1, scheduler, prov).right.value
-    val state3 = exchangeSingleNode(state2, scheduler, prov).right.value
-    val state4 = exchangeSingleNode(state3, scheduler, prov).right.value
+    val state1 = exchangeSingleNode(initState, scheduler, prov).value
+    val state2 = exchangeSingleNode(state1, scheduler, prov).value
+    val state3 = exchangeSingleNode(state2, scheduler, prov).value
+    val state4 = exchangeSingleNode(state3, scheduler, prov).value
     val state5 = scheduler.persistBatch(state4, 1)
     // finalized leaf node i.e state node + storage node + code
     assert(schedulerDb.dataSource.storage.size == 3)
-    val state6 = exchangeSingleNode(state5, scheduler, prov).right.value
-    val state7 = exchangeSingleNode(state6, scheduler, prov).right.value
-    val state8 = exchangeSingleNode(state7, scheduler, prov).right.value
+    val state6 = exchangeSingleNode(state5, scheduler, prov).value
+    val state7 = exchangeSingleNode(state6, scheduler, prov).value
+    val state8 = exchangeSingleNode(state7, scheduler, prov).value
     val state9 = scheduler.persistBatch(state8, 1)
 
     // 1 non finalized request for branch node + 2 non finalized request for leaf nodes
@@ -146,13 +146,13 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
     )
     val (scheduler, schedulerBlockchain, schedulerDb) = buildScheduler()
     val initState = scheduler.initState(worldHash).get
-    val state1 = exchangeSingleNode(initState, scheduler, prov).right.value
+    val state1 = exchangeSingleNode(initState, scheduler, prov).value
     val (allMissingNodes1, state2) = scheduler.getAllMissingNodes(state1)
     val allMissingNodes1Response = prov.getNodes(allMissingNodes1)
-    val state3 = scheduler.processResponses(state2, allMissingNodes1Response).right.value._1
+    val state3 = scheduler.processResponses(state2, allMissingNodes1Response).value._1
     val (allMissingNodes2, state4) = scheduler.getAllMissingNodes(state3)
     val allMissingNodes2Response = prov.getNodes(allMissingNodes2)
-    val state5 = scheduler.processResponses(state4, allMissingNodes2Response).right.value._1
+    val state5 = scheduler.processResponses(state4, allMissingNodes2Response).value._1
     val remaingNodes = state5.numberOfPendingRequests
     val state6 = scheduler.persistBatch(state5, 1)
 
@@ -198,7 +198,7 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
     val (firstMissing, state1) = scheduler.getMissingNodes(initState, 1)
     val firstMissingResponse = prov.getNodes(firstMissing)
     val result1 = scheduler.processResponse(state1, firstMissingResponse.head)
-    val stateAfterReceived = result1.right.value
+    val stateAfterReceived = result1.value
     val result2 = scheduler.processResponse(stateAfterReceived, firstMissingResponse.head)
 
     assert(result1.isRight)
@@ -239,7 +239,7 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
       while (state.activeRequest.nonEmpty) {
         val (allMissingNodes1, state2) = scheduler.getAllMissingNodes(state)
         val allMissingNodes1Response = prov.getNodes(allMissingNodes1)
-        val state3 = scheduler.processResponses(state2, allMissingNodes1Response).right.value._1
+        val state3 = scheduler.processResponses(state2, allMissingNodes1Response).value._1
         state = state3
       }
       assert(state.memBatch.nonEmpty)
@@ -268,7 +268,7 @@ class SyncSchedulerSpec extends AnyFlatSpec with Matchers with EitherValues with
       while (state.activeRequest.nonEmpty) {
         val (allMissingNodes1, state2) = scheduler.getAllMissingNodes(state)
         val allMissingNodes1Response = provider.getNodes(allMissingNodes1)
-        val state3 = scheduler.processResponses(state2, allMissingNodes1Response).right.value._1
+        val state3 = scheduler.processResponses(state2, allMissingNodes1Response).value._1
         state = state3
       }
       state

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncPeers.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/TestSyncPeers.scala
@@ -21,7 +21,13 @@ trait TestSyncPeers { self: TestSyncConfig =>
   val peer3 = Peer(new InetSocketAddress("127.0.0.3", 0), peer3TestProbe.ref, false)
 
   val peer1Status =
-    RemoteStatus(ProtocolVersions.PV64, 1, ChainWeight.totalDifficultyOnly(20), ByteString("peer1_bestHash"), ByteString("unused"))
+    RemoteStatus(
+      ProtocolVersions.PV64,
+      1,
+      ChainWeight.totalDifficultyOnly(20),
+      ByteString("peer1_bestHash"),
+      ByteString("unused")
+    )
   val peer2Status = peer1Status.copy(bestHash = ByteString("peer2_bestHash"))
 
   val bestBlock = 400000

--- a/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
+++ b/src/test/scala/io/iohk/ethereum/blockchain/sync/regular/RegularSyncFixtures.scala
@@ -103,7 +103,13 @@ trait RegularSyncFixtures { self: Matchers with AsyncMockFactory =>
 
     def getPeerInfo(peer: Peer, protocolVersion: Int = ProtocolVersions.PV64): PeerInfo = {
       val status =
-        RemoteStatus(protocolVersion, 1, ChainWeight.totalDifficultyOnly(1), ByteString(s"${peer.id}_bestHash"), ByteString("unused"))
+        RemoteStatus(
+          protocolVersion,
+          1,
+          ChainWeight.totalDifficultyOnly(1),
+          ByteString(s"${peer.id}_bestHash"),
+          ByteString("unused")
+        )
       PeerInfo(
         status,
         forkAccepted = true,

--- a/src/test/scala/io/iohk/ethereum/cli/CliCommandsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/cli/CliCommandsSpec.scala
@@ -16,7 +16,7 @@ class CliCommandsSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   behavior of deriveAddressCommand
   it should "derive address from private key" in {
-    api.parse(Seq(deriveAddressCommand, privateKey)).right.value shouldBe address
+    api.parse(Seq(deriveAddressCommand, privateKey)).value shouldBe address
   }
 
   it should "return an error when called without private key" in {
@@ -33,7 +33,6 @@ class CliCommandsSpec extends AnyFlatSpec with Matchers with EitherValues {
           argument(balanceOption, Some(requestedBalance))
         )
       )
-      .right
       .value shouldBe s""""alloc": {$address: { "balance": $requestedBalance }}"""
   }
 
@@ -47,7 +46,6 @@ class CliCommandsSpec extends AnyFlatSpec with Matchers with EitherValues {
           argument(balanceOption, Some(requestedBalance))
         )
       )
-      .right
       .value shouldBe s""""alloc": {$address: { "balance": $requestedBalance }, $address2: { "balance": $requestedBalance }}"""
   }
 
@@ -61,7 +59,6 @@ class CliCommandsSpec extends AnyFlatSpec with Matchers with EitherValues {
           argument(balanceOption, Some(requestedBalance))
         )
       )
-      .right
       .value shouldBe s""""alloc": {$address: { "balance": $requestedBalance }, $address2: { "balance": $requestedBalance }}"""
   }
 
@@ -76,7 +73,6 @@ class CliCommandsSpec extends AnyFlatSpec with Matchers with EitherValues {
           argument(balanceOption, Some(requestedBalance))
         )
       )
-      .right
       .value shouldBe s""""alloc": {$address: { "balance": $requestedBalance }, $address3: { "balance": $requestedBalance }, $address2: { "balance": $requestedBalance }}"""
   }
 

--- a/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/consensus/BlockGeneratorSpec.scala
@@ -39,7 +39,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val miningTimestamp = 1508751768
 
     val fullBlock = pendingBlock.block.copy(header =
-      pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+      pendingBlock.block.header.copy(
+        nonce = minedNonce,
+        mixHash = minedMixHash,
+        unixTimestamp = miningTimestamp,
+        gasLimit = generatedBlockGasLimit
+      )
     )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
@@ -61,7 +66,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val miningTimestamp = 1508752265
 
     val fullBlock = pendingBlock.block.copy(header =
-      pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+      pendingBlock.block.header.copy(
+        nonce = minedNonce,
+        mixHash = minedMixHash,
+        unixTimestamp = miningTimestamp,
+        gasLimit = generatedBlockGasLimit
+      )
     )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
@@ -83,7 +93,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val miningTimestamp = 1508752265
 
     val fullBlock = pendingBlock.block.copy(header =
-      pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+      pendingBlock.block.header.copy(
+        nonce = minedNonce,
+        mixHash = minedMixHash,
+        unixTimestamp = miningTimestamp,
+        gasLimit = generatedBlockGasLimit
+      )
     )
 
     // Import Block, to create some existing state
@@ -132,7 +147,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val miningTimestamp = 1508752389
 
     val fullBlock = pendingBlock.block.copy(header =
-      pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+      pendingBlock.block.header.copy(
+        nonce = minedNonce,
+        mixHash = minedMixHash,
+        unixTimestamp = miningTimestamp,
+        gasLimit = generatedBlockGasLimit
+      )
     )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
@@ -165,7 +185,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val miningTimestamp = 1508752492
 
     val fullBlock = pendingBlock.block.copy(header =
-      pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+      pendingBlock.block.header.copy(
+        nonce = minedNonce,
+        mixHash = minedMixHash,
+        unixTimestamp = miningTimestamp,
+        gasLimit = generatedBlockGasLimit
+      )
     )
 
     validators.blockHeaderValidator.validate(
@@ -233,7 +258,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
     val fullBlock =
       pendingBlock.block.copy(header =
-        pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+        pendingBlock.block.header.copy(
+          nonce = minedNonce,
+          mixHash = minedMixHash,
+          unixTimestamp = miningTimestamp,
+          gasLimit = generatedBlockGasLimit
+        )
       )
     validators.blockHeaderValidator.validate(
       fullBlock.header,
@@ -323,7 +353,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
     val fullBlock =
       pendingBlock.block.copy(header =
-        pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+        pendingBlock.block.header.copy(
+          nonce = minedNonce,
+          mixHash = minedMixHash,
+          unixTimestamp = miningTimestamp,
+          gasLimit = generatedBlockGasLimit
+        )
       )
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
@@ -355,7 +390,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
 
     val fullBlock =
       pendingBlock.block.copy(header =
-        pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+        pendingBlock.block.header.copy(
+          nonce = minedNonce,
+          mixHash = minedMixHash,
+          unixTimestamp = miningTimestamp,
+          gasLimit = generatedBlockGasLimit
+        )
       )
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
@@ -400,7 +440,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val miningTimestamp = 1499721182
 
     val fullBlock = pendingBlock.block.copy(header =
-      pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+      pendingBlock.block.header.copy(
+        nonce = minedNonce,
+        mixHash = minedMixHash,
+        unixTimestamp = miningTimestamp,
+        gasLimit = generatedBlockGasLimit
+      )
     )
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid
@@ -432,7 +477,12 @@ class BlockGeneratorSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
     val miningTimestamp = 1508752698
 
     val fullBlock = pendingBlock.block.copy(header =
-      pendingBlock.block.header.copy(nonce = minedNonce, mixHash = minedMixHash, unixTimestamp = miningTimestamp, gasLimit = generatedBlockGasLimit)
+      pendingBlock.block.header.copy(
+        nonce = minedNonce,
+        mixHash = minedMixHash,
+        unixTimestamp = miningTimestamp,
+        gasLimit = generatedBlockGasLimit
+      )
     )
     validators.blockHeaderValidator.validate(fullBlock.header, blockchain.getBlockHeaderByHash) shouldBe Right(
       BlockHeaderValid

--- a/src/test/scala/io/iohk/ethereum/crypto/ECDSASignatureSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/crypto/ECDSASignatureSpec.scala
@@ -37,7 +37,11 @@ class ECDSASignatureSpec extends AnyFlatSpec with Matchers with ScalaCheckProper
   }
 
   it should "fail public key recover without throwing when signature is bad (Invalid point compression)" in {
-    val sig = ECDSASignature(ByteStringUtils.string2hash("149a2046f51f5d043633664d76eef4f99cdba8e53851dcda57224dfe8770f98a"), ByteStringUtils.string2hash("a8898478e9aae9fadb71c7ab5451d47d2efa4199fc26ecc1da62ce8fb77e06f1"), 28.toByte)
+    val sig = ECDSASignature(
+      ByteStringUtils.string2hash("149a2046f51f5d043633664d76eef4f99cdba8e53851dcda57224dfe8770f98a"),
+      ByteStringUtils.string2hash("a8898478e9aae9fadb71c7ab5451d47d2efa4199fc26ecc1da62ce8fb77e06f1"),
+      28.toByte
+    )
     val messageHash = ByteStringUtils.string2hash("a1ede9cdf0b6fe37a384b265dce6b74a7464f11799dcee022f628450a19cf4eb")
 
     sig.publicKey(messageHash).isEmpty shouldBe true

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/JsonRpcControllerSpec.scala
@@ -5,7 +5,11 @@ import akka.testkit.TestKit
 import io.iohk.ethereum.domain.ChainWeight
 import io.iohk.ethereum.jsonrpc.DebugService.{ListPeersInfoRequest, ListPeersInfoResponse}
 import io.iohk.ethereum.jsonrpc.NetService.{ListeningResponse, PeerCountResponse, VersionResponse}
-import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.{OptionNoneToJNullSerializer, QuantitiesSerializer, UnformattedDataJsonSerializer}
+import io.iohk.ethereum.jsonrpc.serialization.JsonSerializers.{
+  OptionNoneToJNullSerializer,
+  QuantitiesSerializer,
+  UnformattedDataJsonSerializer
+}
 import io.iohk.ethereum.jsonrpc.server.controllers.JsonRpcBaseController.JsonRpcConfig
 import io.iohk.ethereum.jsonrpc.server.http.JsonRpcHttpServer
 import io.iohk.ethereum.jsonrpc.server.ipc.JsonRpcIpcServer

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisJRCSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisJRCSpec.scala
@@ -56,11 +56,15 @@ class MantisJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
             Right(
               GetAccountTransactionsResponse(
                 List(
-                  ExtendedTransactionData(sentTx, isOutgoing = true, Some(MinedTransactionData(block.header, 0, 42))),
+                  ExtendedTransactionData(
+                    sentTx,
+                    isOutgoing = true,
+                    Some(MinedTransactionData(block.header, 0, 42, false))
+                  ),
                   ExtendedTransactionData(
                     receivedTx,
                     isOutgoing = false,
-                    Some(MinedTransactionData(block.header, 1, 21))
+                    Some(MinedTransactionData(block.header, 1, 21, true))
                   )
                 )
               )
@@ -90,6 +94,7 @@ class MantisJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
             .asInstanceOf[JObject]
             .obj ++ List(
             "isPending" -> JBool(false),
+            "isCheckpointed" -> JBool(false),
             "isOutgoing" -> JBool(true),
             "timestamp" -> JLong(block.header.unixTimestamp),
             "gasUsed" -> JString(s"0x${BigInt(42).toString(16)}")
@@ -101,6 +106,7 @@ class MantisJRCSpec extends FreeSpecBase with SpecFixtures with AsyncMockFactory
             .asInstanceOf[JObject]
             .obj ++ List(
             "isPending" -> JBool(false),
+            "isCheckpointed" -> JBool(true),
             "isOutgoing" -> JBool(false),
             "timestamp" -> JLong(block.header.unixTimestamp),
             "gasUsed" -> JString(s"0x${BigInt(21).toString(16)}")

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/MantisServiceSpec.scala
@@ -63,7 +63,7 @@ class MantisServiceSpec
           ExtendedTransactionData(
             fakeTransaction.tx,
             isOutgoing = true,
-            Some(MinedTransactionData(block.header, 0, 42))
+            Some(MinedTransactionData(block.header, 0, 42, isCheckpointed = false))
           )
         )
 

--- a/src/test/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/jsonrpc/server/http/JsonRpcHttpServerSpec.scala
@@ -190,9 +190,9 @@ class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRout
     val postRequest2 =
       HttpRequest(
         HttpMethods.POST,
-        uri = "/",headers = List(`X-Forwarded-For`(RemoteAddress.apply(InetAddress.getByName("1.2.3.4")))),
-        entity = HttpEntity(MediaTypes.`application/json`,
-        jsonRequest)
+        uri = "/",
+        headers = List(`X-Forwarded-For`(RemoteAddress.apply(InetAddress.getByName("1.2.3.4")))),
+        entity = HttpEntity(MediaTypes.`application/json`, jsonRequest)
       )
 
     postRequest ~> Route.seal(mockJsonRpcHttpServerWithRateLimit.route) ~> check {
@@ -245,7 +245,8 @@ class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRout
       jsonRpcHealthChecker = mockJsonRpcHealthChecker,
       config = serverConfig,
       cors = serverConfig.corsAllowedOrigins,
-      testClock = fakeClock)
+      testClock = fakeClock
+    )
 
     val corsAllowedOrigin = HttpOrigin("http://localhost:3333")
     val mockJsonRpcHttpServerWithCors = new FakeJsonRpcHttpServer(
@@ -253,29 +254,31 @@ class JsonRpcHttpServerSpec extends AnyFlatSpec with Matchers with ScalatestRout
       jsonRpcHealthChecker = mockJsonRpcHealthChecker,
       config = serverConfig,
       cors = HttpOriginMatcher(corsAllowedOrigin),
-      testClock = fakeClock)
+      testClock = fakeClock
+    )
 
     val mockJsonRpcHttpServerWithRateLimit = new FakeJsonRpcHttpServer(
       jsonRpcController = mockJsonRpcController,
       jsonRpcHealthChecker = mockJsonRpcHealthChecker,
       config = serverConfigWithRateLimit,
       cors = serverConfigWithRateLimit.corsAllowedOrigins,
-      testClock = fakeClock)
+      testClock = fakeClock
+    )
   }
 }
 
 class FakeJsonRpcHttpServer(
-   val jsonRpcController: JsonRpcBaseController,
-   val jsonRpcHealthChecker: JsonRpcHealthChecker,
-   val config: JsonRpcHttpServerConfig,
-   val cors: HttpOriginMatcher,
-   val testClock: Clock
-  )(implicit val actorSystem: ActorSystem)
-  extends JsonRpcHttpServer
+    val jsonRpcController: JsonRpcBaseController,
+    val jsonRpcHealthChecker: JsonRpcHealthChecker,
+    val config: JsonRpcHttpServerConfig,
+    val cors: HttpOriginMatcher,
+    val testClock: Clock
+)(implicit val actorSystem: ActorSystem)
+    extends JsonRpcHttpServer
     with Logger {
-    def run(): Unit = ()
-    override def corsAllowedOrigins: HttpOriginMatcher = cors
-    override val clock = testClock
+  def run(): Unit = ()
+  override def corsAllowedOrigins: HttpOriginMatcher = cors
+  override val clock = testClock
 }
 
 class FakeClock extends Clock {

--- a/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/EtcPeerManagerSpec.scala
@@ -139,7 +139,9 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
 
     //then
     requestSender.send(peersInfoHolder, PeerInfoRequest(peer1.id))
-    requestSender.expectMsg(PeerInfoResponse(Some(peer1Info.withChainWeight(ChainWeight.totalDifficultyOnly(newBlock.totalDifficulty)))))
+    requestSender.expectMsg(
+      PeerInfoResponse(Some(peer1Info.withChainWeight(ChainWeight.totalDifficultyOnly(newBlock.totalDifficulty))))
+    )
   }
 
   it should "update the peer chain weight when receiving a PV64.NewBlock" in new TestSetup {
@@ -147,7 +149,12 @@ class EtcPeerManagerSpec extends AnyFlatSpec with Matchers {
     setupNewPeer(peer1, peer1Probe, peer1InfoPV64)
 
     //given
-    val newBlock = PV64.NewBlock(baseBlock, initialPeerInfoPV64.chainWeight.increaseTotalDifficulty(1).copy(lastCheckpointNumber = initialPeerInfoPV64.chainWeight.lastCheckpointNumber +1))
+    val newBlock = PV64.NewBlock(
+      baseBlock,
+      initialPeerInfoPV64.chainWeight
+        .increaseTotalDifficulty(1)
+        .copy(lastCheckpointNumber = initialPeerInfoPV64.chainWeight.lastCheckpointNumber + 1)
+    )
 
     //when
     peersInfoHolder ! MessageFromPeer(newBlock, peer1.id)

--- a/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/handshaker/EtcHandshakerSpec.scala
@@ -26,7 +26,8 @@ import org.scalatest.matchers.should.Matchers
 
 class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
 
-  it should "correctly connect during an appropriate handshake if no fork resolver is used" in new LocalPeerPV63Setup with RemotePeerPV63Setup {
+  it should "correctly connect during an appropriate handshake if no fork resolver is used" in new LocalPeerPV63Setup
+    with RemotePeerPV63Setup {
 
     initHandshakerWithoutResolver.nextMessage.map(_.messageToSend) shouldBe Right(localHello: HelloEnc)
     val handshakerAfterHelloOpt = initHandshakerWithoutResolver.applyMessage(remoteHello)
@@ -56,7 +57,8 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "send status with total difficulty only when peer does not support PV64" in new LocalPeerPV63Setup with RemotePeerPV63Setup {
+  it should "send status with total difficulty only when peer does not support PV64" in new LocalPeerPV63Setup
+    with RemotePeerPV63Setup {
 
     val newChainWeight = ChainWeight.zero.increase(genesisBlock.header).increase(firstBlock.header)
 
@@ -81,7 +83,8 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "send status with total difficulty and latest checkpoint when peer supports PV64" in new LocalPeerPV64Setup with RemotePeerPV64Setup {
+  it should "send status with total difficulty and latest checkpoint when peer supports PV64" in new LocalPeerPV64Setup
+    with RemotePeerPV64Setup {
 
     val newChainWeight = ChainWeight.zero.increase(genesisBlock.header).increase(firstBlock.header)
 
@@ -111,7 +114,8 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "correctly connect during an appropriate handshake if a fork resolver is used and the remote peer has the DAO block" in new LocalPeerSetup with RemotePeerPV63Setup {
+  it should "correctly connect during an appropriate handshake if a fork resolver is used and the remote peer has the DAO block" in new LocalPeerSetup
+    with RemotePeerPV63Setup {
 
     val handshakerAfterHelloOpt = initHandshakerWithResolver.applyMessage(remoteHello)
     val handshakerAfterStatusOpt = handshakerAfterHelloOpt.get.applyMessage(remoteStatusMsg)
@@ -143,7 +147,8 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "correctly connect during an appropriate handshake if a fork resolver is used and the remote peer doesn't have the DAO block" in new LocalPeerSetup with RemotePeerPV63Setup {
+  it should "correctly connect during an appropriate handshake if a fork resolver is used and the remote peer doesn't have the DAO block" in new LocalPeerSetup
+    with RemotePeerPV63Setup {
 
     val handshakerAfterHelloOpt = initHandshakerWithResolver.applyMessage(remoteHello)
     val handshakerAfterStatusOpt = handshakerAfterHelloOpt.get.applyMessage(remoteStatusMsg)
@@ -199,7 +204,8 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "fail if a status msg is received with invalid network id" in new LocalPeerPV63Setup with RemotePeerPV63Setup {
+  it should "fail if a status msg is received with invalid network id" in new LocalPeerPV63Setup
+    with RemotePeerPV63Setup {
     val wrongNetworkId = localStatus.networkId + 1
 
     val handshakerAfterHelloOpt = initHandshakerWithResolver.applyMessage(remoteHello)
@@ -210,7 +216,8 @@ class EtcHandshakerSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  it should "fail if a status msg is received with invalid genesisHash" in new LocalPeerPV63Setup with RemotePeerPV63Setup {
+  it should "fail if a status msg is received with invalid genesisHash" in new LocalPeerPV63Setup
+    with RemotePeerPV63Setup {
     val wrongGenesisHash = (localStatus.genesisHash.head + 1).toByte +: localStatus.genesisHash.tail
 
     val handshakerAfterHelloOpt = initHandshakerWithResolver.applyMessage(remoteHello)

--- a/src/test/scala/io/iohk/ethereum/network/p2p/MessageDecodersSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/MessageDecodersSpec.scala
@@ -69,7 +69,11 @@ class MessageDecodersSpec extends AnyFlatSpec with Matchers with SecureRandomBui
 
   it should "decode BlockHashesFromNumber message for all supported versions of protocol" in {
     val blockHashesFromNumber = PV61.BlockHashesFromNumber(12, 40)
-    decode(Codes.BlockHashesFromNumberCode, blockHashesFromNumberBytes, ProtocolVersions.PV61) shouldBe blockHashesFromNumber
+    decode(
+      Codes.BlockHashesFromNumberCode,
+      blockHashesFromNumberBytes,
+      ProtocolVersions.PV61
+    ) shouldBe blockHashesFromNumber
   }
 
   it should "decode GetBlockHeaders message for all supported versions of protocol" in {

--- a/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/PeerActorSpec.scala
@@ -178,7 +178,8 @@ class PeerActorSpec
     val remoteStatus = PV64.Status(
       protocolVersion = ProtocolVersions.PV64,
       networkId = peerConf.networkId,
-      chainWeight = ChainWeight.totalDifficultyOnly(daoForkBlockChainTotalDifficulty + 100000), // remote is after the fork
+      chainWeight =
+        ChainWeight.totalDifficultyOnly(daoForkBlockChainTotalDifficulty + 100000), // remote is after the fork
       bestHash = ByteString("blockhash"),
       genesisHash = genesisHash
     )
@@ -383,7 +384,8 @@ class PeerActorSpec
     val remoteStatus = RemoteStatus(
       protocolVersion = ProtocolVersions.PV63,
       networkId = peerConf.networkId,
-      chainWeight = ChainWeight.totalDifficultyOnly(daoForkBlockChainTotalDifficulty - 200000), // remote is before the fork
+      chainWeight =
+        ChainWeight.totalDifficultyOnly(daoForkBlockChainTotalDifficulty - 200000), // remote is before the fork
       bestHash = ByteString("blockhash"),
       genesisHash = Fixtures.Blocks.Genesis.header.hash
     )

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/MessagesSerializationSpec.scala
@@ -140,7 +140,12 @@ class MessagesSerializationSpec extends AnyWordSpec with ScalaCheckPropertyCheck
 
     "encoding and decoding GetBlockHeaders" should {
       "return same result" in {
-        verify(GetBlockHeaders(Left(1), 1, 1, false), (m: GetBlockHeaders) => m.toBytes, Codes.GetBlockHeadersCode, version)
+        verify(
+          GetBlockHeaders(Left(1), 1, 1, false),
+          (m: GetBlockHeaders) => m.toBytes,
+          Codes.GetBlockHeadersCode,
+          version
+        )
         verify(
           GetBlockHeaders(Right(ByteString("1" * 32)), 1, 1, true),
           (m: GetBlockHeaders) => m.toBytes,

--- a/src/test/scala/io/iohk/ethereum/network/p2p/messages/ReceiptsSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/network/p2p/messages/ReceiptsSpec.scala
@@ -51,7 +51,11 @@ class ReceiptsSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "decode receipts" in {
-    EthereumMessageDecoder.fromBytes(Codes.ReceiptsCode, encode(encodedReceipts), ProtocolVersions.PV63) shouldBe receipts
+    EthereumMessageDecoder.fromBytes(
+      Codes.ReceiptsCode,
+      encode(encodedReceipts),
+      ProtocolVersions.PV63
+    ) shouldBe receipts
   }
 
   it should "decode encoded receipts" in {

--- a/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/transactions/TransactionHistoryServiceSpec.scala
@@ -3,20 +3,25 @@ package io.iohk.ethereum.transactions
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
 import akka.util.ByteString
-import io.iohk.ethereum._
+import com.softwaremill.diffx.scalatest.DiffMatcher
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
-import io.iohk.ethereum.domain.{Address, Block, HashOutcome, Receipt, SignedTransaction, Transaction}
+import io.iohk.ethereum.crypto.{ECDSASignature, generateKeyPair}
+import io.iohk.ethereum.domain.BlockHeader.HeaderExtraFields.HefPostEcip1097
+import io.iohk.ethereum.domain._
 import io.iohk.ethereum.transactions.TransactionHistoryService.{ExtendedTransactionData, MinedTransactionData}
 import io.iohk.ethereum.transactions.testing.PendingTransactionsManagerAutoPilot
+import io.iohk.ethereum.{blockchain => _, _}
 import monix.eval.Task
-
-import java.security.SecureRandom
+import mouse.all._
+import org.scalatest.matchers.should.Matchers
 
 class TransactionHistoryServiceSpec
     extends TestKit(ActorSystem("TransactionHistoryServiceSpec-system"))
     with FreeSpecBase
     with SpecFixtures
-    with WithActorSystemShutDown {
+    with WithActorSystemShutDown
+    with Matchers
+    with DiffMatcher {
   class Fixture extends EphemBlockchainTestSetup {
     val pendingTransactionManager = TestProbe()
     pendingTransactionManager.setAutoPilot(PendingTransactionsManagerAutoPilot())
@@ -26,12 +31,12 @@ class TransactionHistoryServiceSpec
 
   def createFixture() = new Fixture
 
-  "returns account recent transactions in newest -> oldest order" in testCaseM { fixture =>
+  "returns account recent transactions in newest -> oldest order" in testCaseM { fixture: Fixture =>
     import fixture._
 
-    val address = Address("0xee4439beb5c71513b080bbf9393441697a29f478")
+    val address = Address("ee4439beb5c71513b080bbf9393441697a29f478")
 
-    val keyPair = crypto.generateKeyPair(new SecureRandom)
+    val keyPair = generateKeyPair(secureRandom)
 
     val tx1 = SignedTransaction.sign(Transaction(0, 123, 456, Some(address), 1, ByteString()), keyPair, None).tx
     val tx2 = SignedTransaction.sign(Transaction(0, 123, 456, Some(address), 2, ByteString()), keyPair, None).tx
@@ -54,14 +59,18 @@ class TransactionHistoryServiceSpec
       ExtendedTransactionData(
         tx3,
         isOutgoing = false,
-        Some(MinedTransactionData(blockWithTxs2and3.header, 1, 44))
+        Some(MinedTransactionData(blockWithTxs2and3.header, 1, 44, isCheckpointed = false))
       ),
       ExtendedTransactionData(
         tx2,
         isOutgoing = false,
-        Some(MinedTransactionData(blockWithTxs2and3.header, 0, 43))
+        Some(MinedTransactionData(blockWithTxs2and3.header, 0, 43, isCheckpointed = false))
       ),
-      ExtendedTransactionData(tx1, isOutgoing = false, Some(MinedTransactionData(blockWithTx1.header, 0, 42)))
+      ExtendedTransactionData(
+        tx1,
+        isOutgoing = false,
+        Some(MinedTransactionData(blockWithTx1.header, 0, 42, isCheckpointed = false))
+      )
     )
 
     for {
@@ -77,26 +86,88 @@ class TransactionHistoryServiceSpec
     } yield assert(response === expectedTxs)
   }
 
-  "does not return account recent transactions from older blocks and return pending txs" in testCaseM { fixture =>
-    import fixture._
+  "does not return account recent transactions from older blocks and return pending txs" in testCaseM {
+    fixture: Fixture =>
+      import fixture._
 
-    val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
+      val blockWithTx = Block(Fixtures.Blocks.Block3125369.header, Fixtures.Blocks.Block3125369.body)
 
-    val keyPair = crypto.generateKeyPair(new SecureRandom)
+      val keyPair = generateKeyPair(secureRandom)
 
-    val tx = Transaction(0, 123, 456, None, 99, ByteString())
-    val signedTx = SignedTransaction.sign(tx, keyPair, None)
+      val tx = Transaction(0, 123, 456, None, 99, ByteString())
+      val signedTx = SignedTransaction.sign(tx, keyPair, None)
 
-    val expectedSent =
-      Seq(ExtendedTransactionData(signedTx.tx, isOutgoing = true, None))
+      val expectedSent =
+        Seq(ExtendedTransactionData(signedTx.tx, isOutgoing = true, None))
 
-    for {
-      _ <- Task { blockchain.storeBlock(blockWithTx).commit() }
-      _ <- Task { pendingTransactionManager.ref ! PendingTransactionsManager.AddTransactions(signedTx) }
-      response <- transactionHistoryService.getAccountTransactions(
-        signedTx.senderAddress,
-        BigInt(3125371) to BigInt(3125381)
+      for {
+        _ <- Task { blockchain.storeBlock(blockWithTx).commit() }
+        _ <- Task { pendingTransactionManager.ref ! PendingTransactionsManager.AddTransactions(signedTx) }
+        response <- transactionHistoryService.getAccountTransactions(
+          signedTx.senderAddress,
+          BigInt(3125371) to BigInt(3125381)
+        )
+      } yield assert(response === expectedSent)
+  }
+
+  "marks transactions as checkpointed if there's checkpoint block following block containing transaction" in testCaseM {
+    fixture: Fixture =>
+      import fixture._
+
+      val keyPair = generateKeyPair(secureRandom)
+      val senderAddress = Address(keyPair)
+      val checkpointKey = generateKeyPair(secureRandom)
+
+      val txToBeCheckpointed = Transaction(0, 123, 456, None, 99, ByteString())
+      val signedTxToBeCheckpointed = SignedTransaction.sign(txToBeCheckpointed, keyPair, None)
+
+      val txNotToBeCheckpointed =
+        Transaction(1, 123, 456, Address("ee4439beb5c71513b080bbf9393441697a29f478"), 99, ByteString())
+      val signedTxNotToBeCheckpointed = SignedTransaction.sign(txNotToBeCheckpointed, keyPair, None)
+
+      val block1 = BlockHelpers
+        .generateBlock(BlockHelpers.genesis) |> (BlockHelpers.withTransactions(_, List(signedTxToBeCheckpointed.tx)))
+      val block2 = BlockHelpers.generateBlock(block1) |> (
+        BlockHelpers.updateHeader(
+          _,
+          header => {
+            val checkpoint =
+              Checkpoint(List(ECDSASignature.sign(crypto.kec256(ByteString("foo")).toArray, checkpointKey, None)))
+            header.copy(extraFields = HefPostEcip1097(treasuryOptOut = false, Some(checkpoint)))
+          }
+        )
       )
-    } yield assert(response === expectedSent)
+      val block3 =
+        BlockHelpers.generateBlock(block2) |> (BlockHelpers.withTransactions(_, List(signedTxNotToBeCheckpointed.tx)))
+
+      val expectedCheckpointedTxData = ExtendedTransactionData(
+        signedTxToBeCheckpointed.tx,
+        isOutgoing = true,
+        Some(MinedTransactionData(block1.header, 0, 21000, isCheckpointed = true))
+      )
+      val expectedNonCheckpointedTxData = ExtendedTransactionData(
+        signedTxNotToBeCheckpointed.tx,
+        isOutgoing = true,
+        Some(MinedTransactionData(block3.header, 0, 21000, isCheckpointed = false))
+      )
+
+      def makeReceipts(block: Block): Seq[Receipt] =
+        block.body.transactionList.map(tx => Receipt(HashOutcome(block.hash), BigInt(21000), ByteString("foo"), Nil))
+
+      for {
+        _ <- Task { blockchain.save(block1, makeReceipts(block1), ChainWeight(0, block1.header.difficulty), true) }
+        _ <- Task { blockchain.save(block2, Nil, ChainWeight(2, block1.header.difficulty), true) }
+        _ <- Task { blockchain.save(block3, makeReceipts(block3), ChainWeight(2, block1.header.difficulty * 2), true) }
+        lastCheckpoint <- Task { blockchain.getLatestCheckpointBlockNumber() }
+        response <- transactionHistoryService.getAccountTransactions(
+          senderAddress,
+          BigInt.apply(0) to BigInt(10)
+        )
+      } yield {
+        assert(!block3.hasCheckpoint)
+        assert(lastCheckpoint === block2.number)
+        assert(block2.hasCheckpoint)
+        response should matchTo(List(expectedNonCheckpointedTxData, expectedCheckpointedTxData))
+      }
   }
 }


### PR DESCRIPTION
# Description

This PR adds information about tx being in checkpointed block or not to `mantis_getAccountTransactions`.
Also, as it is very useful - in this PR I've added a dependency on diffx - library which highlights the differences in compared data.

# Testing

All tests should pass. One can also try to use `qa_generateCheckpoint` for adding a checkpoint and checking if transactions from lower blocks are properly marked

