### PR TITLE
[FIX] Moved block metrics to the place after validation and execution of the block

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -100,7 +100,6 @@ class LedgerImpl(
     new BlockImport(
       blockchain,
       blockQueue,
-      blockchainConfig,
       blockValidation,
       blockExecution,
       validationContext


### PR DESCRIPTION
# Description

We were measuring block metrics after the block execution but before validation, which mean that we were measuring blocks which could be removed later.

# Proposed Solution

Moved measuring block metrics to the place after the block execution and validation.