### PR TITLE
[FIX] Trigger block execution metrics on reorg as well

### DIFF
--- a/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/BlockImport.scala
@@ -33,10 +33,7 @@ class BlockImport(
     } yield {
       validationResult.fold(
         error => handleImportTopValidationError(error, block, importResult),
-        _ => {
-          measureBlockMetrics(importResult)
-          importResult
-        }
+        _ => importResult
       )
     }
   }
@@ -78,14 +75,6 @@ class BlockImport(
 
       case None =>
         BlockImportFailed(s"Newly enqueued block with hash: ${block.header.hash} is not part of a known branch")
-    }
-  }
-
-  private def measureBlockMetrics(importResult: BlockImportResult): Unit = {
-    importResult match {
-      case BlockImportedToTop(blockImportData) =>
-        blockImportData.foreach(blockData => BlockMetrics.measure(blockData.block, blockchain.getBlockByHash))
-      case _ => ()
     }
   }
 

--- a/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
+++ b/src/main/scala/io/iohk/ethereum/ledger/Ledger.scala
@@ -130,11 +130,13 @@ class LedgerImpl(
       val hash = currentBestBlock.header.hash
       blockchain.getChainWeightByHash(hash) match {
         case Some(weight) =>
-          if (isPossibleNewBestBlock(block.header, currentBestBlock.header)) {
+          val importResult = if (isPossibleNewBestBlock(block.header, currentBestBlock.header)) {
             blockImport.importToTop(block, currentBestBlock, weight)
           } else {
             blockImport.reorganise(block, currentBestBlock, weight)
           }
+          importResult.foreach(measureBlockMetrics)
+          importResult
 
         case None =>
           Future.successful(BlockImportFailed(s"Couldn't get total difficulty for current best block with hash: $hash"))
@@ -153,6 +155,16 @@ class LedgerImpl(
 
   override def resolveBranch(headers: NonEmptyList[BlockHeader]): BranchResolutionResult =
     branchResolution.resolveBranch(headers)
+
+  private def measureBlockMetrics(importResult: BlockImportResult): Unit = {
+    importResult match {
+      case BlockImportedToTop(blockImportData) =>
+        blockImportData.foreach(blockData => BlockMetrics.measure(blockData.block, blockchain.getBlockByHash))
+      case ChainReorganised(_, newBranch, _) =>
+        newBranch.foreach(block => BlockMetrics.measure(block, blockchain.getBlockByHash))
+      case _ => ()
+    }
+  }
 
 }
 


### PR DESCRIPTION
# Description

Measure block execution metrics on reorg as well.

The current measuring point is only part of the possible paths of blocks execution, meaning that some imported blocks are currently not measured