### PR TITLE
[HotFix] To add Checkpointing Federation keys under the Nomad's testnet configuration

### DIFF
--- a/src/main/resources/chains/testnet-internal-nomad-chain.conf
+++ b/src/main/resources/chains/testnet-internal-nomad-chain.conf
@@ -149,7 +149,13 @@
     ]
 
     # List of hex encoded public keys of Checkpoint Authorities
-    checkpoint-public-keys = []
+    checkpoint-public-keys = [
+        "c3df1dc09a6cc56b94dd9044f087634f06a2cf6f671204d5ffefd062e6c34e272a0699af50bd17f03b7d4926d02cfe6a457915dee95d9b85ea3483b3fa14bc38",
+        "4e846daa19e0dd2da56237475a24ceb9807e76e0c1952b880d963b8afd2aba4251b517641f89a5c214677cceda795d1ea7c4d5a044baf0d1852b87fb87ce40ce",
+        "c1e2c120ecf251b7144813786307b62725c13e4c23197aca9199cc81f1a7a042b8f68b552f5f92963b040703fb3ce0c62d860fb5ddfc272b6feba56713123abd",
+        "faa7718b649fa4713897fcd4331b4f3e26261c1d9d35061cecf414b78a090f76e805e773eaf3e22e2f79d7d7268f38df14f40b72de4f16da0a7066959febb1b8",
+        "5355fc1bba22b121c3954b0174c8ebfd52efe95e3d062980a916770aec1316c6116a46af591f47f07074f48564cb31c15c90498f2ff9fadf86639e60f3cb2c0d"
+    ]
 
     # List of hex encoded public keys of miners which can extend chain (only used when using restricted-ethash consensus)
     # empty means that everybody can mine


### PR DESCRIPTION
# Description

_Fix to add Checkpointing Federation keys under the Nomad's testnet configuration_