### PR TITLE
[FIX] Fix retry config option

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -112,7 +112,7 @@ mantis {
 
     peer {
       # Retry delay for failed attempt at connecting to a peer
-      connect-retry-delay = 1 minute
+      connect-retry-delay = 5 seconds
 
       # Maximum number of reconnect attempts after the connection has been initiated.
       # After that, the connection will be dropped until its initiated again (eg. by peer discovery)


### PR DESCRIPTION
# Description

Our `PeerActor` uses this option to retry outgoing connection when initial try fails. Setting it to `1 minute` means that this actor sits and do nothing for 1 minute, while taking `PeerManagerActor` outgoing connection slot. It can slow down acquiring new connections. In our other project we also tweaked that option. 

In longer perspective we should probably delete this mechanism, and make `PeerManagerActor` one thing responsible for initiating connections and re-connection.